### PR TITLE
ci(nightly): use local Tart image instead of GHCR

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,24 +16,29 @@ jobs:
     runs-on: [self-hosted, macOS, apple-silicon, tart]
     timeout-minutes: 90
     env:
-      TART_IMAGE: ghcr.io/${{ github.repository_owner }}/meow-e2e-base:latest
+      # Local Tart image on the self-hosted runner's host — see
+      # docs/TEST_FIXTURES.md §5 for the "reuse bld-e2e-base" decision.
+      # No `tart pull` / GHCR round-trip because the only place this
+      # workflow ever runs is a host that already has the base image
+      # (the "only-Tart-VM" scope decision in docs/RUNNER.md §1).
+      TART_BASE_IMAGE: bld-e2e-base
+      TART_VM: meow-nightly-${{ github.run_id }}
       VPHONE_SOCK: /tmp/vphone.sock
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Pull Tart base image (SIP-disabled macOS + vphone-cli)
+      - name: Clone ephemeral VM from local base image
         run: |
           brew list tart >/dev/null 2>&1 || brew install cirruslabs/cli/tart
-          tart pull "$TART_IMAGE"
-          tart clone "$TART_IMAGE" meow-e2e
+          tart clone "$TART_BASE_IMAGE" "$TART_VM"
 
       - name: Boot VM and wait for SSH
         run: |
-          tart run meow-e2e --no-graphics &
+          tart run "$TART_VM" --no-graphics &
           for i in $(seq 1 60); do
-            VM_IP=$(tart ip meow-e2e 2>/dev/null || true)
+            VM_IP=$(tart ip "$TART_VM" 2>/dev/null || true)
             [ -n "$VM_IP" ] && ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 admin@$VM_IP 'true' 2>/dev/null && break
             sleep 2
           done
@@ -92,7 +97,7 @@ jobs:
 
       - name: Tear down VM
         if: always()
-        run: tart delete meow-e2e || true
+        run: tart delete "$TART_VM" || true
 
       - name: Notify on failure
         if: failure()

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -89,11 +89,11 @@ gh run watch
 ```
 
 First-run signals to watch for:
-- `tart pull` / `tart clone` steps complete (nested-virt works — the 2026-04-17 risk callout resolves positively).
+- `tart clone` from the local `bld-e2e-base` image completes (nested-virt works — the 2026-04-17 risk callout resolves positively). No `tart pull` step: the workflow runs only on a host that already has the base image locally (see `TEST_FIXTURES.md §5`).
 - `scp` into the inner vphone VM succeeds (SSH keys provisioned inside the outer VM's `~/.ssh/`).
 - The 5-check diagnostics gate ends with `** TEST SUCCEEDED **`.
 
-If `tart pull` fails with a nested-virt error, that's the re-raise scenario team-lead flagged — escalate rather than workaround.
+If `tart clone` fails (`bld-e2e-base` missing, nested-virt disabled, etc.), that's the re-raise scenario team-lead flagged — escalate rather than workaround.
 
 ---
 


### PR DESCRIPTION
## Summary

- `nightly.yml` no longer pulls from GHCR — the self-hosted runner already has `bld-e2e-base` locally. `TART_IMAGE` → `TART_BASE_IMAGE=bld-e2e-base`; the "Pull Tart base image" step is gone.
- Per-run ephemeral VM name is now `meow-nightly-$GITHUB_RUN_ID` (was the static `meow-e2e`, which would collide on any concurrent / dispatched run alongside a schedule tick).
- `docs/RUNNER.md §4` smoke-test signals updated: `tart pull` → `tart clone from local bld-e2e-base`; the escalation line names the new failure modes (missing base image, nested-virt disabled) rather than the GHCR pull error that no longer exists.

Context: follow-up to PR #1. Team-lead called the shot — "Given the only-Tart-VM constraint, I'd skip the fallback." No GHCR fallback env-var added; adding one would imply a non-Tart-VM path that doesn't exist (YAGNI).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml'))"` — YAML parses
- [x] `git diff --stat` — 2 files, 14+ / 9- (workflow + doc only)
- [ ] Live nightly run on the self-hosted runner once the user registers it — `tart clone` signal from `bld-e2e-base` replaces the `tart pull` signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)