### PR TITLE
test(skeletons): M2 T3.x contract skeletons for Connections/Rules/Logs

### DIFF
--- a/MeowIntegrationTests/Screens/ConnectionsScreenTests.swift
+++ b/MeowIntegrationTests/Screens/ConnectionsScreenTests.swift
@@ -1,0 +1,102 @@
+import Testing
+import Foundation
+@testable import meow_ios
+
+/// End-to-end contract for `ConnectionsView` (T4.5) — drives the view
+/// against a stubbed `MihomoAPI` and asserts polling cadence, swipe-to-close
+/// dispatch, Close-All dispatch, and search-filter behavior.
+///
+/// `.disabled("blocked on T4.5")` — this suite depends on two things the
+/// T4.5 Connections Screen task delivers:
+///
+///   1. A hosted-view harness that can inject an `@Environment(MihomoAPI)`
+///      into `ConnectionsView` and observe @State changes. The shared
+///      harness lands with T4.5 (the Traffic / Subscriptions screens will
+///      reuse it), so standing up a one-off fixture here would be churn.
+///   2. Accessibility anchors on the Connections row (host/port, chain,
+///      rule label) and the toolbar's "Close All" button. Today
+///      `ConnectionsView.swift` has none — T4.5 is where the XCUITest
+///      identifiers get wired for nightly E2E selection.
+///
+/// The skeletons here compile against `Connection` / `ConnectionsResponse`
+/// (`App/Sources/Services/MihomoAPITypes.swift`) so contract drift breaks
+/// the build before it reaches a reviewer.
+///
+/// `.serialized` — the MihomoAPI polling loop is long-lived; overlapping
+/// tests against the same stub registry race on shared state.
+@Suite("ConnectionsView — T4.5 screen contract", .tags(.screen), .serialized)
+struct ConnectionsScreenTests {
+
+    /// Compile-time anchor — drift in `Connection` / `ConnectionsResponse`
+    /// or the close-connection API surface breaks this file.
+    private static func _contractAnchor(api: MihomoAPI) async throws {
+        _ = Connection.self
+        _ = ConnectionsResponse.self
+        _ = try await api.getConnections()
+        try await api.closeConnection(id: "")
+        try await api.closeAllConnections()
+    }
+
+    @Test(
+        "appears → polls /connections every ~1s",
+        .disabled("blocked on T4.5")
+    )
+    func pollingCadence() async throws {
+        // Mount ConnectionsView with a stubbed API; count hits on the
+        // `/connections` URL stub over a 3.5s window; expect 3–4 hits
+        // (ConnectionsView.poll() sleeps 1s between calls). Catches any
+        // regression to a run-once fetch when T4.5 adds pull-to-refresh.
+        Issue.record("ConnectionsScreenTests.pollingCadence not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "swipe-to-close row dispatches DELETE /connections/{id}",
+        .disabled("blocked on T4.5")
+    )
+    func swipeToClose() async throws {
+        // Seed stub with one `Connection { id: "abc-123", … }`; invoke the
+        // row's swipe-action Close button via the harness; assert a
+        // DELETE to `/connections/abc-123` was captured. Confirms the
+        // id → URL binding in the row's swipeActions block.
+        Issue.record("ConnectionsScreenTests.swipeToClose not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "Close-All toolbar button dispatches DELETE /connections",
+        .disabled("blocked on T4.5")
+    )
+    func closeAllToolbar() async throws {
+        // Hit the toolbar's "Close All" affordance; assert
+        // `api.closeAllConnections()` fired exactly once (DELETE on the
+        // collection URL, no id suffix).
+        Issue.record("ConnectionsScreenTests.closeAllToolbar not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "search query filters visible rows by metadata.host (case-insensitive)",
+        .disabled("blocked on T4.5")
+    )
+    func searchFiltersByHost() async throws {
+        // Seed three connections with hosts "example.com", "FOO.bar",
+        // "speedtest.net"; set `query = "foo"`; assert only the FOO.bar
+        // row is visible. Mirrors the `filtered` computed property;
+        // locks the localizedCaseInsensitiveContains behavior in so
+        // we don't silently regress to exact-match.
+        Issue.record("ConnectionsScreenTests.searchFiltersByHost not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "empty ConnectionsResponse renders zero rows without error overlay",
+        .disabled("blocked on T4.5")
+    )
+    func emptyStateNoError() async throws {
+        // `{"downloadTotal":0,"uploadTotal":0,"connections":null}` — the
+        // idle-tunnel payload. Assert List renders 0 rows and the nav
+        // title shows "Connections (0)" with no error state.
+        Issue.record("ConnectionsScreenTests.emptyStateNoError not implemented — skeleton gated on T4.5")
+    }
+}
+
+extension Tag {
+    @Tag static var screen: Self
+}

--- a/MeowTests/API/ConnectionsTests.swift
+++ b/MeowTests/API/ConnectionsTests.swift
@@ -1,0 +1,110 @@
+import Testing
+import Foundation
+@testable import meow_ios
+
+/// Contract for the Connections half of the mihomo REST client (T3.4) — the
+/// slice consumed by T4.5 Connections Screen.
+///
+/// The `.disabled("blocked on T4.5")` attribute is deliberate: the REST
+/// methods already exist on `MihomoAPI`, but the full URLProtocolStub
+/// harness for the `@Observable` client (shared with `MihomoAPITests.swift`)
+/// lands with T4.5 when the Connections Screen goes through end-to-end
+/// wiring. Until then these tests exist to:
+///
+///   1. Compile against today's `Connection` / `ConnectionsResponse`
+///      contract from `App/Sources/Services/MihomoAPITypes.swift` — if any
+///      field gets renamed or retyped, this file fails to build (the point
+///      of skeleton tests, per team-lead).
+///   2. Pin the endpoint list T4.5 must satisfy: polling `/connections`,
+///      `DELETE /connections/{id}`, `DELETE /connections`, plus empty-list
+///      and HTTP-error handling.
+///
+/// Fixture source: `URLProtocolStub` in `MeowTests/Support/URLProtocolStub.swift`.
+@Suite("MihomoAPI connections endpoints", .tags(.api))
+struct ConnectionsTests {
+
+    /// Compile-time anchor: if any of the shapes below drifts, this file
+    /// fails to build. That is the point of skeleton tests.
+    private static func _contractAnchor(api: MihomoAPI) async throws {
+        _ = ConnectionsResponse.self
+        _ = Connection.self
+        _ = Connection.Metadata.self
+        _ = MihomoAPIError.http(status: 0)
+        _ = try await api.getConnections()
+        try await api.closeConnection(id: "")
+        try await api.closeAllConnections()
+    }
+
+    @Test(
+        "GET /connections decodes ConnectionsResponse with non-empty list",
+        .disabled("blocked on T4.5")
+    )
+    func getConnectionsHappyPath() async throws {
+        // Expected shape (see MihomoAPITypes.swift):
+        //   ConnectionsResponse { downloadTotal, uploadTotal, connections: [Connection]? }
+        //   Connection { id, metadata: Metadata, upload, download, start, chains, rule, rulePayload }
+        //
+        // Stub `http://127.0.0.1:9090/connections` with one entry, assert:
+        //   - `resp.connections?.count == 1`
+        //   - first connection's `metadata.host` and `metadata.destinationPort` round-trip
+        //   - `chains` decodes as ordered array (reversed in the view)
+        Issue.record("ConnectionsTests.getConnectionsHappyPath not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "GET /connections decodes empty-list payload (null connections)",
+        .disabled("blocked on T4.5")
+    )
+    func getConnectionsEmptyList() async throws {
+        // mihomo emits `"connections": null` when idle. Client must surface
+        // `nil` (or `[]`) without throwing — `ConnectionsView` treats either
+        // as "empty state" via `resp.connections ?? []`.
+        Issue.record("ConnectionsTests.getConnectionsEmptyList not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "DELETE /connections/{id} issues correct verb and path",
+        .disabled("blocked on T4.5")
+    )
+    func closeConnectionByID() async throws {
+        // Invoke `api.closeConnection(id: "abc-123")`, capture the outbound
+        // URLRequest, assert `httpMethod == "DELETE"` and path ends with
+        // `/connections/abc-123`. Swipe-to-close row in ConnectionsView
+        // relies on this contract.
+        Issue.record("ConnectionsTests.closeConnectionByID not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "DELETE /connections issues correct verb for close-all",
+        .disabled("blocked on T4.5")
+    )
+    func closeAllConnections() async throws {
+        // Toolbar "Close All" button in ConnectionsView calls
+        // `api.closeAllConnections()`. Same stub harness as above but
+        // targeting the collection URL (no id suffix).
+        Issue.record("ConnectionsTests.closeAllConnections not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "non-2xx HTTP status surfaces as MihomoAPIError.http",
+        .disabled("blocked on T4.5")
+    )
+    func httpErrorSurfaces() async throws {
+        // Stub `/connections` with 500 status; assert the thrown error
+        // matches `MihomoAPIError.http(status: 500)`. Baseline behavior for
+        // the error overlay the Connections Screen will add during T4.5.
+        Issue.record("ConnectionsTests.httpErrorSurfaces not implemented — skeleton gated on T4.5")
+    }
+
+    @Test(
+        "malformed JSON body surfaces as decoding error",
+        .disabled("blocked on T4.5")
+    )
+    func malformedPayloadSurfaces() async throws {
+        // Stub `/connections` with `{"downloadTotal": "not-a-number"}`.
+        // Swift's JSONDecoder must throw; client must propagate rather
+        // than swallow. Polling loop in ConnectionsView.poll() currently
+        // silently drops errors — T4.5 replaces that with an error banner.
+        Issue.record("ConnectionsTests.malformedPayloadSurfaces not implemented — skeleton gated on T4.5")
+    }
+}

--- a/MeowTests/API/LogsTests.swift
+++ b/MeowTests/API/LogsTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import Foundation
+@testable import meow_ios
+
+/// Contract for `streamLogs(level:)` — the WebSocket half of `MihomoAPI`
+/// consumed by T4.7 Logs Screen.
+///
+/// `.disabled("blocked on T4.7")` — WebSocket stubbing is not built into
+/// `URLProtocolStub` and lands with the T4.7 Logs Screen harness. Until
+/// then these skeletons pin the `LogEntry` contract and the
+/// level-picker / malformed-line behaviors the view depends on, so that
+/// any drift in `App/Sources/Services/MihomoAPITypes.swift` breaks the
+/// build.
+///
+/// Fixture source: `URLProtocolStub` in `MeowTests/Support/URLProtocolStub.swift`
+/// (plus a WebSocket stub helper that lands with T4.7).
+@Suite("MihomoAPI logs WebSocket", .tags(.api))
+struct LogsTests {
+
+    /// Compile-time anchor — drift in `LogEntry` or the `streamLogs`
+    /// signature breaks this file. `streamLogs` returns synchronously; the
+    /// `AsyncThrowingStream` itself is the asynchrony boundary.
+    private static func _contractAnchor(api: MihomoAPI) {
+        _ = LogEntry.self
+        _ = LogEntry.from(jsonString: "")
+        let stream: AsyncThrowingStream<LogEntry, Error> = api.streamLogs(level: "info")
+        _ = stream
+    }
+
+    @Test(
+        "LogEntry.from(jsonString:) decodes well-formed {type,payload}",
+        .disabled("blocked on T4.7")
+    )
+    func logEntryDecodesHappyPath() throws {
+        // `LogEntry { type, payload }` — see MihomoAPITypes.swift.
+        // Exercise: `LogEntry.from(jsonString: #"{"type":"info","payload":"hi"}"#)`
+        // must yield a non-nil entry with both fields populated.
+        Issue.record("LogsTests.logEntryDecodesHappyPath not implemented — skeleton gated on T4.7")
+    }
+
+    @Test(
+        "LogEntry.from(jsonString:) returns nil on malformed JSON",
+        .disabled("blocked on T4.7")
+    )
+    func logEntryMalformedYieldsNil() throws {
+        // Partial frames / non-JSON keepalives must not crash the stream.
+        // `LogsView.subscribe()` drops `nil` entries silently; this test
+        // locks that contract in so we don't regress to an `Optional.!` or
+        // `try!` anywhere in the decode path.
+        Issue.record("LogsTests.logEntryMalformedYieldsNil not implemented — skeleton gated on T4.7")
+    }
+
+    @Test(
+        "streamLogs request URL embeds ?level= query param",
+        .disabled("blocked on T4.7")
+    )
+    func streamLogsLevelQuery() async throws {
+        // Picker in LogsView toggles between debug/info/warning/error and
+        // restarts the stream on change (`task(id: level)`). The client
+        // must encode the level as `?level=<value>` on the WebSocket URL —
+        // mihomo honors this as a server-side filter.
+        Issue.record("LogsTests.streamLogsLevelQuery not implemented — skeleton gated on T4.7")
+    }
+
+    @Test(
+        "streamLogs yields entries in order; cancellation finishes the stream",
+        .disabled("blocked on T4.7")
+    )
+    func streamLogsOrderingAndCancellation() async throws {
+        // Feed three framed messages through the WebSocket stub, assert
+        // the `AsyncThrowingStream` yields them in the same order with no
+        // drops. Then cancel the task — `continuation.onTermination` must
+        // fire and the stream must finish without a thrown error.
+        Issue.record("LogsTests.streamLogsOrderingAndCancellation not implemented — skeleton gated on T4.7")
+    }
+
+    @Test(
+        "WebSocket remote close surfaces as throwing-stream error",
+        .disabled("blocked on T4.7")
+    )
+    func streamLogsRemoteClosePropagates() async throws {
+        // When the server tears down the socket (engine restart / mihomo
+        // panic), `ws.receive()` throws. The stream must finish(throwing:)
+        // so LogsView can recover on the next `.task(id: level)` cycle
+        // rather than silently stalling.
+        Issue.record("LogsTests.streamLogsRemoteClosePropagates not implemented — skeleton gated on T4.7")
+    }
+}

--- a/MeowTests/API/RulesTests.swift
+++ b/MeowTests/API/RulesTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import Foundation
+@testable import meow_ios
+
+/// Contract for `GET /rules` — consumed by T4.6 Rules Screen.
+///
+/// `.disabled("blocked on T4.6")` until the URLProtocolStub harness for
+/// the `@Observable` `MihomoAPI` is shared across API suites (lands with
+/// the T4.6 Rules Screen work). Today these skeletons serve as a
+/// compile-time contract check against `Rule` / `RulesResponse` in
+/// `App/Sources/Services/MihomoAPITypes.swift`: if either shape drifts,
+/// this file fails to build.
+///
+/// Fixture source: `URLProtocolStub` in `MeowTests/Support/URLProtocolStub.swift`.
+@Suite("MihomoAPI rules endpoint", .tags(.api))
+struct RulesTests {
+
+    /// Compile-time anchor — drift in `Rule` / `RulesResponse` or in the
+    /// `getRules()` signature breaks this file.
+    private static func _contractAnchor(api: MihomoAPI) async throws {
+        _ = Rule.self
+        _ = RulesResponse.self
+        _ = try await api.getRules()
+    }
+
+    @Test(
+        "GET /rules parses Rule array with type/payload/proxy triples",
+        .disabled("blocked on T4.6")
+    )
+    func getRulesHappyPath() async throws {
+        // Expected shape (MihomoAPITypes.swift):
+        //   RulesResponse { rules: [Rule] }
+        //   Rule { type, payload, proxy, id: "\(type)\(payload)\(proxy)" }
+        //
+        // Stub `http://127.0.0.1:9090/rules` with a three-entry mix of
+        // DOMAIN-SUFFIX / GEOIP / MATCH rules; assert each decodes and
+        // `rule.id` is unique across the list (RulesView relies on
+        // Identifiable for ForEach).
+        Issue.record("RulesTests.getRulesHappyPath not implemented — skeleton gated on T4.6")
+    }
+
+    @Test(
+        "GET /rules handles empty rules list",
+        .disabled("blocked on T4.6")
+    )
+    func getRulesEmpty() async throws {
+        // Fresh config with no rules yet: `{"rules":[]}`. Decoder must
+        // yield `RulesResponse(rules: [])`, not throw. RulesView renders
+        // empty List without error overlay.
+        Issue.record("RulesTests.getRulesEmpty not implemented — skeleton gated on T4.6")
+    }
+
+    @Test(
+        "non-2xx HTTP status surfaces as MihomoAPIError.http",
+        .disabled("blocked on T4.6")
+    )
+    func httpErrorSurfaces() async throws {
+        // Stub `/rules` with 503; the `.overlay` showing error text in
+        // RulesView depends on this being a throwing path rather than a
+        // silent empty-list.
+        Issue.record("RulesTests.httpErrorSurfaces not implemented — skeleton gated on T4.6")
+    }
+
+    @Test(
+        "unknown rule `type` string preserves raw value (no enum coercion)",
+        .disabled("blocked on T4.6")
+    )
+    func unknownRuleTypePreserved() async throws {
+        // mihomo adds new rule kinds upstream faster than we ship; `Rule.type`
+        // is `String` not an enum so new kinds pass through unchanged.
+        // Guards against a well-meaning enum refactor that would start
+        // rejecting valid server payloads.
+        Issue.record("RulesTests.unknownRuleTypePreserved not implemented — skeleton gated on T4.6")
+    }
+}

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -24,11 +24,19 @@ rustup target add aarch64-apple-ios aarch64-apple-ios-sim
 
 ## Regenerating the Xcode project
 
+`project.yml` is the source of truth. `meow-ios.xcodeproj` is git-ignored
+and generated output — never hand-edit `project.pbxproj`. If you add or
+rename a target, source folder, or dependency, resync with:
+
 ```sh
-./scripts/generate-xcodeproj.sh
+./scripts/generate-xcodeproj.sh   # wraps `xcodegen generate`
 ```
 
-`meow-ios.xcodeproj` is git-ignored; always regenerate it from `project.yml`.
+If adding a new test bundle or source path and the generator misbehaves,
+`xcodegen generate` can be invoked directly from the repo root to surface
+its diagnostics. CI always regenerates from `project.yml`, so any drift
+between the checked-in `project.yml` and a hand-edited `project.pbxproj`
+will be silently overwritten.
 
 ## Native library builds
 


### PR DESCRIPTION
## Summary

- **M2 T3.x compile-against-contract skeletons** for the three REST/WebSocket surfaces the upcoming screen tasks will wire up (T4.5 Connections, T4.6 Rules, T4.7 Logs).
- **Every @Test gated via `.disabled("blocked on T4.x")`** — bodies call `Issue.record(...)` only. The gate is the screen task, not the already-landed T3.4 REST client, because the URLProtocolStub harness for the `@Observable` `MihomoAPI` lands with T4.5 (shared with T4.6/T4.7).
- **Each suite carries a `_contractAnchor` helper** that touches the shared DTO (`Connection` / `Rule` / `LogEntry`) and the `MihomoAPI` method it claims to cover — drift in any of those shapes breaks the file's build. That is the whole value of skeleton tests per team-lead: *"skeletons that compile catch drift, skeletons that don't compile are noise."*

## Files

- `MeowTests/API/ConnectionsTests.swift` — GET /connections (happy path, empty list, HTTP-error, malformed payload), DELETE /connections/{id}, DELETE /connections for close-all.
- `MeowTests/API/RulesTests.swift` — GET /rules parsing, empty-list, HTTP-error, unknown-`type` passthrough (guards against a future enum refactor that would start rejecting valid server payloads).
- `MeowTests/API/LogsTests.swift` — `LogEntry` decoding (happy / malformed), `streamLogs` URL query param, ordering + cancellation, remote-close propagation.
- `MeowIntegrationTests/Screens/ConnectionsScreenTests.swift` — T4.5 screen contract: polling cadence, swipe-to-close, Close-All toolbar, host search filter, empty-state overlay. Declares new `.screen` tag.
- `docs/BUILD.md` — expanded *Regenerating the Xcode project* section to call out that `project.pbxproj` is generated output (never hand-edit) and that CI regenerates from `project.yml` on every run, so pbxproj drift is silently overwritten.

Pattern mirrors `MeowIntegrationTests/ProtocolFixtures/UDPProtocolTests.swift` (@Test(.disabled(...)) + Issue.record + file-top docstring naming unblocker / milestone / fixture source).

## Test plan

- [x] `xcodebuild build-for-testing -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4'` — **TEST BUILD SUCCEEDED** locally against pre-built `MihomoCore.xcframework`.
- [ ] CI `build-core` produces the xcframework, then `unit-test` and `ui-test` compile the skeleton suites. Skeletons never *run* (all tests `.disabled`), so no behavior check — drift-detection is the whole contract.
- [ ] When T4.5 lands, drop `.disabled("blocked on T4.5")` on `ConnectionsTests.swift` + `ConnectionsScreenTests.swift` and fill in bodies using the forthcoming URLProtocolStub harness. Same for T4.6 → `RulesTests.swift` and T4.7 → `LogsTests.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)