### PR TITLE
ci: bump swift-dependent jobs to macos-15 + Xcode 26 for Swift 6.2 (#34a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,17 @@ jobs:
 
   unit-test:
     needs: [build-core]
-    runs-on: macos-14
+    # macos-15: required for Xcode 26 / Swift 6.2, which MeowShared/Package.swift
+    # pins via `swift-tools-version: 6.2`. The macos-14 image ships Xcode 15.x /
+    # Swift 5.10 and rejects the manifest at parse time — previously this job
+    # failed in ~17s with an unreadable Package.swift error that masked as a
+    # generic CI red. See task #34(a) for the triage trail.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ^26.0
       - uses: actions/download-artifact@v4
         with:
           name: MihomoCore.xcframework
@@ -100,7 +108,7 @@ jobs:
           xcodebuild test \
             -project meow-ios.xcodeproj \
             -scheme meow-ios \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=26.0' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
             -only-testing:MeowTests \
             -resultBundlePath build/unit.xcresult \
             -enableCodeCoverage YES \
@@ -113,9 +121,15 @@ jobs:
 
   ui-test:
     needs: [build-core]
-    runs-on: macos-14
+    # Same Xcode 26 / Swift 6.2 requirement as unit-test — xcodebuild resolves
+    # the MeowShared local SPM package (tools-version 6.2) before building
+    # the app host for XCUITest.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ^26.0
       - uses: actions/download-artifact@v4
         with:
           name: MihomoCore.xcframework
@@ -129,7 +143,7 @@ jobs:
           xcodebuild test \
             -project meow-ios.xcodeproj \
             -scheme meow-ios \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=26.0' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
             -only-testing:MeowUITests \
             -resultBundlePath build/ui.xcresult \
             | xcbeautify
@@ -141,9 +155,14 @@ jobs:
 
   archive:
     needs: [build-core, unit-test, ui-test, security-scan]
-    runs-on: macos-14
+    # Same Xcode 26 / Swift 6.2 requirement — the Release archive
+    # re-resolves MeowShared's SPM package.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ^26.0
       - uses: actions/download-artifact@v4
         with:
           name: MihomoCore.xcframework

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,16 @@ on:
 
 jobs:
   testflight:
-    runs-on: macos-14
+    # macos-15 + Xcode 26: fastlane invokes xcodebuild, which resolves the
+    # MeowShared local SPM package (swift-tools-version: 6.2) — same
+    # substrate requirement as ci.yml's unit-test / ui-test / archive jobs.
+    runs-on: macos-15
     environment: release
     steps:
       - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ^26.0
       - name: Install fastlane
         run: |
           brew install fastlane xcodegen


### PR DESCRIPTION
## Summary

- **Root cause of #34(a) red:** `MeowShared/Package.swift` declares `swift-tools-version: 6.2`; `macos-14` runner ships Xcode 15.x / Swift 5.10 and rejects the manifest at parse time. Every job that resolves this local SPM package was failing fast (~17s) on what looked like a generic CI red. Main has been red 5-for-5 on this root cause since PR #4.
- **Fix:** `unit-test` / `ui-test` / `archive` (in `ci.yml`) and `testflight` (in `release.yml`) move to **`macos-15` + explicit Xcode 26** via `maxim-lobanov/setup-xcode@v1` with `xcode-version: ^26.0`.
- **Destination flag:** `OS=26.0` → `OS=latest` on the two simulator-test jobs. Xcode 26.x ships 26.2+ sims — pinning 26.0 would miss every available image.
- **Unchanged (no Swift toolchain dep):** `lint` (swiftlint binary), `security-scan` (grep / git-secrets / cargo audit), `build-core` (pure Rust).

## GH runner image check (pre-CI)

Verified via `actions/runner-images` repo `images/macos/macos-15-Readme.md` before burning a CI run:
- macos-15 ships **Xcode 26.0.1, 26.1.1, 26.2, 26.3** (plus 16.0–16.4; default remains 16.4).
- `setup-xcode@v1` with `xcode-version: ^26.0` resolves to **26.3** → Swift 6.2 → parses `swift-tools-version: 6.2` cleanly.
- Nice side-effect: our `import Testing` usage (Swift Testing framework, needs Xcode 16+) also becomes uniformly supported across every Swift-building job.

## Workflow audit

**Audit: confirmed no changes needed.** No vphone-cli references exist in `ci.yml` or `release.yml`; `nightly.yml`'s e2e job is the sole self-hosted step and already correctly labelled `[self-hosted, macOS, apple-silicon, tart]` with every tart/vphone-cli step contained inside it.

The `release.yml` Xcode 26 bump in this PR is a latent-bug fix for the same Swift-toolchain root cause (fastlane invokes xcodebuild on MeowShared), not driven by the audit.

## Scope boundary

This is **#34(a) only**. Leaves:
- **#34(b) — SwiftLint violations:** `identifier_name` / `trailing_comma` / `line_length` across ~20 files. Separate PR after this one lands.
- **#34(c) — security-scan:** investigate first. Separate PR.

Stacking would obscure which regression a revert targets.

## Test plan

- [ ] CI on this PR: `unit-test` and `ui-test` now compile MeowShared cleanly; `archive` binary-size gate re-enables after build-core → unit-test → archive chain completes end-to-end.
- [ ] `lint` and `security-scan` remain red on this PR (expected — they're #34(b)/(c)).
- [ ] Post-merge, main's CI conclusion flips from "failure" to "failure-on-lint-and-security-scan-only" — measurable progress toward green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)