### PR TITLE
feat(app): T4.1 meow://connect subscription-import deep link (#31)

### DIFF
--- a/App/Sources/Services/SubscriptionDeepLink.swift
+++ b/App/Sources/Services/SubscriptionDeepLink.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Parsed `meow://connect?url=<encoded>[&name=<encoded>][&select=1]`
+/// subscription-import deep link. Pure parsing — the actual
+/// fetch/persist happens through `SubscriptionService.add(name:url:)`
+/// so the existing auth, timeout, YAML validation, and persistence
+/// code path is reused unchanged.
+///
+/// Routing lives in `ContentView.onOpenURL`; this type is separate so
+/// URL semantics can be unit-tested without UIKit.
+struct SubscriptionDeepLink: Equatable, Sendable {
+    let subscriptionURL: URL
+    let name: String
+    let autoSelect: Bool
+
+    /// Returns `nil` for anything that isn't a well-formed
+    /// `meow://connect?url=…` link — unknown hosts (`meow://foo`),
+    /// missing `url=`, or `url=` values that don't parse as http/https
+    /// are all rejected here so `ContentView` doesn't have to branch.
+    ///
+    /// **Security**: we only accept `http`/`https` subscription URLs.
+    /// `file://`, `data:` etc. would let a crafted link read arbitrary
+    /// local paths or inject inline YAML, so they're rejected outright.
+    static func parse(_ deepLink: URL) -> SubscriptionDeepLink? {
+        guard deepLink.scheme == "meow", deepLink.host == "connect" else {
+            return nil
+        }
+        guard let components = URLComponents(url: deepLink, resolvingAgainstBaseURL: false),
+              let items = components.queryItems else {
+            return nil
+        }
+
+        guard let rawURL = items.first(where: { $0.name == "url" })?.value,
+              let subscriptionURL = URL(string: rawURL),
+              let scheme = subscriptionURL.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              subscriptionURL.host?.isEmpty == false else {
+            return nil
+        }
+
+        let explicit = items.first(where: { $0.name == "name" })?.value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let name: String
+        if let explicit, !explicit.isEmpty {
+            name = explicit
+        } else {
+            name = subscriptionURL.host ?? "Subscription"
+        }
+
+        let autoSelect = items.first(where: { $0.name == "select" })?.value == "1"
+
+        return SubscriptionDeepLink(
+            subscriptionURL: subscriptionURL,
+            name: name,
+            autoSelect: autoSelect
+        )
+    }
+}

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(AppModel.self) private var appModel
+    @Environment(SubscriptionService.self) private var subscriptionService
     @State private var showDiagnostics = false
+    @State private var importError: String?
 
     var body: some View {
         TabView {
@@ -25,6 +27,10 @@ struct ContentView: View {
         .onOpenURL { url in
             if url.scheme == "meow" && url.host == "diagnostics" {
                 showDiagnostics = true
+                return
+            }
+            if let link = SubscriptionDeepLink.parse(url) {
+                Task { await handleSubscriptionImport(link) }
             }
         }
         .fullScreenCover(isPresented: $showDiagnostics) {
@@ -39,6 +45,26 @@ struct ContentView: View {
                         }
                     }
             }
+        }
+        .alert("Couldn't import subscription", isPresented: .constant(importError != nil)) {
+            Button("OK") { importError = nil }
+        } message: {
+            Text(importError ?? "")
+        }
+    }
+
+    @MainActor
+    private func handleSubscriptionImport(_ link: SubscriptionDeepLink) async {
+        do {
+            let profile = try await subscriptionService.add(
+                name: link.name,
+                url: link.subscriptionURL.absoluteString
+            )
+            if link.autoSelect {
+                try subscriptionService.select(profile)
+            }
+        } catch {
+            importError = error.localizedDescription
         }
     }
 }

--- a/MeowTests/Services/SubscriptionDeepLinkTests.swift
+++ b/MeowTests/Services/SubscriptionDeepLinkTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import Foundation
+@testable import meow_ios
+
+/// `meow://connect?url=<encoded>` deep-link parsing. The app-side
+/// handler (`ContentView.onOpenURL`) only branches on
+/// `SubscriptionDeepLink.parse(_:) != nil`, so every acceptance /
+/// rejection decision must happen here.
+///
+/// PRD §4.3 Subscriptions — subscription import must tolerate the
+/// common share-sheet shape (URL-encoded subscription link, optional
+/// friendly name) while rejecting anything that could be used to
+/// smuggle a non-remote YAML source.
+@Suite("SubscriptionDeepLink.parse", .tags(.deepLink))
+struct SubscriptionDeepLinkTests {
+
+    @Test("accepts well-formed meow://connect with http(s) url")
+    func acceptsHappyPath() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml")!
+        ))
+        #expect(link.subscriptionURL == URL(string: "https://example.com/sub.yaml"))
+        #expect(link.name == "example.com")
+        #expect(link.autoSelect == false)
+    }
+
+    @Test("http subscription urls are accepted (not every user has TLS)")
+    func acceptsHTTPScheme() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=http%3A%2F%2F10.0.0.1%2Fsub.yaml")!
+        ))
+        #expect(link.subscriptionURL.scheme == "http")
+    }
+
+    @Test("explicit name query parameter overrides host-derived default")
+    func explicitNameWins() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml&name=My%20VPN")!
+        ))
+        #expect(link.name == "My VPN")
+    }
+
+    @Test("select=1 opts in to auto-select; absent or any other value stays off")
+    func autoSelectOptIn() throws {
+        let on = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs&select=1")!
+        ))
+        #expect(on.autoSelect)
+
+        let absent = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs")!
+        ))
+        #expect(absent.autoSelect == false)
+
+        let wrongValue = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs&select=yes")!
+        ))
+        #expect(wrongValue.autoSelect == false)
+    }
+
+    @Test("rejects wrong host — only meow://connect is this handler's business")
+    func rejectsWrongHost() {
+        #expect(SubscriptionDeepLink.parse(
+            URL(string: "meow://diagnostics?url=https%3A%2F%2Fe.com%2Fs")!
+        ) == nil)
+        #expect(SubscriptionDeepLink.parse(
+            URL(string: "meow://random?url=https%3A%2F%2Fe.com%2Fs")!
+        ) == nil)
+    }
+
+    @Test("rejects wrong scheme — https://connect is not our URL scheme")
+    func rejectsWrongScheme() {
+        #expect(SubscriptionDeepLink.parse(
+            URL(string: "https://connect?url=https%3A%2F%2Fe.com%2Fs")!
+        ) == nil)
+    }
+
+    @Test("rejects missing ?url= entirely")
+    func rejectsMissingURL() {
+        #expect(SubscriptionDeepLink.parse(URL(string: "meow://connect")!) == nil)
+        #expect(SubscriptionDeepLink.parse(URL(string: "meow://connect?name=foo")!) == nil)
+    }
+
+    @Test("rejects empty ?url= value")
+    func rejectsEmptyURL() {
+        #expect(SubscriptionDeepLink.parse(URL(string: "meow://connect?url=")!) == nil)
+    }
+
+    @Test("rejects non-http(s) schemes to block file:/data: smuggling")
+    func rejectsDangerousSchemes() {
+        let cases = [
+            "file%3A%2F%2F%2Fetc%2Fpasswd",
+            "data%3Atext%2Fplain%2Chello",
+            "javascript%3Aalert(1)",
+            "ftp%3A%2F%2Fexample.com%2Fs",
+        ]
+        for encoded in cases {
+            let url = URL(string: "meow://connect?url=\(encoded)")!
+            #expect(SubscriptionDeepLink.parse(url) == nil,
+                    "expected rejection for \(url.absoluteString)")
+        }
+    }
+
+    @Test("rejects http url with empty host")
+    func rejectsEmptyHost() {
+        #expect(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2F%2Fsub.yaml")!
+        ) == nil)
+    }
+
+    @Test("blank explicit name falls back to host-derived default")
+    func blankNameFallsBack() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fs&name=")!
+        ))
+        #expect(link.name == "example.com")
+
+        let whitespace = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fs&name=%20%20%20")!
+        ))
+        #expect(whitespace.name == "example.com")
+    }
+}
+
+extension Tag {
+    @Tag static var deepLink: Self
+}


### PR DESCRIPTION
## Summary

- Adds `meow://connect?url=<encoded>[&name=…][&select=1]` handling to `ContentView.onOpenURL` — re-uses the existing `SubscriptionService.add(name:url:)` pipeline, no service-level changes.
- Parser lives in its own file (`App/Sources/Services/SubscriptionDeepLink.swift`) so URL semantics are unit-testable without UIKit.

## URL contract

| param | required | meaning |
|---|---|---|
| `url` | ✅ | percent-encoded subscription URL. **http/https only** — `file://`, `data:`, `javascript:`, `ftp://` are rejected. |
| `name` | ❌ | friendly name. Blank or whitespace-only → fall back to the subscription URL's host. |
| `select` | ❌ | `select=1` auto-selects the new profile. Anything else (absent, `select=0`, `select=yes`) leaves the current selection untouched. **Opt-in by design** so Safari/share-sheet deep links can't silently switch the user's active VPN. |

Malformed links (missing `?url=`, empty host, wrong URL host like `meow://foo`) are silently ignored — keeps the router branching in `onOpenURL` boring.

## Why this is needed

Team-lead's assignment points at three unlock cases:
- LocalE2ETests Option 2 (pre-seeded `NETunnelProviderManager` from a test subscription)
- vphone-cli nightly harness can `open meow://connect?url=...` to install a test profile
- User-facing: click a subscription link from Safari / iMessage → lands in meow with the profile added

## Error UX

Fetch/decode failures surface as a modal alert on the root view — same shape as the manual Add Subscription sheet, so users see a concrete reason ("cancelled", "http 404", etc.) rather than a silent no-op.

## Test coverage

11 parser cases in `MeowTests/Services/SubscriptionDeepLinkTests`:

- [x] well-formed `meow://connect` with `https` URL
- [x] `http` subscription URLs accepted (not everyone has TLS)
- [x] explicit `&name=` overrides host-derived default
- [x] `&select=1` opts in; absent/other values stay off
- [x] wrong host (`meow://diagnostics?url=…`, `meow://random?…`) rejected
- [x] wrong scheme (`https://connect?…`) rejected
- [x] missing `?url=` rejected
- [x] empty `?url=` rejected
- [x] dangerous schemes — `file://`, `data:`, `javascript:`, `ftp://` — rejected
- [x] empty host rejected
- [x] blank/whitespace `&name=` falls back to host

Full `SubscriptionService.add()` integration (URLProtocolStub + in-memory SwiftData) stays on the T4.5 skeleton — not widening #31 to enable the whole suite.

## Test plan

- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests/SubscriptionDeepLinkTests` → 11 passed, 0 failed.
- [ ] Manual: `xcrun simctl openurl booted "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml"` in a booted sim once a valid subscription host is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)