### PR TITLE
test(tests): LocalE2ETests Option 2 — seeder + NE error-surface pin (β)

### DIFF
--- a/App/Resources/UITestsFixtureProfile.yaml
+++ b/App/Resources/UITestsFixtureProfile.yaml
@@ -1,0 +1,19 @@
+# Minimal Clash profile used by LocalE2ETests (#33, Option 2).
+#
+# Compiled into the app bundle and seeded via UITestsSeeder when the
+# process is launched with `-UITests`. The point is only to have *a*
+# valid, selectable profile so the VPN toggle enables and the tunnel
+# can start — none of the rules need to be reachable on a local sim.
+#
+# DIRECT-only by design: no remote proxies means no DNS lookups that
+# can hang the sim, and every connection shortcircuits. Ports match
+# the defaults mihomo-rust pins in effective-config.yaml so that the
+# app's normal bootstrap paths don't have to special-case this YAML.
+mixed-port: 7890
+external-controller: 127.0.0.1:9090
+mode: rule
+log-level: info
+proxies: []
+proxy-groups: []
+rules:
+  - MATCH,DIRECT

--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -32,6 +32,9 @@ final class AppModel {
         didBootstrap = true
 
         await AssetSeeder.seedIfNeeded()
+        #if DEBUG
+        UITestsSeeder.seedIfNeeded(modelContext: AppModelContainer.shared.container.mainContext)
+        #endif
         await vpnManager.refresh()
         ipcBridge.start()
     }

--- a/App/Sources/Services/UITestsSeeder.swift
+++ b/App/Sources/Services/UITestsSeeder.swift
@@ -1,0 +1,74 @@
+#if DEBUG
+import Foundation
+import SwiftData
+import MeowModels
+
+/// Seeds a minimal Clash profile into SwiftData + the App Group container
+/// when the app is launched under XCUITest with `-UITests`. The fixture is
+/// bundled as `UITestsFixtureProfile.yaml` (see `App/Resources`).
+///
+/// Scope: this is Option 2 of the LocalE2ETests ladder. On a cold sim, the
+/// VPN toggle is disabled until a profile is selected, which meant the
+/// `testToggleMovesBadgeToConnecting` test had to `XCTSkip`. Running this
+/// seeder before `VpnManager.refresh()` means the toggle is live and the
+/// diagnostics panel's `TUN_EXISTS` / `MEM_OK` checks can be asserted
+/// locally without standing up the Tart vphone fixture.
+///
+/// `#if DEBUG` keeps the seeder out of Release builds — no chance of a
+/// release build silently picking up a fixture profile.
+enum UITestsSeeder {
+    static let launchArg = "-UITests"
+    static let fixtureName = "UITests Fixture"
+    static let fixtureResource = "UITestsFixtureProfile"
+    static let fixtureURLPlaceholder = "meow://ui-tests-fixture"
+
+    static func seedIfNeeded(modelContext: ModelContext) {
+        guard CommandLine.arguments.contains(launchArg) else { return }
+        guard let yaml = loadBundledYAML() else {
+            NSLog("UITestsSeeder: %@.yaml missing from bundle — skipping seed", fixtureResource)
+            return
+        }
+
+        do {
+            try upsertProfile(yaml: yaml, modelContext: modelContext)
+            try writeActiveConfig(yaml: yaml)
+        } catch {
+            NSLog("UITestsSeeder: seed failed: %@", String(describing: error))
+        }
+    }
+
+    private static func loadBundledYAML() -> String? {
+        guard let url = Bundle.main.url(forResource: fixtureResource, withExtension: "yaml") else {
+            return nil
+        }
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func upsertProfile(yaml: String, modelContext: ModelContext) throws {
+        let existing = try modelContext.fetch(FetchDescriptor<Profile>())
+        let fixture = existing.first { $0.name == fixtureName }
+            ?? {
+                let p = Profile(
+                    name: fixtureName,
+                    url: fixtureURLPlaceholder,
+                    yamlContent: yaml,
+                    yamlBackup: yaml
+                )
+                modelContext.insert(p)
+                return p
+            }()
+        fixture.yamlContent = yaml
+        fixture.yamlBackup = yaml
+        for p in existing where p.id != fixture.id { p.isSelected = false }
+        fixture.isSelected = true
+        AppGroup.defaults.set(fixture.id.uuidString, forKey: PreferenceKey.selectedProfileID)
+        try modelContext.save()
+    }
+
+    private static func writeActiveConfig(yaml: String) throws {
+        let dir = AppGroup.containerURL
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try yaml.write(to: AppGroup.configURL, atomically: true, encoding: .utf8)
+    }
+}
+#endif

--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -10,7 +10,28 @@ import Observation
 @Observable
 final class VpnManager {
     private(set) var stage: VpnStage = .idle
-    private(set) var lastError: String?
+    private(set) var lastError: VpnManagerError?
+
+    /// Structured error surface. `lastError.label` is the PRD §4.3 text
+    /// rendered at `home.error` (accessibility id) and pinned by
+    /// `LocalE2ETests` — keeping domain + code + message machine-parseable
+    /// means a rename (`localizedDescription` drift, string interpolation
+    /// typo) breaks the test instead of silently swallowing the change.
+    struct VpnManagerError: Sendable, Equatable {
+        let domain: String
+        let code: Int
+        let message: String
+
+        init(_ error: Error) {
+            let ns = error as NSError
+            self.domain = ns.domain
+            self.code = ns.code
+            self.message = error.localizedDescription
+        }
+
+        /// `<domain>(<code>): <message>` — pinned by `LocalE2ETests`.
+        var label: String { "\(domain)(\(code)): \(message)" }
+    }
     private var manager: NETunnelProviderManager?
     // nonisolated(unsafe): written only from attach() on MainActor, read from
     // deinit (which is nonisolated). NotificationCenter.removeObserver is
@@ -34,7 +55,7 @@ final class VpnManager {
             try await mgr.loadFromPreferences()
             attach(mgr)
         } catch {
-            lastError = error.localizedDescription
+            lastError = VpnManagerError(error)
             stage = .error
         }
     }
@@ -47,7 +68,7 @@ final class VpnManager {
             guard let manager else { return }
             try manager.connection.startVPNTunnel()
         } catch {
-            lastError = error.localizedDescription
+            lastError = VpnManagerError(error)
             stage = .error
         }
     }

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -63,6 +63,14 @@ struct HomeView: View {
                     Spacer()
                 }
 
+                if let err = vpnManager.lastError {
+                    Text(err.label)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(3)
+                        .accessibilityIdentifier("home.error")
+                }
+
                 vpnToggle
             }
         }

--- a/MeowUITests/Flows/LocalE2ETests.swift
+++ b/MeowUITests/Flows/LocalE2ETests.swift
@@ -97,7 +97,7 @@ final class LocalE2ETests: XCTestCase {
             VPhone.HomeScreen.AccessibilityID.vpnToggle,
             VPhone.HomeScreen.AccessibilityID.stateBadge,
             VPhone.HomeScreen.AccessibilityID.profileName,
-            VPhone.HomeScreen.AccessibilityID.navDiagnostics,
+            VPhone.HomeScreen.AccessibilityID.navDiagnostics
         ]
 
         for id in anchors {
@@ -209,13 +209,12 @@ final class LocalE2ETests: XCTestCase {
         XCTAssertNotNil(Int(codeStr), "home.error code = \"\(codeStr)\", expected integer")
     }
 
-    /// `<Domain>(<Code>): <message>` — matches `VpnManagerError.label`.
-    /// Domain is any non-paren/non-colon run so a rename like
-    /// `NEVPNError` (without `Domain`) still matches structurally; the
-    /// separate equality check on `NEVPNErrorDomain` pins the exact name.
-    private static let errorLabelRegex: NSRegularExpression = {
-        try! NSRegularExpression(pattern: #"^([^(]+)\((-?\d+)\):\s"#)
-    }()
+    // `<Domain>(<Code>): <message>` — matches `VpnManagerError.label`. Domain is any
+    // non-paren/non-colon run so a rename like `NEVPNError` (without `Domain`) still
+    // matches structurally; the separate equality check on `NEVPNErrorDomain` pins the
+    // exact name.
+    // swiftlint:disable:next force_try
+    private static let errorLabelRegex = try! NSRegularExpression(pattern: #"^([^(]+)\((-?\d+)\):\s"#)
 
     // MARK: - (4) Diagnostics panel contract
 

--- a/MeowUITests/Flows/LocalE2ETests.swift
+++ b/MeowUITests/Flows/LocalE2ETests.swift
@@ -1,12 +1,17 @@
 import MeowModels
 import XCTest
 
-/// Contract-smoke layer for the M1.5 5-check gate, runnable on any Mac
-/// with an iOS 26 simulator. This bundle *is not* the PASS-asserting
-/// gate — that's the nightly vphone-cli path
-/// (`MeowUITests/Flows/E2E5CheckGateTests` + `Support/VPhone.swift`,
-/// TEST_STRATEGY v1.2 §7) which needs a Tart VM, a real proxy, and
-/// extension entitlements. Those assertions belong there.
+/// Local XCUITest layer for the M1.5 5-check gate, runnable on any
+/// Mac with an iOS 26 simulator. Ladder position: *Option 2* on the
+/// contract-smoke ↔ full-vphone-gate continuum. It drives the `-UITests`
+/// seeder (bundled fixture YAML, auto-selected profile, pre-approved
+/// NETunnelProviderManager) so that the toggle goes live and the
+/// tunnel can actually start. It is *still not* the PASS-asserting
+/// nightly — that's `E2E5CheckGateTests` + `Support/VPhone.swift`
+/// (TEST_STRATEGY v1.2 §7), which needs a Tart VM, a real proxy, and
+/// a live C2 endpoint. The only checks this bundle asserts PASS for
+/// are the ones that don't depend on an outbound path: `TUN_EXISTS`
+/// (extension running) and `MEM_OK` (extension under the appex cap).
 ///
 /// What this bundle does:
 ///
@@ -18,31 +23,55 @@ import XCTest
 ///    via `VPhone.HomeScreen.ConnectionState(rawValue:)`. Any drift
 ///    from the frozen lowercase-ASCII vocabulary (PRD §4.3) fails
 ///    here, not two hours into a nightly run.
-/// 3. **Toggle liveness** — tapping `home.toggle.vpn` moves the badge
-///    to `connecting`. We deliberately don't wait for `connected` —
-///    that needs a real proxy; local sims have no tunnel target.
-/// 4. **Diagnostics panel contract** — navigating via
+/// 3. **Toggle liveness** — with the `-UITests` seeder selecting a
+///    DIRECT-only fixture profile, `home.toggle.vpn` enables on
+///    launch. Tapping it must move the badge to `connecting` within
+///    5s. We deliberately don't wait for `connected` — locally there
+///    is no remote proxy to tunnel to, but the extension itself
+///    comes up and that's what the next test pins on.
+/// 4. **Diagnostics contract + extension liveness** — navigating via
 ///    `home.nav.diagnostics` exposes the 5 PRD §4.4 rows with correct
-///    `diagnostics.row.<KEY>` identifiers, and the `Run Diagnostics`
-///    button updates each row within a bounded timeout. We assert
-///    only that each row parses via `DiagnosticsLabelParser` — the
-///    result (PASS or FAIL) is irrelevant here because there's no
-///    real extension backing the checks on a local sim.
+///    `diagnostics.row.<KEY>` identifiers and parseable labels. Post-
+///    connect, `TUN_EXISTS: PASS` and `MEM_OK: PASS` are asserted
+///    (the extension is up and under the 50MB cap). `DNS_OK`,
+///    `TCP_PROXY_OK`, and `HTTP_204_OK` are allowed to FAIL — those
+///    need a real outbound, which local sims don't have.
 ///
-/// Why contract-smoke and not PASS-asserting: the user's Mac has no
-/// Tart fixture, no wireguard-go endpoint, no C2 server — all the
-/// things the 5 checks actually probe. Asserting PASS locally would
-/// either force every contributor to stand up that infra or make the
-/// tests lie. The nightly vphone run is the gate; this is the
-/// compile-time-adjacent guard that the contract the gate relies on
-/// still exists.
+/// Why not full PASS: the user's Mac has no Tart fixture, no
+/// wireguard-go endpoint, no C2 server — all the things the three
+/// outbound checks probe. The nightly vphone run asserts PASS on all
+/// 5; this bundle asserts PASS only on the subset that stays true in
+/// an outbound-less environment, plus pins the contract the nightly
+/// relies on.
 ///
 /// Running: `xcodebuild test -scheme meow-ios
 /// -destination 'platform=iOS Simulator,name=iPhone 17'
 /// -only-testing:MeowUITests/LocalE2ETests`.
+@MainActor
 final class LocalE2ETests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
+    }
+
+    /// Belt-and-braces fallback for the NE consent dialog. `VpnManager.refresh()`
+    /// calls `saveToPreferences` on launch, which on a brand-new sim image
+    /// triggers a system consent sheet ("meow Would Like to Add VPN
+    /// Configurations"). Programmatic save is enough on most images because
+    /// the manager is reused across relaunches, but on a fresh image we need
+    /// a UI path too. The monitor must be followed by an interaction with
+    /// the app — XCTest only drains interruption handlers on the next
+    /// `app.*` call.
+    private func installNEConsentMonitor(on app: XCUIApplication) {
+        addUIInterruptionMonitor(withDescription: "NE consent") { alert in
+            for label in ["Allow", "OK"] {
+                let button = alert.buttons[label]
+                if button.exists {
+                    button.tap()
+                    return true
+                }
+            }
+            return false
+        }
     }
 
     // MARK: - (1) Anchor wiring
@@ -92,10 +121,14 @@ final class LocalE2ETests: XCTestCase {
     // MARK: - (3) Toggle liveness
 
     /// Tapping the VPN toggle from a disconnected state must move the
-    /// badge to `connecting`. We don't wait for `connected` — that
-    /// would require a real proxy + extension approval, which local
-    /// sims don't have. The goal here is only to prove the toggle is
-    /// wired to `vpnManager.connect()` and the badge re-renders.
+    /// badge to `connecting` within 5s. The `-UITests` seeder (see
+    /// `UITestsSeeder`) installs a DIRECT-only Clash profile and
+    /// `VpnManager.refresh()` pre-approves the NETunnelProviderManager,
+    /// so the toggle is enabled on launch and the tunnel can start.
+    /// We don't wait for `connected` — on a local sim there is no
+    /// remote proxy to tunnel to. The bookkeeping we *do* care about
+    /// (the extension is running, it's under its memory cap) moves to
+    /// `testPostConnectDiagnosticsReportTunAndMemPass`.
     func testToggleMovesBadgeToConnecting() throws {
         let app = launchHome()
 
@@ -108,31 +141,124 @@ final class LocalE2ETests: XCTestCase {
         XCTAssertTrue(badge.waitForExistence(timeout: 5))
         XCTAssertTrue(toggle.waitForExistence(timeout: 5))
 
-        // Precondition — we start disconnected. If a prior run left
-        // state around, `-ResetState` in `launchHome()` should have
-        // cleared it.
-        XCTAssertEqual(badge.label, VPhone.HomeScreen.ConnectionState.disconnected.rawValue)
+        waitForDisconnected(badge: badge, app: app, timeout: 10)
 
-        // On a cold sim with no seeded profile, `home.toggle.vpn` is
-        // `.disabled(true)` in HomeView (the button only enables when
-        // a profile is selected or the tunnel is already up). That's
-        // the common case for this bundle — full toggle liveness is
-        // exercised in the nightly vphone path where a profile is
-        // pre-seeded on the Tart image. Contract-smoke-wise, proving
-        // the anchor exists + is well-typed-but-disabled is the
-        // strongest statement we can honestly make locally.
-        guard toggle.isEnabled else {
-            throw XCTSkip(
-                "home.toggle.vpn is disabled — no profile seeded on this launch. " +
-                    "Full toggle liveness runs in the nightly vphone gate, not here.",
-            )
-        }
+        XCTAssertTrue(
+            toggle.isEnabled,
+            "home.toggle.vpn is disabled — `-UITests` seeder should have installed a selected profile. " +
+            "Check UITestsSeeder + bundled UITestsFixtureProfile.yaml."
+        )
         toggle.tap()
+        app.activate() // flush any pending NE consent interruption
 
         let reachedConnecting = expectation(for: NSPredicate(format: "label == %@",
                                                              VPhone.HomeScreen.ConnectionState.connecting.rawValue),
                                             evaluatedWith: badge)
-        wait(for: [reachedConnecting], timeout: 3)
+        wait(for: [reachedConnecting], timeout: 5)
+    }
+
+    /// With the tunnel up, the diagnostics panel should report
+    /// `TUN_EXISTS: PASS` (extension is running) and `MEM_OK: PASS`
+    /// (extension is under the 50MB appex cap). The other three checks
+    /// need a real outbound path and are expected to `FAIL(...)` on a
+    /// local sim — we don't assert on them.
+    ///
+    /// One retry budget: first-ever launch on a fresh sim image may
+    /// stall on the NE consent flow; the interruption monitor + a
+    /// single relaunch gets past it. Beyond that, we surface a real
+    /// failure rather than paper over flakiness.
+    func testPostConnectDiagnosticsReportTunAndMemPass() throws {
+        try runPostConnectDiagnostics(attempt: 1, maxAttempts: 2)
+    }
+
+    private func runPostConnectDiagnostics(attempt: Int, maxAttempts: Int) throws {
+        let app = launchHome()
+
+        let badge = app.descendants(matching: .any)[
+            VPhone.HomeScreen.AccessibilityID.stateBadge
+        ]
+        let toggle = app.descendants(matching: .any)[
+            VPhone.HomeScreen.AccessibilityID.vpnToggle
+        ]
+        XCTAssertTrue(badge.waitForExistence(timeout: 5))
+        XCTAssertTrue(toggle.waitForExistence(timeout: 5))
+
+        waitForDisconnected(badge: badge, app: app, timeout: 10)
+
+        guard toggle.isEnabled else {
+            if attempt < maxAttempts {
+                app.terminate()
+                try runPostConnectDiagnostics(attempt: attempt + 1, maxAttempts: maxAttempts)
+                return
+            }
+            XCTFail("home.toggle.vpn stayed disabled across \(maxAttempts) attempts")
+            return
+        }
+
+        toggle.tap()
+        app.activate() // flush consent interruption, if any
+
+        // Wait for the tunnel to leave `disconnected`. We accept either
+        // `connecting` or `connected` — the point of this test is that the
+        // extension is up, not that the status machine passed through a
+        // specific state.
+        let leftDisconnected = expectation(for: NSPredicate(format: "label != %@",
+                                                            VPhone.HomeScreen.ConnectionState.disconnected.rawValue),
+                                           evaluatedWith: badge)
+        let leftResult = XCTWaiter().wait(for: [leftDisconnected], timeout: 10)
+        guard leftResult == .completed else {
+            if attempt < maxAttempts {
+                app.terminate()
+                try runPostConnectDiagnostics(attempt: attempt + 1, maxAttempts: maxAttempts)
+                return
+            }
+            XCTFail("tunnel did not leave disconnected after \(maxAttempts) attempts")
+            return
+        }
+
+        let nav = app.descendants(matching: .any)[
+            VPhone.HomeScreen.AccessibilityID.navDiagnostics
+        ]
+        XCTAssertTrue(nav.waitForExistence(timeout: 5))
+        nav.tap()
+
+        let runButton = app.descendants(matching: .any)["diagnostics.button.run"]
+        XCTAssertTrue(runButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(runButton.isHittable)
+        runButton.tap()
+
+        let deadline = Date().addingTimeInterval(20)
+        var lastResults: [DiagnosticsCheck: DiagnosticsResult] = [:]
+        while Date() < deadline {
+            let dump = DiagnosticsCheck.allCases.compactMap { check -> String? in
+                let row = app.descendants(matching: .any)["diagnostics.row.\(check.rawValue)"]
+                return row.exists ? row.label : nil
+            }.joined(separator: "\n")
+
+            if let parsed = try? DiagnosticsLabelParser.parse(dump) {
+                lastResults = parsed
+                if parsed[.tunExists] == .pass && parsed[.memOk] == .pass {
+                    return
+                }
+            }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+
+        let snapshot = DiagnosticsCheck.allCases.map { check in
+            "\(check.rawValue)=\(lastResults[check].map(String.init(describing:)) ?? "<absent>")"
+        }.joined(separator: ", ")
+        XCTFail("TUN_EXISTS + MEM_OK did not both reach PASS within 20s — last seen: \(snapshot)")
+    }
+
+    private func waitForDisconnected(badge: XCUIElement, app: XCUIApplication, timeout: TimeInterval) {
+        let isDisconnected = NSPredicate(format: "label == %@",
+                                         VPhone.HomeScreen.ConnectionState.disconnected.rawValue)
+        let e = expectation(for: isDisconnected, evaluatedWith: badge)
+        if XCTWaiter().wait(for: [e], timeout: timeout) == .completed { return }
+        // Give interruption monitor a chance to dismiss NE consent, then
+        // accept the current label — the individual tests will assert their
+        // own preconditions.
+        app.activate()
     }
 
     // MARK: - (4) Diagnostics panel contract
@@ -198,7 +324,13 @@ final class LocalE2ETests: XCTestCase {
     private func launchHome() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments.append(contentsOf: ["-UITests", "-ResetState"])
+        installNEConsentMonitor(on: app)
         app.launch()
+        // Nudge the app so XCTest drains any pending interruption handler.
+        // The monitor only fires on the *next* app interaction.
+        _ = app.descendants(matching: .any)[
+            VPhone.HomeScreen.AccessibilityID.stateBadge
+        ].waitForExistence(timeout: 5)
         return app
     }
 }

--- a/MeowUITests/Flows/LocalE2ETests.swift
+++ b/MeowUITests/Flows/LocalE2ETests.swift
@@ -2,18 +2,23 @@ import MeowModels
 import XCTest
 
 /// Local XCUITest layer for the M1.5 5-check gate, runnable on any
-/// Mac with an iOS 26 simulator. Ladder position: *Option 2* on the
-/// contract-smoke ↔ full-vphone-gate continuum. It drives the `-UITests`
-/// seeder (bundled fixture YAML, auto-selected profile, pre-approved
-/// NETunnelProviderManager) so that the toggle goes live and the
-/// tunnel can actually start. It is *still not* the PASS-asserting
-/// nightly — that's `E2E5CheckGateTests` + `Support/VPhone.swift`
-/// (TEST_STRATEGY v1.2 §7), which needs a Tart VM, a real proxy, and
-/// a live C2 endpoint. The only checks this bundle asserts PASS for
-/// are the ones that don't depend on an outbound path: `TUN_EXISTS`
-/// (extension running) and `MEM_OK` (extension under the appex cap).
+/// Mac with an iOS 26 simulator. Ladder position: *Option 2 (β)* on
+/// the contract-smoke ↔ full-vphone-gate continuum — seeder pipeline
+/// + NE error-surface UX, but *not* a real `.connecting → .connected`
+/// transition. That lives in the nightly vphone gate
+/// (`E2E5CheckGateTests` + `Support/VPhone.swift`, TEST_STRATEGY v1.2
+/// §7), which needs a Tart VM, a real proxy, and a live C2 endpoint.
 ///
-/// What this bundle does:
+/// Why this bundle doesn't assert connected: `NETunnelProviderManager`
+/// operations fail on the iOS 26 simulator with
+/// `NEVPNErrorDomain Code=5 ("IPC failed")` — the sim has no
+/// `nesessionmanager` daemon to service the IPC. So
+/// `saveToPreferences` / `startVPNTunnel` never complete, and no
+/// amount of seeder wiring can get the badge to `connecting`. That
+/// failure mode is the one we lean into: we pin the UX contract that
+/// an NE error bubbles up to the user instead of vanishing.
+///
+/// What this bundle pins:
 ///
 /// 1. **Anchor wiring** — every `VPhone.HomeScreen.AccessibilityID`
 ///    identifier the T4.2 spec promises is actually queryable at
@@ -23,26 +28,30 @@ import XCTest
 ///    via `VPhone.HomeScreen.ConnectionState(rawValue:)`. Any drift
 ///    from the frozen lowercase-ASCII vocabulary (PRD §4.3) fails
 ///    here, not two hours into a nightly run.
-/// 3. **Toggle liveness** — with the `-UITests` seeder selecting a
-///    DIRECT-only fixture profile, `home.toggle.vpn` enables on
-///    launch. Tapping it must move the badge to `connecting` within
-///    5s. We deliberately don't wait for `connected` — locally there
-///    is no remote proxy to tunnel to, but the extension itself
-///    comes up and that's what the next test pins on.
-/// 4. **Diagnostics contract + extension liveness** — navigating via
-///    `home.nav.diagnostics` exposes the 5 PRD §4.4 rows with correct
-///    `diagnostics.row.<KEY>` identifiers and parseable labels. Post-
-///    connect, `TUN_EXISTS: PASS` and `MEM_OK: PASS` are asserted
-///    (the extension is up and under the 50MB cap). `DNS_OK`,
-///    `TCP_PROXY_OK`, and `HTTP_204_OK` are allowed to FAIL — those
-///    need a real outbound, which local sims don't have.
+/// 3. **Seeder + NE error surface** — with the `-UITests` seeder
+///    selecting a DIRECT-only fixture profile, `home.toggle.vpn` is
+///    enabled on launch (which by itself proves the seeder ran end to
+///    end). Tapping the toggle triggers `VpnManager.connect()`, which
+///    on the sim fails with an `NEVPNError`. The test asserts:
+///    (a) `home.badge.state` stays `disconnected`,
+///    (b) `home.error` renders a machine-parseable
+///        `<Domain>(<Code>): <message>` label pointing at
+///        `NEVPNErrorDomain` with an integer code.
+///    Loose assertions ("any non-empty error") would let a rename of
+///    `VpnManager.lastError` or a string-interpolation typo slip
+///    through — the tight domain+code pin catches that.
+/// 4. **Diagnostics contract** — navigating via `home.nav.diagnostics`
+///    exposes the 5 PRD §4.4 rows with correct `diagnostics.row.<KEY>`
+///    identifiers, and the `Run Diagnostics` button updates each row
+///    within a bounded timeout. We assert only that each row parses
+///    via `DiagnosticsLabelParser`; the actual PASS/FAIL result is
+///    irrelevant here because the extension never runs on the sim.
 ///
-/// Why not full PASS: the user's Mac has no Tart fixture, no
-/// wireguard-go endpoint, no C2 server — all the things the three
-/// outbound checks probe. The nightly vphone run asserts PASS on all
-/// 5; this bundle asserts PASS only on the subset that stays true in
-/// an outbound-less environment, plus pins the contract the nightly
-/// relies on.
+/// What this bundle does **not** do (intentionally):
+/// - assert `.connecting` / `.connected` — sim NE can't reach either;
+/// - assert `TUN_EXISTS: PASS` / `MEM_OK: PASS` — needs the extension
+///   to be running, which needs NE IPC, which the sim doesn't have.
+/// Both live in the nightly vphone gate.
 ///
 /// Running: `xcodebuild test -scheme meow-ios
 /// -destination 'platform=iOS Simulator,name=iPhone 17'
@@ -118,18 +127,31 @@ final class LocalE2ETests: XCTestCase {
         )
     }
 
-    // MARK: - (3) Toggle liveness
+    // MARK: - (3) Seeder + NE error surface
 
-    /// Tapping the VPN toggle from a disconnected state must move the
-    /// badge to `connecting` within 5s. The `-UITests` seeder (see
-    /// `UITestsSeeder`) installs a DIRECT-only Clash profile and
-    /// `VpnManager.refresh()` pre-approves the NETunnelProviderManager,
-    /// so the toggle is enabled on launch and the tunnel can start.
-    /// We don't wait for `connected` — on a local sim there is no
-    /// remote proxy to tunnel to. The bookkeeping we *do* care about
-    /// (the extension is running, it's under its memory cap) moves to
-    /// `testPostConnectDiagnosticsReportTunAndMemPass`.
-    func testToggleMovesBadgeToConnecting() throws {
+    /// End-to-end pin for Option 2 (β): seeder runs → toggle enables →
+    /// tap produces a tightly-typed NE error surface. Three assertions,
+    /// all of which must hold:
+    ///
+    /// 1. **Seeder ran.** `home.toggle.vpn.isEnabled == true` at launch
+    ///    — only possible if `UITestsSeeder` inserted a selected Profile
+    ///    into SwiftData on the `-UITests` path.
+    /// 2. **Badge stays `disconnected`.** On sim NE IPC fails, so the
+    ///    UI must not lie by advancing to `connecting`. Loose check
+    ///    ("not connected") would allow a `connecting` → `disconnected`
+    ///    flicker to slip through.
+    /// 3. **`home.error` is populated and parseable.** Label format is
+    ///    `<Domain>(<Code>): <message>`. On iOS 26 sim `Domain` is
+    ///    exactly `NEVPNErrorDomain` and `Code` is an integer. A
+    ///    rename in `VpnManager.VpnManagerError.label` breaks this,
+    ///    which is the intent — loose "label != empty" would hide
+    ///    that regression.
+    ///
+    /// This doesn't prove the real-device NE path works. That's what
+    /// the nightly vphone gate is for. What it *does* prove: if the
+    /// NE stack surfaces an error, the user sees a structured one
+    /// (not a silent no-op).
+    func testTapToggleSurfacesNEError() throws {
         let app = launchHome()
 
         let badge = app.descendants(matching: .any)[
@@ -141,7 +163,11 @@ final class LocalE2ETests: XCTestCase {
         XCTAssertTrue(badge.waitForExistence(timeout: 5))
         XCTAssertTrue(toggle.waitForExistence(timeout: 5))
 
-        waitForDisconnected(badge: badge, app: app, timeout: 10)
+        XCTAssertEqual(
+            badge.label,
+            VPhone.HomeScreen.ConnectionState.disconnected.rawValue,
+            "Expected home.badge.state to read `disconnected` on a cold launch"
+        )
 
         XCTAssertTrue(
             toggle.isEnabled,
@@ -151,115 +177,45 @@ final class LocalE2ETests: XCTestCase {
         toggle.tap()
         app.activate() // flush any pending NE consent interruption
 
-        let reachedConnecting = expectation(for: NSPredicate(format: "label == %@",
-                                                             VPhone.HomeScreen.ConnectionState.connecting.rawValue),
-                                            evaluatedWith: badge)
-        wait(for: [reachedConnecting], timeout: 5)
-    }
-
-    /// With the tunnel up, the diagnostics panel should report
-    /// `TUN_EXISTS: PASS` (extension is running) and `MEM_OK: PASS`
-    /// (extension is under the 50MB appex cap). The other three checks
-    /// need a real outbound path and are expected to `FAIL(...)` on a
-    /// local sim — we don't assert on them.
-    ///
-    /// One retry budget: first-ever launch on a fresh sim image may
-    /// stall on the NE consent flow; the interruption monitor + a
-    /// single relaunch gets past it. Beyond that, we surface a real
-    /// failure rather than paper over flakiness.
-    func testPostConnectDiagnosticsReportTunAndMemPass() throws {
-        try runPostConnectDiagnostics(attempt: 1, maxAttempts: 2)
-    }
-
-    private func runPostConnectDiagnostics(attempt: Int, maxAttempts: Int) throws {
-        let app = launchHome()
-
-        let badge = app.descendants(matching: .any)[
-            VPhone.HomeScreen.AccessibilityID.stateBadge
+        let errorLabel = app.descendants(matching: .any)[
+            VPhone.HomeScreen.AccessibilityID.errorMessage
         ]
-        let toggle = app.descendants(matching: .any)[
-            VPhone.HomeScreen.AccessibilityID.vpnToggle
-        ]
-        XCTAssertTrue(badge.waitForExistence(timeout: 5))
-        XCTAssertTrue(toggle.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            errorLabel.waitForExistence(timeout: 5),
+            "home.error did not appear after tapping toggle — VpnManager.lastError not surfaced"
+        )
 
-        waitForDisconnected(badge: badge, app: app, timeout: 10)
+        // Pin #1: badge didn't lie about progress.
+        XCTAssertEqual(
+            badge.label,
+            VPhone.HomeScreen.ConnectionState.disconnected.rawValue,
+            "home.badge.state advanced past `disconnected` despite NE error — " +
+            "UX is reporting progress that isn't happening"
+        )
 
-        guard toggle.isEnabled else {
-            if attempt < maxAttempts {
-                app.terminate()
-                try runPostConnectDiagnostics(attempt: attempt + 1, maxAttempts: maxAttempts)
-                return
-            }
-            XCTFail("home.toggle.vpn stayed disabled across \(maxAttempts) attempts")
-            return
-        }
-
-        toggle.tap()
-        app.activate() // flush consent interruption, if any
-
-        // Wait for the tunnel to leave `disconnected`. We accept either
-        // `connecting` or `connected` — the point of this test is that the
-        // extension is up, not that the status machine passed through a
-        // specific state.
-        let leftDisconnected = expectation(for: NSPredicate(format: "label != %@",
-                                                            VPhone.HomeScreen.ConnectionState.disconnected.rawValue),
-                                           evaluatedWith: badge)
-        let leftResult = XCTWaiter().wait(for: [leftDisconnected], timeout: 10)
-        guard leftResult == .completed else {
-            if attempt < maxAttempts {
-                app.terminate()
-                try runPostConnectDiagnostics(attempt: attempt + 1, maxAttempts: maxAttempts)
-                return
-            }
-            XCTFail("tunnel did not leave disconnected after \(maxAttempts) attempts")
-            return
-        }
-
-        let nav = app.descendants(matching: .any)[
-            VPhone.HomeScreen.AccessibilityID.navDiagnostics
-        ]
-        XCTAssertTrue(nav.waitForExistence(timeout: 5))
-        nav.tap()
-
-        let runButton = app.descendants(matching: .any)["diagnostics.button.run"]
-        XCTAssertTrue(runButton.waitForExistence(timeout: 5))
-        XCTAssertTrue(runButton.isHittable)
-        runButton.tap()
-
-        let deadline = Date().addingTimeInterval(20)
-        var lastResults: [DiagnosticsCheck: DiagnosticsResult] = [:]
-        while Date() < deadline {
-            let dump = DiagnosticsCheck.allCases.compactMap { check -> String? in
-                let row = app.descendants(matching: .any)["diagnostics.row.\(check.rawValue)"]
-                return row.exists ? row.label : nil
-            }.joined(separator: "\n")
-
-            if let parsed = try? DiagnosticsLabelParser.parse(dump) {
-                lastResults = parsed
-                if parsed[.tunExists] == .pass && parsed[.memOk] == .pass {
-                    return
-                }
-            }
-            Thread.sleep(forTimeInterval: 0.25)
-        }
-
-        let snapshot = DiagnosticsCheck.allCases.map { check in
-            "\(check.rawValue)=\(lastResults[check].map(String.init(describing:)) ?? "<absent>")"
-        }.joined(separator: ", ")
-        XCTFail("TUN_EXISTS + MEM_OK did not both reach PASS within 20s — last seen: \(snapshot)")
+        // Pin #2: error label is structured — `<Domain>(<Code>): <message>`.
+        let raw = errorLabel.label
+        let match = try XCTUnwrap(
+            Self.errorLabelRegex.firstMatch(in: raw, range: NSRange(raw.startIndex..., in: raw)),
+            "home.error = \"\(raw)\", expected `<Domain>(<Code>): <message>` per VpnManagerError.label"
+        )
+        let domain = (raw as NSString).substring(with: match.range(at: 1))
+        let codeStr = (raw as NSString).substring(with: match.range(at: 2))
+        XCTAssertEqual(
+            domain, "NEVPNErrorDomain",
+            "home.error domain = \"\(domain)\" — expected `NEVPNErrorDomain` (seeing a non-NE error " +
+            "here would mean the failure is upstream of the NE call, which is a real regression)"
+        )
+        XCTAssertNotNil(Int(codeStr), "home.error code = \"\(codeStr)\", expected integer")
     }
 
-    private func waitForDisconnected(badge: XCUIElement, app: XCUIApplication, timeout: TimeInterval) {
-        let isDisconnected = NSPredicate(format: "label == %@",
-                                         VPhone.HomeScreen.ConnectionState.disconnected.rawValue)
-        let e = expectation(for: isDisconnected, evaluatedWith: badge)
-        if XCTWaiter().wait(for: [e], timeout: timeout) == .completed { return }
-        // Give interruption monitor a chance to dismiss NE consent, then
-        // accept the current label — the individual tests will assert their
-        // own preconditions.
-        app.activate()
-    }
+    /// `<Domain>(<Code>): <message>` — matches `VpnManagerError.label`.
+    /// Domain is any non-paren/non-colon run so a rename like
+    /// `NEVPNError` (without `Domain`) still matches structurally; the
+    /// separate equality check on `NEVPNErrorDomain` pins the exact name.
+    private static let errorLabelRegex: NSRegularExpression = {
+        try! NSRegularExpression(pattern: #"^([^(]+)\((-?\d+)\):\s"#)
+    }()
 
     // MARK: - (4) Diagnostics panel contract
 

--- a/MeowUITests/Support/VPhone.swift
+++ b/MeowUITests/Support/VPhone.swift
@@ -104,6 +104,11 @@ struct VPhone {
             static let stateBadge = "home.badge.state"
             static let profileName = "home.profile.name"
             static let navDiagnostics = "home.nav.diagnostics"
+            /// Present only when `VpnManager.lastError != nil`. Label is
+            /// `<domain>(<code>): <message>` — parseable so the local sim
+            /// test can pin on a real `NEVPNError` code instead of
+            /// a loose "any non-empty string".
+            static let errorMessage = "home.error"
             static func group(_ groupName: String) -> String {
                 "home.group.\(groupName.identifierSlug)"
             }

--- a/project.yml
+++ b/project.yml
@@ -36,9 +36,8 @@ targets:
     platform: iOS
     sources:
       - path: App/Sources
-    resources:
       - path: App/Resources
-        optional: true
+        buildPhase: resources
     info:
       path: App/Info.plist
       properties:


### PR DESCRIPTION
## Summary

Upgrades `LocalE2ETests` from the bare contract-smoke bundle to **Option 2 (β)** per team-lead's directive on task #33:

- **`-UITests` seeder** (`UITestsSeeder.swift`) inserts a bundled DIRECT-only fixture profile into SwiftData and selects it on launch, so the VPN toggle is enabled without a live subscription.
- **Structured `VpnManager.lastError`** (`VpnManagerError { domain, code, message }`) renders a machine-parseable `<Domain>(<Code>): <message>` label at a new `home.error` UI anchor.
- **`testTapToggleSurfacesNEError`** pins the seeder path end-to-end: toggle is enabled on cold launch, tapping it surfaces a `NEVPNErrorDomain` + integer-code error, and `home.badge.state` stays `disconnected` (no lying progress).

## Scope + honest limits

**Why β, not α (real connect transition).** iOS 26 simulator has no `nesessionmanager` daemon, so every `NETunnelProviderManager` operation fails with `NEVPNErrorDomain Code=5 "IPC failed"`. That's a fundamental Apple sim gap — not a bug in this code — and it makes any `.disconnected → .connecting` assertion impossible locally no matter how many preferences we pre-install.

**What this bundle pins:**
1. Anchor wiring (every T4.2 `AccessibilityID` is queryable at launch).
2. `home.badge.state` vocabulary parses via `ConnectionState(rawValue:)`.
3. Seeder ran **and** NE error surface is structured (tight domain+code match, not "any error").
4. Diagnostics panel exposes 5 PRD §4.4 rows whose labels parse through `DiagnosticsLabelParser`.

**What this bundle does NOT assert** (intentionally, per team-lead):
- `.connecting` / `.connected` transitions
- `TUN_EXISTS: PASS` / `MEM_OK: PASS`

Those live in the nightly vphone gate (`E2E5CheckGateTests` + `Support/VPhone.swift`, TEST_STRATEGY v1.2 §7) which runs on Tart-provisioned iPhone 17 VMs with real NE IPC available. The nightly gate is separately blocked today (Apple VF disallows macOS-in-macOS nesting), tracked as T-infra — but β ships independently regardless.

## Files

- `App/Resources/UITestsFixtureProfile.yaml` (new) — DIRECT-only Clash config
- `App/Sources/Services/UITestsSeeder.swift` (new, `#if DEBUG`)
- `App/Sources/AppModel.swift` — calls seeder between `AssetSeeder` and `VpnManager.refresh()`
- `App/Sources/Services/VpnManager.swift` — `lastError: VpnManagerError?`
- `App/Sources/Views/HomeView.swift` — `home.error` row
- `MeowUITests/Support/VPhone.swift` — `AccessibilityID.errorMessage`
- `MeowUITests/Flows/LocalE2ETests.swift` — `@MainActor`, new test + updated doc header
- `project.yml` — moved `App/Resources` to `sources:` with `buildPhase: resources` (the `resources:` array with `optional: true` wasn't generating a Copy Bundle Resources phase in xcodegen)

## Test plan

- [x] `xcodebuild build-for-testing` clean on iPhone 17 / iOS 26.2 sim
- [x] `xcodebuild test-without-building -only-testing:MeowUITests/LocalE2ETests` — 5/5 pass locally (~44s)
- [x] `testTapToggleSurfacesNEError` specifically pins all three invariants (toggle enabled, badge frozen, NE domain+code parse)
- [ ] Nightly vphone gate retains responsibility for the real connected-path — unblocked when T-infra lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)