### PR TITLE
feat(rules): T4.6 screen contract — accessibility IDs, empty state, error banner

### DIFF
--- a/App/Sources/Views/RulesView.swift
+++ b/App/Sources/Views/RulesView.swift
@@ -1,39 +1,84 @@
+import MeowModels
 import SwiftUI
 
 struct RulesView: View {
     @Environment(MihomoAPI.self) private var api
     @State private var rules: [Rule] = []
-    @State private var error: String?
+    @State private var errorMessage: String?
 
     var body: some View {
-        List(rules) { rule in
-            VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text(rule.type)
-                        .font(.caption.monospaced())
-                        .padding(.horizontal, 6).padding(.vertical, 2)
-                        .background(.secondary.opacity(0.15), in: .capsule)
-                    Text(rule.payload).lineLimit(1)
-                    Spacer()
-                    Text(rule.proxy).foregroundStyle(.secondary)
-                }
+        List {
+            ForEach(Array(rules.enumerated()), id: \.element.id) { index, rule in
+                row(for: rule, index: index)
             }
         }
         .listStyle(.plain)
-        .navigationTitle("Rules")
+        .overlay {
+            if rules.isEmpty {
+                ContentUnavailableView(
+                    "No rules",
+                    systemImage: "arrow.triangle.branch",
+                    description: Text("Rules appear when a profile is loaded."),
+                )
+                .accessibilityIdentifier("rules.emptyState")
+            }
+        }
+        .safeAreaInset(edge: .top) {
+            if let errorMessage {
+                errorBanner(errorMessage)
+            }
+        }
+        .navigationTitle("Rules (\(rules.count))")
         .refreshable { await load() }
         .task { await load() }
-        .overlay(alignment: .center) {
-            if let error { Text(error).foregroundStyle(.secondary) }
+    }
+
+    private func row(for rule: Rule, index: Int) -> some View {
+        GlassCard {
+            HStack(spacing: 8) {
+                Text(rule.type)
+                    .font(.caption.monospaced())
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.secondary.opacity(0.15), in: .capsule)
+                    .accessibilityIdentifier("rules.row.\(index).type")
+                Text(rule.payload)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("rules.row.\(index).payload")
+                Spacer()
+                Text(rule.proxy)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("rules.row.\(index).proxy")
+            }
         }
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .accessibilityIdentifier("rules.row.\(index)")
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
+        .padding(.horizontal)
+        .accessibilityIdentifier("rules.errorBanner")
     }
 
     private func load() async {
         do {
             rules = try await api.getRules().rules
-            error = nil
+            errorMessage = nil
         } catch {
-            self.error = error.localizedDescription
+            errorMessage = error.localizedDescription
         }
     }
 }


### PR DESCRIPTION
## Summary
- Polishes `RulesView` to match the T4.5 Connections precedent (PR #19): accessibility identifiers on each row element, empty state via `ContentUnavailableView`, error banner in `.safeAreaInset(edge: .top)`, GlassCard rows, and nav-title count suffix.
- Error banner replaces the previous `.overlay` that silently showed error text centered over the (empty) list. It clears on the next successful `getRules()` poll.
- Skeleton tests in `MeowTests/API/RulesTests.swift` remain `.disabled("blocked on T4.6")` — matches PR #19 shape (harness unblock is a separate T4.x task).

## Accessibility ID namespace
- `rules.row.<index>` — per-row anchor
- `rules.row.<index>.type|payload|proxy` — per-element anchors
- `rules.emptyState`, `rules.errorBanner` — overlay/banner anchors
- Inline string literals (matches Connections precedent). Index-keyed rather than id-keyed because `Rule.id` is the concatenated `type+payload+proxy` triple — opaque for selector ergonomics, and payload can contain characters that make a11y selection fragile.

## Test plan
- [x] `swiftlint` at repo root — 0 violations across 68 files
- [x] `xcodebuild test -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` — TEST SUCCEEDED
- [ ] CI green on this PR (build-core + unit-test + ui-test + archive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)