### PR TITLE
feat(connections): T4.5 screen contract — accessibility IDs, empty state, error banner

### DIFF
--- a/App/Sources/Views/ConnectionsView.swift
+++ b/App/Sources/Views/ConnectionsView.swift
@@ -1,60 +1,111 @@
+import MeowModels
 import SwiftUI
 
 struct ConnectionsView: View {
     @Environment(MihomoAPI.self) private var api
     @State private var connections: [Connection] = []
     @State private var query: String = ""
+    @State private var errorMessage: String?
 
     var body: some View {
         List {
             ForEach(filtered) { conn in
-                GlassCard {
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            Text("\(conn.metadata.host):\(conn.metadata.destinationPort)")
-                                .font(.headline)
-                                .lineLimit(1)
-                            Spacer()
-                            Text(conn.metadata.network.uppercased())
-                                .font(.caption.monospaced())
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(.secondary.opacity(0.15), in: .capsule)
-                        }
-                        HStack(spacing: 10) {
-                            let up = ByteCountFormatter.string(fromByteCount: conn.upload, countStyle: .binary)
-                            let down = ByteCountFormatter.string(fromByteCount: conn.download, countStyle: .binary)
-                            Label(up, systemImage: "arrow.up")
-                            Label(down, systemImage: "arrow.down")
-                            Spacer()
-                            Text(conn.chains.reversed().joined(separator: " › "))
-                                .font(.caption.monospaced())
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                        }
-                        Text("\(conn.rule) · \(conn.rulePayload)")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-                .swipeActions {
-                    Button(role: .destructive) {
-                        Task { try? await api.closeConnection(id: conn.id) }
-                    } label: { Label("Close", systemImage: "xmark") }
-                }
+                row(for: conn)
             }
         }
         .listStyle(.plain)
+        .overlay {
+            if connections.isEmpty {
+                ContentUnavailableView(
+                    "No connections",
+                    systemImage: "link",
+                    description: Text("Active traffic will appear here."),
+                )
+                .accessibilityIdentifier("connections.emptyState")
+            } else if filtered.isEmpty {
+                ContentUnavailableView.search(text: query)
+                    .accessibilityIdentifier("connections.emptySearch")
+            }
+        }
+        .safeAreaInset(edge: .top) {
+            if let errorMessage {
+                errorBanner(errorMessage)
+            }
+        }
         .searchable(text: $query)
         .navigationTitle("Connections (\(connections.count))")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button("Close All") { Task { try? await api.closeAllConnections() } }
+                Button("Close All") {
+                    Task { try? await api.closeAllConnections() }
+                }
+                .accessibilityIdentifier("connections.toolbar.closeAll")
             }
         }
         .task { await poll() }
+    }
+
+    private func row(for conn: Connection) -> some View {
+        let slug = conn.id.identifierSlug
+        return GlassCard {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("\(conn.metadata.host):\(conn.metadata.destinationPort)")
+                        .font(.headline)
+                        .lineLimit(1)
+                        .accessibilityIdentifier("connections.row.\(slug).host")
+                    Spacer()
+                    Text(conn.metadata.network.uppercased())
+                        .font(.caption.monospaced())
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.secondary.opacity(0.15), in: .capsule)
+                }
+                HStack(spacing: 10) {
+                    let up = ByteCountFormatter.string(fromByteCount: conn.upload, countStyle: .binary)
+                    let down = ByteCountFormatter.string(fromByteCount: conn.download, countStyle: .binary)
+                    Label(up, systemImage: "arrow.up")
+                    Label(down, systemImage: "arrow.down")
+                    Spacer()
+                    Text(conn.chains.reversed().joined(separator: " › "))
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .accessibilityIdentifier("connections.row.\(slug).chain")
+                }
+                Text("\(conn.rule) · \(conn.rulePayload)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("connections.row.\(slug).rule")
+            }
+        }
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .accessibilityIdentifier("connections.row.\(slug)")
+        .swipeActions {
+            Button(role: .destructive) {
+                Task { try? await api.closeConnection(id: conn.id) }
+            } label: {
+                Label("Close", systemImage: "xmark")
+            }
+            .accessibilityIdentifier("connections.row.\(slug).close")
+        }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
+        .padding(.horizontal)
+        .accessibilityIdentifier("connections.errorBanner")
     }
 
     private var filtered: [Connection] {
@@ -64,8 +115,12 @@ struct ConnectionsView: View {
 
     private func poll() async {
         while !Task.isCancelled {
-            if let resp = try? await api.getConnections() {
+            do {
+                let resp = try await api.getConnections()
                 connections = resp.connections ?? []
+                errorMessage = nil
+            } catch {
+                errorMessage = error.localizedDescription
             }
             try? await Task.sleep(for: .seconds(1))
         }


### PR DESCRIPTION
## Summary

T3.x / T4.5 Connections screen fill-in. Scaffolding was already ~85% complete (GlassCard rows, polling loop, filtering, swipe-close, Close-All). This PR adds the three bits the `.disabled()` test skeletons explicitly call out as T4.5's responsibility:

- **Accessibility identifiers** on row (`connections.row.<slug>`), host label, chain, rule label, swipe-close button, and the Close-All toolbar button. Connection id is passed through `MeowModels.String.identifierSlug` so selectors are stable across whatever characters mihomo emits. Test contract: `MeowIntegrationTests/Screens/ConnectionsScreenTests.swift` lines 18–19.
- **Empty states.** `ContentUnavailableView` when there are no connections; `ContentUnavailableView.search(text:)` when a search query returns no matches. Test contract: `empty ConnectionsResponse renders zero rows without error overlay` (line 86).
- **Error banner** in `.safeAreaInset(edge: .top)` that surfaces poll failures and auto-clears on the next successful poll. Replaces the previous silent `try?` drop. Test contract: `MeowTests/API/ConnectionsTests.swift` line 100.

The `.disabled("blocked on T4.5")` test skeletons stay as-is — their enablement needs the hosted-view harness + URLProtocolStub wiring that is a separate T4.x task, not T3.x screen-polish.

## Test plan
- [x] `swiftlint` — 0 violations, 0 serious in 68 files
- [x] `xcodebuild build -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug` — **BUILD SUCCEEDED**
- [x] `xcodebuild test … -only-testing:MeowTests -only-testing:MeowIntegrationTests` — **TEST SUCCEEDED** (26 tests, 4 suites, Connections skeletons remain skipped per `.disabled("blocked on T4.5")`)
- [ ] Manual-on-device smoke (per user directive 2026-04-18): reviewer or user to verify the three new affordances render in the Liquid Glass style consistent with HomeView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)