### PR TITLE
docs: CLAUDE.md — run lint + tests locally before push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# meow-ios — Contributor Guide for Claude
+
+## Workflow Rules
+
+### Run lint + tests locally before pushing
+
+To save GitHub Actions minutes and keep the red-main failure mode from coming back, always run lint and the full relevant test suite locally before pushing to the remote.
+
+- Before `git push` on any Swift / Rust / YAML change, run the local equivalents of the CI jobs your diff touches:
+  - **Swift:** `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17'` against the relevant test bundles (`MeowTests`, `MeowUITests`, `MeowIntegrationTests`).
+  - **Rust:** `scripts/build-rust.sh`, plus `cargo test` in `core/rust/mihomo-ios-ffi/` where relevant.
+  - **Lint:** `swiftlint` at the repo root.
+- If a local run fails, fix it before pushing. Do not push "to see what CI says."
+- Docs / infra-only changes (no Swift / Rust / YAML touched) don't need the full suite — skip what isn't relevant.
+- Also check `gh run list --branch main --workflow=ci.yml --limit=1` before opening a PR so you know whether main's baseline is green. "Merging to red main" should be a known condition, not a discovery.


### PR DESCRIPTION
## Summary

Adds a project-level `CLAUDE.md` capturing the team rule established today: always run lint and the relevant test suite locally before pushing to remote. Prevents the "merging to red main" failure mode that let pre-existing CI failures hide for five consecutive runs.

## Context

Recent history: main CI was red 5-for-5 on the most recent runs (unit-test toolchain mismatch, pre-existing SwiftLint violations, security-scan) and nobody noticed until PR #9's build-core wiring surfaced the baseline. The rule is the remediation — pre-push checks turn red-main from a discovery into an enforced precondition.

## Test plan

- [x] Doc-only change, no code affected.
- [x] Markdown renders cleanly in GitHub preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)