### PR TITLE
docs: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Max Lv
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ that both the app and extension link against:
 ```
 
 See [`docs/BUILD.md`](docs/BUILD.md) for toolchain requirements.
+
+## License
+
+[MIT](LICENSE) © 2026 Max Lv


### PR DESCRIPTION
## Summary
- Adds standard MIT `LICENSE` at repo root (year 2026, copyright holder Max Lv) per user directive 2026-04-18, ahead of public repo release.
- Adds one-line `## License` section to `README.md` linking to the file.

## Non-code bypass
Docs-only (`LICENSE`, `README.md`). Per `CLAUDE.md` non-code-PR rules, eligible for `gh pr merge --rebase --admin --delete-branch`.

## Test plan
- [x] Verified no existing `LICENSE` / `LICENSE.md` / `COPYING` in git tree
- [x] Verified `README.md` had no prior license mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)