### PR TITLE
fix(tests): prevent nested #require macro in SubscriptionDeepLinkTests (#34b)

### DIFF
--- a/MeowIntegrationTests/.swiftformat
+++ b/MeowIntegrationTests/.swiftformat
@@ -1,0 +1,6 @@
+--swiftversion 6.2
+
+# See MeowTests/.swiftformat — same rationale: noForceUnwrapInTests produces
+# nested #require patterns that fail to compile under Swift 6.3+ Testing
+# macro expansion.
+--disable noForceUnwrapInTests

--- a/MeowTests/.swiftformat
+++ b/MeowTests/.swiftformat
@@ -1,0 +1,9 @@
+--swiftversion 6.2
+
+# Swift Testing's #require macro can't be nested inside another #require
+# without tripping the Swift 6.3+ compiler's "recursive expansion of macro"
+# check. swiftformat's noForceUnwrapInTests would rewrite URL(string:)! into
+# #require(URL(string:)), producing that nested pattern here because the
+# result feeds another #require. Keep the explicit force-unwrap on known-good
+# test URLs instead.
+--disable noForceUnwrapInTests

--- a/MeowTests/Services/SubscriptionDeepLinkTests.swift
+++ b/MeowTests/Services/SubscriptionDeepLinkTests.swift
@@ -15,8 +15,8 @@ import Testing
 struct SubscriptionDeepLinkTests {
     @Test
     func `accepts well-formed meow://connect with http(s) url`() throws {
-        let link = try #require(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml")),
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml")!,
         ))
         #expect(link.subscriptionURL == URL(string: "https://example.com/sub.yaml"))
         #expect(link.name == "example.com")
@@ -25,64 +25,64 @@ struct SubscriptionDeepLinkTests {
 
     @Test
     func `http subscription urls are accepted (not every user has TLS)`() throws {
-        let link = try #require(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=http%3A%2F%2F10.0.0.1%2Fsub.yaml")),
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=http%3A%2F%2F10.0.0.1%2Fsub.yaml")!,
         ))
         #expect(link.subscriptionURL.scheme == "http")
     }
 
     @Test
     func `explicit name query parameter overrides host-derived default`() throws {
-        let link = try #require(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml&name=My%20VPN")),
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml&name=My%20VPN")!,
         ))
         #expect(link.name == "My VPN")
     }
 
     @Test
     func `select=1 opts in to auto-select; absent or any other value stays off`() throws {
-        let on = try #require(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs&select=1")),
+        let on = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs&select=1")!,
         ))
         #expect(on.autoSelect)
 
-        let absent = try #require(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs")),
+        let absent = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs")!,
         ))
         #expect(absent.autoSelect == false)
 
-        let wrongValue = try #require(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs&select=yes")),
+        let wrongValue = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs&select=yes")!,
         ))
         #expect(wrongValue.autoSelect == false)
     }
 
     @Test
-    func `rejects wrong host — only meow://connect is this handler's business`() throws {
-        #expect(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://diagnostics?url=https%3A%2F%2Fe.com%2Fs")),
+    func `rejects wrong host — only meow://connect is this handler's business`() {
+        #expect(SubscriptionDeepLink.parse(
+            URL(string: "meow://diagnostics?url=https%3A%2F%2Fe.com%2Fs")!,
         ) == nil)
-        #expect(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://random?url=https%3A%2F%2Fe.com%2Fs")),
-        ) == nil)
-    }
-
-    @Test
-    func `rejects wrong scheme — https://connect is not our URL scheme`() throws {
-        #expect(try SubscriptionDeepLink.parse(
-            #require(URL(string: "https://connect?url=https%3A%2F%2Fe.com%2Fs")),
+        #expect(SubscriptionDeepLink.parse(
+            URL(string: "meow://random?url=https%3A%2F%2Fe.com%2Fs")!,
         ) == nil)
     }
 
     @Test
-    func `rejects missing ?url= entirely`() throws {
-        #expect(try SubscriptionDeepLink.parse(#require(URL(string: "meow://connect"))) == nil)
-        #expect(try SubscriptionDeepLink.parse(#require(URL(string: "meow://connect?name=foo"))) == nil)
+    func `rejects wrong scheme — https://connect is not our URL scheme`() {
+        #expect(SubscriptionDeepLink.parse(
+            URL(string: "https://connect?url=https%3A%2F%2Fe.com%2Fs")!,
+        ) == nil)
     }
 
     @Test
-    func `rejects empty ?url= value`() throws {
-        #expect(try SubscriptionDeepLink.parse(#require(URL(string: "meow://connect?url="))) == nil)
+    func `rejects missing ?url= entirely`() {
+        #expect(SubscriptionDeepLink.parse(URL(string: "meow://connect")!) == nil)
+        #expect(SubscriptionDeepLink.parse(URL(string: "meow://connect?name=foo")!) == nil)
+    }
+
+    @Test
+    func `rejects empty ?url= value`() {
+        #expect(SubscriptionDeepLink.parse(URL(string: "meow://connect?url=")!) == nil)
     }
 
     @Test
@@ -101,21 +101,21 @@ struct SubscriptionDeepLinkTests {
     }
 
     @Test
-    func `rejects http url with empty host`() throws {
-        #expect(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=https%3A%2F%2F%2Fsub.yaml")),
+    func `rejects http url with empty host`() {
+        #expect(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2F%2Fsub.yaml")!,
         ) == nil)
     }
 
     @Test
     func `blank explicit name falls back to host-derived default`() throws {
-        let link = try #require(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fs&name=")),
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fs&name=")!,
         ))
         #expect(link.name == "example.com")
 
-        let whitespace = try #require(try SubscriptionDeepLink.parse(
-            #require(URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fs&name=%20%20%20")),
+        let whitespace = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fs&name=%20%20%20")!,
         ))
         #expect(whitespace.name == "example.com")
     }


### PR DESCRIPTION
## Summary

- Scoped `MeowTests/.swiftformat` + `MeowIntegrationTests/.swiftformat` that `--disable noForceUnwrapInTests`. This rule rewrote `URL(string:)!` → `#require(URL(string:))`, and because those calls were nested inside an outer `try #require(...)` in SubscriptionDeepLinkTests, the Swift 6.3 Testing-macro expansion flagged every site as "recursive expansion of macro 'require'".
- Reverted `SubscriptionDeepLinkTests.swift` call sites to force-unwrap on the hard-coded test URLs (known-valid string literals). Dropped the now-redundant inner `try` and `throws`.

## Why scoped, not global

The rule is intentionally test-only. A scoped `.swiftformat` in each test dir documents the rationale where future readers will hit it, rather than adding a blanket disable at repo root.

## Why not avoid force-unwrap

`URL(string: "https://example.com/...")!` on a literal is the correct primitive — the input is constant and compile-time-known-good. The lint rule's intent (catching runtime-optional force-unwraps in tests) doesn't apply to these literals; it's producing nested `#require` because it can't see the enclosing context.

## CI divergence note

Main CI (Xcode ^26.0 / Swift 6.2) currently accepts the nested-`#require` pattern, which is why `a49368e`'s autofix tree passed CI on 2026-04-17. Xcode 26.4 / Swift 6.3 (current local default for iOS dev on this workstation) rejects it. This PR unblocks local dev and future-proofs the toolchain bump.

## Test plan

- [x] `swiftformat --lint .` — 0 files require formatting
- [x] `swiftlint --strict` — 0 violations in 68 files
- [x] `xcodebuild test -only-testing:MeowTests` on iPhone 17 simulator — 99 tests in 20 suites passed (incl. all 11 SubscriptionDeepLinkTests cases)
- [ ] CI build-core / lint / unit-test / ui-test / archive all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)