### PR TITLE
ci(fixtures): provision on runner host, resolve Tart-visible IP for guest→host reach

### DIFF
--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -1,20 +1,25 @@
-# Self-hosted GitHub Actions Runner (Tart VM)
+# Self-hosted GitHub Actions Runner (Tart host)
 
 **Status:** 2026-04-17 — runner not yet registered on `github.com/madeye/meow-ios`. `nightly.yml` references `runs-on: [self-hosted, macOS, apple-silicon, tart]`; until the runner registers with that label set, the job sits queued.
 
-**Scope decision (2026-04-17 team-lead):** nightly E2E runs **only inside the Tart VM** — no Mac mini fallback. See [`TEST_FIXTURES.md §5`](./TEST_FIXTURES.md) for the image-reuse decision (`bld-e2e-base`, layered via `scripts/provision-tart-fixtures.sh`).
+**Scope decision (2026-04-17 team-lead):** nightly E2E uses Tart as the vphone sandbox (no Mac mini fallback). The runner itself and the fixture servers live on the **outer runner host**; the Tart guest only runs vphone-cli + SSH + SIP-disabled macOS. See [`TEST_FIXTURES.md §5`](./TEST_FIXTURES.md) for the wiring.
 
-This file is the manual setup runbook the user follows **once per VM build** to register a self-hosted runner inside that Tart image.
+This file is the manual setup runbook the user follows once per runner-host build to register a self-hosted runner.
 
 ---
 
-## 1. Prereqs inside the Tart VM
+## 1. Prereqs on the runner host (not inside the Tart VM)
+
+The runner and the fixture servers both live on the **outer macOS host** that boots Tart. The Tart guest only runs vphone-cli + SSH + SIP-disabled macOS; the virtual iPhone inside it reaches fixtures on the outer host via the Tart bridge IP (resolved inside `scripts/test-e2e-ios.sh` from `VPHONE_HOST`).
+
+Run on the runner host:
 
 ```bash
-# Fixture binaries (layered delta on the local base; idempotent)
-./scripts/provision-tart-fixtures.sh
+# Fixture binaries (shadowsocks-rust / trojan-go / xray / wireguard /
+# hysteria / tuic-server) — idempotent; installs only what's missing.
+bash scripts/provision-tart-fixtures.sh
 
-# Host-side build + virt tools the nightly workflow invokes
+# Virt + build tools the nightly workflow invokes on the host
 brew install tart xcodegen xcbeautify
 
 # Self-hosted runner bits
@@ -24,7 +29,7 @@ curl -fsSL -o actions-runner-osx-arm64.tar.gz \
 tar xzf actions-runner-osx-arm64.tar.gz
 ```
 
-Confirm the VM has SIP disabled (`csrutil status`) — vphone-cli requires it (see [`TEST_STRATEGY.md §7`](./TEST_STRATEGY.md)). If not, boot into Recovery and disable before continuing.
+SIP status matters **inside the Tart guest**, not on the host: vphone-cli needs SIP-disabled macOS, and that constraint is satisfied by `bld-e2e-base` itself (see [`TEST_STRATEGY.md §7`](./TEST_STRATEGY.md)). The host can keep SIP enabled.
 
 ---
 

--- a/docs/TEST_FIXTURES.md
+++ b/docs/TEST_FIXTURES.md
@@ -10,11 +10,11 @@ Answers the open question flagged in `TEST_STRATEGY.md` (§13 risks): *"Protocol
 
 ## 1. Recommendation
 
-**Run fixture servers natively via Homebrew inside the Tart VM, alongside vphone-cli.** Fall back to a lightweight container runtime (Lima or Colima, **not** Docker Desktop) only for protocols without a maintained brew formula.
+**Run fixture servers natively via Homebrew on the outer runner host, outside the Tart VM.** The Tart guest only runs vphone-cli + SSH + SIP-disabled macOS; the virtual iPhone in the guest reaches the fixtures via the Tart bridge IP (resolved at runtime inside `scripts/test-e2e-ios.sh` — see §5). Fall back to a lightweight container runtime (Lima or Colima, **not** Docker Desktop) only for protocols without a maintained brew formula.
 
 ### Why not Docker-compose
 
-The fixtures live inside the Tart macOS guest (per `TEST_STRATEGY.md` §7 — vphone-cli requires SIP-disabled macOS). Docker Desktop in a macOS-in-macOS nesting is heavy, fragile under virtualization, and adds a second VM layer (Docker's Linux VM inside the Tart VM). Native Homebrew services sidestep that entirely. Every protocol in scope has either a brew formula or a single-binary release.
+Docker Desktop on the runner host adds a second VM layer (Docker's Linux VM alongside the Tart macOS VM) — heavy, and for zero benefit since every protocol in scope has either a brew formula or a single-binary release. Native Homebrew on the host sidesteps that entirely.
 
 ### Why not live endpoints
 
@@ -73,22 +73,24 @@ Consequence for fixtures:
 
 ## 5. Tart VM Integration
 
-**Runner scope (2026-04-17 team-lead decision):** the nightly E2E runs **inside the Tart VM only** — no Mac mini fallback. We accept the nested-virtualisation risk for macOS guests on Apple Silicon. If `Virtualization.framework` refuses to nest reliably in practice, that re-raises as a real blocker; until then we proceed on the assumption it works.
+**Runner scope (2026-04-17 team-lead decision):** the nightly E2E uses a Tart guest as the vphone sandbox — no Mac mini fallback. We accept the nested-virtualisation risk for macOS guests on Apple Silicon. If `Virtualization.framework` refuses to nest reliably in practice, that re-raises as a real blocker; until then we proceed on the assumption it works.
 
-**Image strategy (2026-04-17 team-lead decision):** **reuse the existing local `bld-e2e-base` Tart VM** (already present per `tart list`; last accessed 2026-04-14, 32 GB disk-used). Rather than rebaking the base every time a fixture binary set shifts, we layer a delta on top via `scripts/provision-tart-fixtures.sh` (idempotent — installs only what's missing). Rebake becomes a last resort, not the default path.
+**Topology (amended 2026-04-17 after probing `bld-e2e-base`):** fixture servers and the GitHub Actions runner both live on the **outer macOS host** that boots Tart. The **Tart guest** runs only vphone-cli + SSH + SIP-disabled macOS (SIP needed for vphone, per `TEST_STRATEGY.md §7`). The virtual iPhone inside the guest reaches the fixture servers via the Tart bridge IP — the outer host's address on the `bridgeN` interface Tart bridges onto, typically `192.168.64.1` for the default vmnet-host NAT. `scripts/test-e2e-ios.sh` resolves this automatically from `VPHONE_HOST` using `route -n get <vm-ip>` → interface → `ifconfig inet`; local runs (no `VPHONE_HOST`) fall back to `127.0.0.1`. The binds stay on `0.0.0.0` so both paths work — do **not** tighten to loopback, since loopback on the host is invisible to the iPhone's network stack inside the guest.
 
-The fixture orchestrator is a shell script `scripts/test-e2e-ios.sh` (already referenced in `TEST_STRATEGY.md` §7 as the Android-parity entry point; P1–P3 live). Inside the Tart VM, the script will:
+**Image strategy (2026-04-17):** reuse the existing local `bld-e2e-base` Tart VM (already present per `tart list`; last accessed 2026-04-14, 32 GB disk-used). The guest stays stateless beyond what vphone-cli needs; fixture binaries go on the outer host, not the guest.
 
-1. `brew install` + release-binary drops are laid down once by `scripts/provision-tart-fixtures.sh` (see below). Subsequent runs are no-ops against the `bld-e2e-base` image; the orchestrator itself doesn't reach for `brew`.
-2. Generate per-run ephemeral credentials (Trojan passwords, VLESS UUIDs, WG keypairs) into `/tmp/meow-fixtures/<uuid>/`.
-3. Fork each fixture as a background process from the orchestrator itself (`binary … &; FIXTURE_PID=$!`), track its PID in a shell variable, and register an `EXIT INT TERM` trap that reaps every tracked PID in reverse-start order and then wipes `/tmp/meow-fixtures/<uuid>/`. Fork-and-trap over `launchctl bootstrap` (speculated in v1): one script owns the whole lifecycle, no per-run LaunchAgent plist pollution of the Tart guest, and interactive Ctrl-C plus programmatic `kill -TERM` both land on the same cleanup path. Trojan's fallback-probe requirement is handled in the same style — a dedicated loopback `python3 -m http.server` on an ephemeral port is forked alongside trojan-go and reaped by the trap.
-4. Serve a Clash subscription YAML via `python3 -m http.server 18080` — same port as the Android `test-e2e.sh` pattern, so local devs don't have to rediscover it. Claimed port allocation for future Tart VM conflict bookkeeping.
-5. Point vphone-cli's iPhone at the subscription URL via the `meow://connect` deep link.
+The fixture orchestrator is a shell script `scripts/test-e2e-ios.sh` (already referenced in `TEST_STRATEGY.md` §7 as the Android-parity entry point; P1–P3 live). On the outer runner host the script:
+
+1. Assumes fixture binaries are already installed on `PATH` by `scripts/provision-tart-fixtures.sh` (runner-host prereq — see [`RUNNER.md §1`](./RUNNER.md)). The orchestrator itself doesn't reach for `brew`.
+2. Generates per-run ephemeral credentials (Trojan passwords, VLESS UUIDs, WG keypairs) into `/tmp/meow-fixtures/<uuid>/` on the host.
+3. Forks each fixture as a background process from the orchestrator itself (`binary … &; FIXTURE_PID=$!`), tracks its PID in a shell variable, and registers an `EXIT INT TERM` trap that reaps every tracked PID in reverse-start order and then wipes `/tmp/meow-fixtures/<uuid>/`. Fork-and-trap over `launchctl bootstrap` (speculated in v1): one script owns the whole lifecycle, no per-run LaunchAgent plist pollution, and interactive Ctrl-C plus programmatic `kill -TERM` both land on the same cleanup path. Trojan's fallback-probe requirement is handled in the same style — a loopback `python3 -m http.server` on an ephemeral port is forked alongside trojan-go and reaped by the trap.
+4. Serves a Clash subscription YAML on the host via `python3 -m http.server 18080` — same port as the Android `test-e2e.sh` pattern, so local devs don't have to rediscover it.
+5. Points vphone-cli's iPhone (inside the guest, driven via SSH through `VPHONE_HOST`) at the subscription URL via the `meow://connect` deep link. The URL's host component is the Tart bridge IP so the in-guest iPhone can resolve and dial it.
 6. Tear down: the trap from step 3 fires (on exit, Ctrl-C, or SIGTERM), `kill -TERM`s each tracked PID, and removes `/tmp/meow-fixtures/<uuid>/`. No post-run LaunchAgent cleanup needed because no LaunchAgents were ever registered.
 
-**Tart image provisioning — `scripts/provision-tart-fixtures.sh`:** layered delta on top of `bld-e2e-base`, not a rebuild. Idempotent. Installs the Homebrew-core set (`shadowsocks-rust`, `trojan-go`, `xray`, `wireguard-tools`, `wireguard-go`) and drops the two GitHub-release binaries (`hysteria` from `apernet/hysteria`, `tuic-server` from `EAimTY/tuic` — neither has a homebrew-core formula as of 2026-04) into `/usr/local/bin`. Pin versions via `HYSTERIA_VERSION` / `TUIC_VERSION` env. `DRY_RUN=1` prints a present/missing summary without mutating the guest — useful for probing what the existing base already has.
+**Runner-host provisioning — `scripts/provision-tart-fixtures.sh`:** idempotent host-side installer. Installs the Homebrew-core set (`shadowsocks-rust`, `trojan-go`, `xray`, `wireguard-tools`, `wireguard-go`) and drops the two GitHub-release binaries (`hysteria` from `apernet/hysteria`, `tuic-server` from `EAimTY/tuic` — neither has a homebrew-core formula as of 2026-04) into `/usr/local/bin`. Pin versions via `HYSTERIA_VERSION` / `TUIC_VERSION` env. `DRY_RUN=1` prints a present/missing summary without mutating state — useful for probing a host (or, if someone ever wants to, a guest).
 
-Operational note: the same script also runs cleanly on a developer laptop, so `MEOW_FIXTURE_SEEDED=1` local-dev loops don't require a Tart boot. Targeted delta vs a clean `bld-e2e-base` is ~80 MB; subsequent invocations are no-ops.
+Operational note: the same script also runs cleanly on a developer laptop outside CI, so `MEOW_FIXTURE_SEEDED=1` local-dev loops don't require any Tart boot at all.
 
 ---
 

--- a/scripts/provision-tart-fixtures.sh
+++ b/scripts/provision-tart-fixtures.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
 #
-# Idempotent Tart-guest provisioning for the protocol fixture binaries
-# consumed by scripts/test-e2e-ios.sh. Layered on top of the existing
-# `bld-e2e-base` image (per team-lead: reuse the local base, do not
-# rebake) so repeated runs only install what's missing.
+# Idempotent runner-host provisioning for the protocol fixture binaries
+# consumed by scripts/test-e2e-ios.sh. Repeated runs only install what's
+# missing.
 #
-# Runs in two modes:
-#   - inside the Tart macOS guest (most common): installs/downloads
-#     directly onto the guest's filesystem.
-#   - on a developer laptop: same provisioning, so `scripts/test-e2e-ios.sh`
-#     can be exercised locally without a Tart boot (MEOW_FIXTURE_SEEDED=1).
+# Runs on the **outer runner host** — the same macOS host that boots
+# the Tart guest for nightly E2E. The fixture servers spawn here (not
+# inside the guest); the virtual iPhone in the guest reaches them via
+# the Tart-visible host IP. The bld-e2e-base Tart image stays stateless
+# beyond SIP-disabled macOS + vphone-cli + SSH (see docs/TEST_FIXTURES.md
+# §5). Running this script inside the guest works too — fixture binaries
+# don't care where they live — but it's wasted installation on an image
+# the nightly pipeline never reaches with these binaries on PATH.
+#
+# Non-interactive SSH gotcha (for the guest-path, if anyone reaches for
+# it): `command -v brew` returns empty under `ssh user@host 'bash …'`
+# because /opt/homebrew/bin isn't on the non-interactive PATH. Prefix
+# with `eval "$(/opt/homebrew/bin/brew shellenv)"` or run the script
+# under an interactive shell. The outer-host path doesn't hit this
+# because it runs directly.
 #
 # What gets installed / downloaded:
 #   - Homebrew core formulas:

--- a/scripts/test-e2e-ios.sh
+++ b/scripts/test-e2e-ios.sh
@@ -16,9 +16,21 @@
 # behind T4.1 (deep-link handler) and T4.2 (Home Screen anchors); T2.6
 # Diagnostics Panel is live so Step 9 anchors are known.
 #
+# Execution model:
+#   The fixture servers (ssserver / trojan-go / xray / wg / hy2 / tuic)
+#   spawn on the host this script runs on — the **outer runner host**
+#   in the nightly pipeline. Only vphone-cli ops run inside the Tart
+#   guest, reached over SSH via VPHONE_HOST. The virtual iPhone in the
+#   guest reaches these fixture servers via the Tart-visible host IP
+#   (the outer host's address on the `bridgeN` interface Tart bridges
+#   onto), which we resolve from VPHONE_HOST. This is why the binds
+#   below are 0.0.0.0 and NOT 127.0.0.1 — loopback on the host is
+#   invisible to the iPhone's network stack inside the guest.
+#
 # Required env:
 #   VPHONE_HOST           SSH target where vphone-cli and the virtual iPhone live
-#                         (e.g. admin@<tart-vm-ip>). Empty = local vphone-cli.
+#                         (e.g. admin@<tart-vm-ip>). Empty = local vphone-cli,
+#                         in which case FIXTURE_HOST stays on 127.0.0.1.
 #   VPHONE_SOCK           Path to vm/vphone.sock on VPHONE_HOST. Default /tmp/vphone.sock.
 #
 # Optional env:
@@ -57,8 +69,33 @@ MEOW_FIXTURE_PROTOCOLS="${MEOW_FIXTURE_PROTOCOLS:-ss}"
 
 SSSERVER="${SSSERVER:-ssserver}"
 SS_METHOD="${SS_METHOD:-aes-256-gcm}"
-SS_HOST="127.0.0.1"
 SUB_PORT="${SUB_PORT:-18080}"
+
+# FIXTURE_HOST is the address advertised to the iPhone in the Clash
+# subscription YAML — i.e. where the iPhone dials the fixture servers.
+# - Local mode (no VPHONE_HOST): loopback is correct, iPhone and
+#   fixtures share a kernel.
+# - Tart mode (VPHONE_HOST=admin@<vm-ip>): the iPhone lives inside the
+#   Tart guest and sees the outer host via Tart's bridged interface,
+#   NOT via loopback. We resolve the outer-host address on the
+#   interface that routes to the VM IP and advertise that instead.
+tart_visible_host_ip() {
+    # Parse the VM IP out of VPHONE_HOST (form: user@host)
+    local vm_ip="${VPHONE_HOST#*@}"
+    [[ -z "$vm_ip" || "$vm_ip" == "$VPHONE_HOST" ]] && return 1
+    local iface
+    iface="$(route -n get "$vm_ip" 2>/dev/null | awk '/interface: /{print $2; exit}')"
+    [[ -n "$iface" ]] || return 1
+    ifconfig "$iface" 2>/dev/null | awk '/inet /{print $2; exit}'
+}
+
+if [[ -n "$VPHONE_HOST" ]]; then
+    FIXTURE_HOST="$(tart_visible_host_ip || true)"
+    [[ -n "$FIXTURE_HOST" ]] \
+        || { echo "error: could not resolve Tart-visible host IP from VPHONE_HOST=$VPHONE_HOST — check 'route -n get <vm-ip>' output" >&2; exit 1; }
+else
+    FIXTURE_HOST="127.0.0.1"
+fi
 
 FIXTURE_BASE="/tmp/meow-fixtures"
 
@@ -197,7 +234,7 @@ setup_ss() {
     cat >"$FIXTURE_DIR/proxies.d/ss.yaml" <<EOF
   - name: meow-fixture-ss
     type: ss
-    server: ${SS_HOST}
+    server: ${FIXTURE_HOST}
     port: ${SS_PORT}
     cipher: ${SS_METHOD}
     password: "${SS_PASSWORD}"
@@ -261,7 +298,7 @@ EOF
     cat >"$FIXTURE_DIR/proxies.d/trojan.yaml" <<EOF
   - name: meow-fixture-trojan
     type: trojan
-    server: ${SS_HOST}
+    server: ${FIXTURE_HOST}
     port: ${TROJAN_PORT}
     password: "${TROJAN_PASSWORD}"
     sni: meow-fixture.local
@@ -305,7 +342,7 @@ EOF
     cat >"$FIXTURE_DIR/proxies.d/vless.yaml" <<EOF
   - name: meow-fixture-vless
     type: vless
-    server: ${SS_HOST}
+    server: ${FIXTURE_HOST}
     port: ${VLESS_PORT}
     uuid: ${VLESS_UUID}
     network: tcp
@@ -343,7 +380,7 @@ EOF
     cat >"$FIXTURE_DIR/proxies.d/vmess.yaml" <<EOF
   - name: meow-fixture-vmess
     type: vmess
-    server: ${SS_HOST}
+    server: ${FIXTURE_HOST}
     port: ${VMESS_PORT}
     uuid: ${VMESS_UUID}
     alterId: 0
@@ -423,7 +460,7 @@ EOF
     cat >"$FIXTURE_DIR/proxies.d/wg.yaml" <<EOF
   - name: meow-fixture-wg
     type: wireguard
-    server: ${SS_HOST}
+    server: ${FIXTURE_HOST}
     port: ${WG_PORT}
     private-key: "${cli_priv}"
     public-key: "${srv_pub}"
@@ -458,7 +495,7 @@ EOF
     cat >"$FIXTURE_DIR/proxies.d/hy2.yaml" <<EOF
   - name: meow-fixture-hy2
     type: hysteria2
-    server: ${SS_HOST}
+    server: ${FIXTURE_HOST}
     port: ${HY2_PORT}
     password: "${HY2_PASSWORD}"
     sni: meow-fixture.local
@@ -498,7 +535,7 @@ EOF
     cat >"$FIXTURE_DIR/proxies.d/tuic.yaml" <<EOF
   - name: meow-fixture-tuic
     type: tuic
-    server: ${SS_HOST}
+    server: ${FIXTURE_HOST}
     port: ${TUIC_PORT}
     uuid: ${TUIC_UUID}
     password: "${TUIC_PASSWORD}"
@@ -574,7 +611,7 @@ HTTPD_PID=$!
 sleep 0.5
 kill -0 "$HTTPD_PID" 2>/dev/null || fail "http.server failed to start — see $FIXTURE_DIR/httpd.log"
 
-SUBSCRIPTION_URL="http://${SS_HOST}:${SUB_PORT}/clash.yaml"
+SUBSCRIPTION_URL="http://${FIXTURE_HOST}:${SUB_PORT}/clash.yaml"
 
 # Machine-parseable fixture summary — downstream harness (Swift XCUITest, etc.)
 # can parse these lines directly. Only variables for enabled protocols
@@ -588,41 +625,41 @@ SUBSCRIPTION_URL="http://${SS_HOST}:${SUB_PORT}/clash.yaml"
     for name in "${ENABLED_PROTOCOLS[@]}"; do
         case "$name" in
             meow-fixture-ss)
-                echo "SS_HOST=${SS_HOST}"
+                echo "SS_HOST=${FIXTURE_HOST}"
                 echo "SS_PORT=${SS_PORT}"
                 echo "SS_METHOD=${SS_METHOD}"
                 echo "SS_PASSWORD=${SS_PASSWORD}"
                 ;;
             meow-fixture-trojan)
-                echo "TROJAN_HOST=${SS_HOST}"
+                echo "TROJAN_HOST=${FIXTURE_HOST}"
                 echo "TROJAN_PORT=${TROJAN_PORT}"
                 echo "TROJAN_PASSWORD=${TROJAN_PASSWORD}"
                 echo "TROJAN_CERT=${FIXTURE_DIR}/trojan-cert.pem"
                 ;;
             meow-fixture-vless)
-                echo "VLESS_HOST=${SS_HOST}"
+                echo "VLESS_HOST=${FIXTURE_HOST}"
                 echo "VLESS_PORT=${VLESS_PORT}"
                 echo "VLESS_UUID=${VLESS_UUID}"
                 ;;
             meow-fixture-vmess)
-                echo "VMESS_HOST=${SS_HOST}"
+                echo "VMESS_HOST=${FIXTURE_HOST}"
                 echo "VMESS_PORT=${VMESS_PORT}"
                 echo "VMESS_UUID=${VMESS_UUID}"
                 ;;
             meow-fixture-wg)
-                echo "WG_HOST=${SS_HOST}"
+                echo "WG_HOST=${FIXTURE_HOST}"
                 echo "WG_PORT=${WG_PORT}"
                 echo "WG_CLIENT_PRIV=${FIXTURE_DIR}/wg-client.priv"
                 echo "WG_SERVER_PUB=${FIXTURE_DIR}/wg-server.pub"
                 ;;
             meow-fixture-hy2)
-                echo "HY2_HOST=${SS_HOST}"
+                echo "HY2_HOST=${FIXTURE_HOST}"
                 echo "HY2_PORT=${HY2_PORT}"
                 echo "HY2_PASSWORD=${HY2_PASSWORD}"
                 echo "HY2_CERT=${FIXTURE_DIR}/hy2-cert.pem"
                 ;;
             meow-fixture-tuic)
-                echo "TUIC_HOST=${SS_HOST}"
+                echo "TUIC_HOST=${FIXTURE_HOST}"
                 echo "TUIC_PORT=${TUIC_PORT}"
                 echo "TUIC_UUID=${TUIC_UUID}"
                 echo "TUIC_PASSWORD=${TUIC_PASSWORD}"


### PR DESCRIPTION
## Summary

Closes the wiring gap surfaced by the `bld-e2e-base` probe (task #30): `provision-tart-fixtures.sh` said "runs inside the guest" but `nightly.yml` + `test-e2e-ios.sh` actually spawn fixtures on the outer host. Per team-lead adjudication (2026-04-17), path (A) wins — fixtures stay on the host, guest stays stateless.

Also folds in the `tart run --nested` flag needed so vphone-cli's inner virtual iPhone can use `Virtualization.framework` inside the Tart guest (two-level virt stack; requires M3+ host).

### Commits

1. **`fb80c47`** `ci(fixtures): provision on runner host, resolve Tart-visible IP…`
   - `scripts/test-e2e-ios.sh` — new `FIXTURE_HOST` mode resolver. When `VPHONE_HOST` is set, resolves the Tart-visible host IP via `route -n get <vm-ip>` → interface → `ifconfig inet` (no hard-coded `192.168.64.1` / `bridge100`). Local runs keep `127.0.0.1`. All `server:` fields + the `SUBSCRIPTION_URL` pick up the mode-aware address. Binds were already `0.0.0.0` / `:port` / `[::]`, no bind changes needed — added an "Execution model" docstring block explaining why.
   - `scripts/provision-tart-fixtures.sh` — docstring flipped from "Tart-guest provisioning" → "runner-host provisioning". Rolled in the non-interactive-SSH `/opt/homebrew/bin` PATH gotcha.
   - `docs/RUNNER.md §1` — "Prereqs on the runner host (not inside the Tart VM)"; `bash scripts/provision-tart-fixtures.sh` now first host prereq; SIP clarification.
   - `docs/TEST_FIXTURES.md §1 + §5` — rewritten for host-side topology, bridge-IP resolution path, "do not tighten to loopback" warning.

2. **`74ebe60`** `ci(nightly): pass --nested to tart run…`
   - `.github/workflows/nightly.yml:37` — add `--nested` to `tart run` with inline comment.
   - `docs/RUNNER.md §4` — Apple Silicon M3-or-later host requirement callout; updated first-run signals + re-raise failure modes.
   - `docs/TEST_FIXTURES.md §5` — "Nested-virt requirement" paragraph documenting the two-level virt stack + host chip floor.

## Test plan

- [x] `bash -n` syntax check clean on both shell scripts
- [x] End-to-end reachability: `VPHONE_HOST=admin@192.168.64.79` resolves to host IP `192.168.64.1`; host-side `python3 -m http.server --bind 0.0.0.0 18080`; iPhone in Tart guest successfully `curl http://192.168.64.1:18080/`
- [x] Local-mode fallback: `VPHONE_HOST` unset → `FIXTURE_HOST=127.0.0.1` (preserves `MEOW_FIXTURE_SEEDED=1` dev loop)
- [x] Runner host (user's M4) supports nested-virt — no hardware-gate escalation
- [ ] Nightly smoke-test via `workflow_dispatch` — deferred, gated on runner registration + vphone-cli bake into `bld-e2e-base` (user in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)