### PR TITLE
ci: wire build-core to actually build MihomoCore.xcframework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,28 +48,36 @@ jobs:
 
   build-core:
     # PRD v1.1: single pure-Rust MihomoCore.xcframework — no Go toolchain.
+    # mihomo-rust is pulled as a cargo git dependency (pinned via Cargo.lock),
+    # not a submodule, so no --recurse-submodules here.
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Rust (stable + iOS targets)
+        uses: dtolnay/rust-toolchain@stable
         with:
-          submodules: recursive  # mihomo-rust is a git submodule
-      - name: Set up Rust
-        run: |
-          rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
-          cargo install cbindgen
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+      - name: Cache cargo registry, git, and build target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            core/rust/mihomo-ios-ffi/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('core/rust/mihomo-ios-ffi/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
       - name: Build MihomoCore.xcframework
-        run: |
-          # scripts/build-rust.sh   # lands with T0.4 / T1.4
-          echo "Rust build placeholder — enable after T1.4"
+        run: scripts/build-rust.sh
       - name: Enforce size budget (≤ 8 MB stripped — see TEST_STRATEGY §8.1)
         run: |
           # test $(stat -f %z MeowCore/Frameworks/MihomoCore.xcframework/ios-arm64/libmihomo_ios_ffi.a) -lt 8388608
-          echo "Size gate placeholder — enable after T1.4 (8 MB limit to stay inside the 15 MB NE memory cap)"
+          echo "Size gate placeholder — stripped-binary enforcement lives in the archive job (PacketTunnel.appex); raw-.a gate lands with T1.4."
       - uses: actions/upload-artifact@v4
         with:
           name: MihomoCore.xcframework
           path: MeowCore/Frameworks/MihomoCore.xcframework
-          if-no-files-found: warn
+          if-no-files-found: error
 
   unit-test:
     needs: [build-core]
@@ -132,10 +140,14 @@ jobs:
           path: build/ui.xcresult
 
   archive:
-    needs: [unit-test, ui-test, security-scan]
+    needs: [build-core, unit-test, ui-test, security-scan]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: MihomoCore.xcframework
+          path: MeowCore/Frameworks/MihomoCore.xcframework
       - name: Archive (no signing on PR)
         run: |
           brew install xcodegen


### PR DESCRIPTION
## Summary

Closes #28. The `build-core` job was a placeholder emitting `echo "Rust build placeholder"` and producing an empty artifact — Rust changes were passing CI without being exercised (Dev flagged this on the REST bind-race PR).

### `build-core` changes

- **Rust setup**: `dtolnay/rust-toolchain@stable` with `targets: aarch64-apple-ios,aarch64-apple-ios-sim` — replaces the previous placeholder that called `rustup target add` + `cargo install cbindgen`. (cbindgen is a Cargo build-dep invoked from `build.rs`, not a CLI the script ever reaches for. `x86_64-apple-ios` was listed but the script doesn't target it.)
- **Cache**: `actions/cache@v4` on `~/.cargo/registry`, `~/.cargo/git`, and `core/rust/mihomo-ios-ffi/target`, keyed on `Cargo.lock` hash. Cold build is ~36s locally on macos-14-equivalent; unchanged lock will be near-instant.
- **Build**: run `scripts/build-rust.sh` unmodified — script is the contract; T1.4's formal build unification supersedes this but doesn't block it.
- **Artifact**: flip `if-no-files-found: warn → error` — a missing xcframework should fail the job, not silently degrade downstream jobs.
- **Checkout**: drop `submodules: recursive` — mihomo-rust is a cargo git dep pinned via `Cargo.lock`, not a submodule (no `.gitmodules` in repo).

### `archive` changes

- Add `build-core` to `needs:` (was transitive via `unit-test`/`ui-test`; making it explicit).
- `actions/download-artifact@v4` the xcframework into `MeowCore/Frameworks/` before `xcodebuild archive`. Previously the archive step would fail on a fresh runner since no earlier step in `archive`'s own job planted the framework on disk. This closes the `build-core → artifact → archive` loop Dev flagged.

### Non-goals (T1.4 scope)

- Raw `.a` size budget (stripped-binary enforcement already lives in the `archive` job against `PacketTunnel`).
- Multi-profile matrix (release-only ships today).
- Any mutation to `scripts/build-rust.sh`.

## Test plan

- [x] `bash scripts/build-rust.sh` on clean worktree locally → produces `MeowCore/Frameworks/MihomoCore.xcframework` with both slices (`ios-arm64`, `ios-arm64-simulator`, ~16 MB per-slice unstripped)
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] dtolnay/rust-toolchain@stable accepts comma-separated `targets:` input (documented API)
- [x] Cache path `core/rust/mihomo-ios-ffi/target` matches build-rust.sh's `CRATE_DIR=core/rust/mihomo-ios-ffi` → `target/aarch64-apple-ios/release/`
- [ ] First CI run — defer until the PR runs (cold build + cache miss, so will be slower than subsequent runs; expecting ~4–7 min on GH-hosted macos-14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)