### PR TITLE
refactor(shared): promote identifierSlug to MeowModels with contract test

### DIFF
--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -545,34 +545,3 @@ private struct NavRow<Destination: View>: View {
         .accessibilityIdentifier(identifier)
     }
 }
-
-// MARK: - Slug helper
-
-private extension String {
-    /// Identifier-safe slug for XCUITest `accessibilityIdentifier`. Lowercases
-    /// and collapses anything outside `[a-z0-9]` to single `-` separators. QA's
-    /// harness pins on deterministic IDs, so this must stay pure — no
-    /// locale-aware casing, no Unicode normalisation beyond ASCII.
-    var identifierSlug: String {
-        var out = ""
-        var trailingDash = true
-        for scalar in unicodeScalars {
-            let v = scalar.value
-            let isLower = v >= 0x61 && v <= 0x7A
-            let isUpper = v >= 0x41 && v <= 0x5A
-            let isDigit = v >= 0x30 && v <= 0x39
-            if isDigit || isLower {
-                out.append(Character(scalar))
-                trailingDash = false
-            } else if isUpper {
-                out.append(Character(Unicode.Scalar(v + 0x20)!))
-                trailingDash = false
-            } else if !trailingDash {
-                out.append("-")
-                trailingDash = true
-            }
-        }
-        while out.hasSuffix("-") { out.removeLast() }
-        return out.isEmpty ? "_" : out
-    }
-}

--- a/MeowShared/Sources/MeowModels/IdentifierSlug.swift
+++ b/MeowShared/Sources/MeowModels/IdentifierSlug.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public extension String {
+    /// Identifier-safe slug used in XCUITest `accessibilityIdentifier`s
+    /// (e.g. `home.group.<slug>`, `home.proxy.<group>.<proxy>`).
+    /// Lowercases ASCII letters, keeps digits, and collapses anything
+    /// outside `[a-z0-9]` into single `-` separators. Leading and
+    /// trailing dashes are stripped; an empty result (all non-ASCII
+    /// input) becomes `"_"` so the identifier is never empty.
+    ///
+    /// Pure — no locale-aware casing, no Unicode normalisation beyond
+    /// the ASCII-digit/letter check — so the app's rendering side
+    /// (`App/Sources/Views/HomeView.swift`, which prior to consolidation
+    /// carried a private copy of this function) and the test bundle's
+    /// selector-builder side always agree on the exact same bytes.
+    ///
+    /// Contract-tested in `MeowTests/IdentifierSlugTests.swift` against
+    /// the known input/output pairs the E2E nightly depends on.
+    var identifierSlug: String {
+        var out = ""
+        var trailingDash = true
+        for scalar in unicodeScalars {
+            let v = scalar.value
+            let isLower = v >= 0x61 && v <= 0x7A
+            let isUpper = v >= 0x41 && v <= 0x5A
+            let isDigit = v >= 0x30 && v <= 0x39
+            if isDigit || isLower {
+                out.append(Character(scalar))
+                trailingDash = false
+            } else if isUpper {
+                out.append(Character(Unicode.Scalar(v + 0x20)!))
+                trailingDash = false
+            } else if !trailingDash {
+                out.append("-")
+                trailingDash = true
+            }
+        }
+        while out.hasSuffix("-") { out.removeLast() }
+        return out.isEmpty ? "_" : out
+    }
+}

--- a/MeowTests/Models/IdentifierSlugTests.swift
+++ b/MeowTests/Models/IdentifierSlugTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import Foundation
+import MeowModels
+
+/// Contract for `String.identifierSlug` (MeowShared/MeowModels) — the
+/// slug used to build XCUITest `accessibilityIdentifier`s on the Home
+/// Screen (e.g. `home.group.<slug>`, `home.proxy.<group>.<proxy>`).
+///
+/// Two sides depend on byte-for-byte agreement:
+///   - `App/Sources/Views/HomeView.swift` renders `accessibilityIdentifier(…)`
+///     with the slug applied to the Mihomo group / proxy display name.
+///   - `MeowUITests/Support/VPhone.swift` builds the same identifiers
+///     in `HomeScreen.AccessibilityID.{group,proxy}` via the shared
+///     extension below, so the XCUITest selectors match what the view
+///     layer rendered.
+///
+/// If either side drifts, this file fails — which is preferable to the
+/// alternative of silently-mismatched identifiers producing "element
+/// not found" errors at nightly E2E time.
+@Suite("identifierSlug — home.group / home.proxy slug contract", .tags(.model))
+struct IdentifierSlugTests {
+
+    @Test("ASCII lowercase passes through unchanged")
+    func passthrough() {
+        #expect("auto".identifierSlug == "auto")
+        #expect("direct".identifierSlug == "direct")
+        #expect("reject".identifierSlug == "reject")
+    }
+
+    @Test("uppercase folds to lowercase, digits preserved")
+    func caseFold() {
+        #expect("ALLCAPS".identifierSlug == "allcaps")
+        #expect("Hong Kong 01".identifierSlug == "hong-kong-01")
+        #expect("Node42".identifierSlug == "node42")
+    }
+
+    @Test("non-ASCII letters and emoji collapse to dash boundaries")
+    func nonAscii() {
+        // Dev's T4.2 example — regional-indicator flag + spaces.
+        #expect("🇺🇸 US Nodes".identifierSlug == "us-nodes")
+        #expect("Speedtest.net ⚡️".identifierSlug == "speedtest-net")
+        #expect("东京 01".identifierSlug == "01")
+    }
+
+    @Test("leading / trailing / repeated non-alphanumerics collapse cleanly")
+    func dashCollapsing() {
+        #expect("  hello  world  ".identifierSlug == "hello-world")
+        #expect("...dots...".identifierSlug == "dots")
+        #expect("a--b".identifierSlug == "a-b")
+    }
+
+    @Test("empty or all-non-ASCII input yields the '_' sentinel")
+    func emptySentinel() {
+        #expect("".identifierSlug == "_")
+        #expect("---".identifierSlug == "_")
+        #expect("🇺🇸".identifierSlug == "_")
+        #expect("   ".identifierSlug == "_")
+    }
+}
+

--- a/MeowUITests/Support/VPhone.swift
+++ b/MeowUITests/Support/VPhone.swift
@@ -57,22 +57,24 @@ struct VPhone {
     struct HomeScreen {
         let phone: VPhone
 
-        /// T4.2 Home Screen accessibility-identifier spec. Mirrors the
-        /// names Dev is wiring on the `View`s — any rename here or
-        /// there is a compile-time / test-time break, which is the
-        /// point. Composite helpers (`group`, `proxy`) build the
-        /// `home.group.<groupName>` / `home.proxy.<groupName>.<proxyName>`
-        /// patterns; `groupName` is the URL-safe slug the app emits.
+        /// T4.2 Home Screen accessibility-identifier spec (landed in
+        /// `ac4c433`). Literalises the names Dev wired on the `View`s —
+        /// any rename here or there is a compile-time / test-time
+        /// break, which is the point. The `group` / `proxy` builders
+        /// accept the raw display name the Mihomo config emits and
+        /// apply `String.identifierSlug` (shared via `MeowModels`)
+        /// internally, so callers can pass `"🇺🇸 US Nodes"` and land
+        /// on `home.group.us-nodes` without hand-rolling the slug.
         enum AccessibilityID {
             static let vpnToggle = "home.toggle.vpn"
             static let stateBadge = "home.badge.state"
             static let profileName = "home.profile.name"
             static let navDiagnostics = "home.nav.diagnostics"
             static func group(_ groupName: String) -> String {
-                "home.group.\(groupName)"
+                "home.group.\(groupName.identifierSlug)"
             }
             static func proxy(group groupName: String, proxy proxyName: String) -> String {
-                "home.proxy.\(groupName).\(proxyName)"
+                "home.proxy.\(groupName.identifierSlug).\(proxyName.identifierSlug)"
             }
         }
 


### PR DESCRIPTION
## Summary

- Moves the XCUITest-identifier slug (`identifierSlug`) out of HomeView.swift's private extension and into `MeowShared/MeowModels` as a `public extension String`, so the app's `.accessibilityIdentifier(…)` renderer and the MeowUITests page-object selectors share byte-for-byte bytes.
- Wires `VPhone.HomeScreen.AccessibilityID.group(_:)` / `.proxy(group:proxy:)` to apply the slug internally — callers pass raw Mihomo display names (`"🇺🇸 US Nodes"` → `home.group.us-nodes`).
- Adds `MeowTests/Models/IdentifierSlugTests.swift` — 5 Swift Testing cases pinning the known I/O pairs the nightly E2E depends on (ASCII passthrough, case-fold, non-ASCII collapse, dash trimming, `"_"` empty sentinel).
- Deletes the redundant private copy from `App/Sources/Views/HomeView.swift` so the two sides can't drift silently.

Context: Dev flagged the slug rule after T4.2 landed on `ac4c433` — "if a group is named '🇺🇸 US Nodes' the ID will be home.group.us-nodes." This PR makes that contract a compile-time guarantee.

## Test plan

- [x] `xcodebuild test -scheme meow-ios -only-testing:MeowTests/IdentifierSlugTests` — 5/5 passing on iPhone 17 / iOS 26.4 sim
- [x] Full-project `build-for-testing` succeeds with HomeView private copy removed
- [ ] Nightly E2E (M1.5) picks up the shared extension once the 5-check gate runs live

🤖 Generated with [Claude Code](https://claude.com/claude-code)