### PR TITLE
feat(logs): T4.7 screen contract — accessibility IDs, empty state, error banner

### DIFF
--- a/App/Sources/Views/LogsView.swift
+++ b/App/Sources/Views/LogsView.swift
@@ -5,6 +5,7 @@ struct LogsView: View {
     @State private var entries: [LogEntry] = []
     @State private var level = "info"
     @State private var autoScroll = true
+    @State private var errorMessage: String?
     @State private var streamTask: Task<Void, Never>?
 
     var body: some View {
@@ -17,26 +18,30 @@ struct LogsView: View {
                     Text("error").tag("error")
                 }
                 .pickerStyle(.segmented)
+                .accessibilityIdentifier("logs.levelPicker")
                 Toggle("Auto-scroll", isOn: $autoScroll)
                     .labelsHidden()
                     .toggleStyle(.button)
+                    .accessibilityIdentifier("logs.autoScrollToggle")
             }
             .padding(.horizontal)
 
             ScrollViewReader { proxy in
                 List(Array(entries.enumerated()), id: \.offset) { index, entry in
-                    HStack(alignment: .top, spacing: 8) {
-                        Text(entry.type.uppercased())
-                            .font(.caption2.monospaced())
-                            .foregroundStyle(color(for: entry.type))
-                            .frame(width: 52, alignment: .leading)
-                        Text(entry.payload)
-                            .font(.caption.monospaced())
-                            .textSelection(.enabled)
-                    }
-                    .id(index)
+                    row(for: entry, index: index)
+                        .id(index)
                 }
                 .listStyle(.plain)
+                .overlay {
+                    if entries.isEmpty {
+                        ContentUnavailableView(
+                            "No logs",
+                            systemImage: "text.alignleft",
+                            description: Text("Logs appear when the tunnel is active."),
+                        )
+                        .accessibilityIdentifier("logs.emptyState")
+                    }
+                }
                 .onChange(of: entries.count) { _, count in
                     guard autoScroll, count > 0 else { return }
                     withAnimation(.linear(duration: 0.1)) {
@@ -45,8 +50,44 @@ struct LogsView: View {
                 }
             }
         }
-        .navigationTitle("Logs")
+        .safeAreaInset(edge: .top) {
+            if let errorMessage {
+                errorBanner(errorMessage)
+            }
+        }
+        .navigationTitle("Logs (\(entries.count))")
         .task(id: level) { await subscribe() }
+    }
+
+    private func row(for entry: LogEntry, index: Int) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(entry.type.uppercased())
+                .font(.caption2.monospaced())
+                .foregroundStyle(color(for: entry.type))
+                .frame(width: 52, alignment: .leading)
+                .accessibilityIdentifier("logs.row.\(index).level")
+            Text(entry.payload)
+                .font(.caption.monospaced())
+                .textSelection(.enabled)
+                .accessibilityIdentifier("logs.row.\(index).message")
+        }
+        .accessibilityIdentifier("logs.row.\(index)")
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
+        .padding(.horizontal)
+        .accessibilityIdentifier("logs.errorBanner")
     }
 
     private func subscribe() async {
@@ -55,11 +96,12 @@ struct LogsView: View {
         let stream = api.streamLogs(level: level)
         do {
             for try await entry in stream {
+                errorMessage = nil
                 entries.append(entry)
                 if entries.count > 2000 { entries.removeFirst(entries.count - 2000) }
             }
         } catch {
-            // Stream ended / failed; silently recover on next appear.
+            errorMessage = error.localizedDescription
         }
     }
 


### PR DESCRIPTION
## Summary
- Polishes `LogsView` to match the T4.5 Connections + T4.6 Rules precedent (PR #19, PR #25): a11y IDs on each row element, empty state via `ContentUnavailableView`, error banner in `.safeAreaInset(edge: .top)`, count suffix in the nav title.
- Error banner clears **inside** the `for try await` loop body — so a transient WebSocket hiccup that later reconnects drops the banner the moment new logs arrive, not on a timer.
- Replaces the previous silent error swallow at `subscribe()`.

## Accessibility ID namespace
- `logs.row.<index>` + `.level` + `.message` — per-row + per-field anchors
- `logs.levelPicker`, `logs.autoScrollToggle` — header controls
- `logs.emptyState`, `logs.errorBanner` — overlay / banner anchors
- Inline string literals, index-keyed (matches Rules precedent; `LogEntry` has no stable unique ID).

## Out of scope (deliberately)
- Reverse-chronological ordering — nice-to-have in the brief, but flipping display order conflicts with the existing `auto-scroll to bottom` toggle and shifts index-keyed selector ergonomics. Left as future work.
- Auto-scroll pause/resume, level filter, timestamp surfacing — all engine/harness territory for T5.x.
- No new test files. `MeowTests/API/LogsTests.swift` skeletons stay `.disabled("blocked on T4.7")`.

## Test plan
- [x] `swiftlint --strict` — 0 violations across 68 files
- [x] `xcodebuild test … -only-testing:MeowTests -only-testing:MeowIntegrationTests` on iPhone 17 sim — TEST SUCCEEDED
- [ ] CI green on this PR (build-core + unit-test + ui-test + archive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)