### PR TITLE
docs: T4.8 Settings screen brief (PM → Dev handoff)

### DIFF
--- a/docs/T4.8-SETTINGS-BRIEF.md
+++ b/docs/T4.8-SETTINGS-BRIEF.md
@@ -1,0 +1,98 @@
+# T4.8 — Settings screen brief
+
+Implementation brief for the Settings screen, handed from PM → Dev. Lives in `docs/` so it survives the M2→M3 milestone team respawn.
+
+## Context
+
+Spec in `docs/PROJECT_PLAN.md` §T4.8:
+
+- Toggle: Allow LAN, IPv6
+- Picker: Log Level
+- Text field: DoH Server URL
+- Navigation: User-Facing Diagnostics (lands in T4.10)
+- Version display, memory usage (polled)
+- Triple-tap version label → Debug Diagnostics Panel (T2.6), debug builds only
+- Depends on T3.4, T4.1
+
+Existing scaffold: `App/Sources/Views/SettingsView.swift` (77 LoC). Most surface is already wired — toggles, log-level picker, DoH field, version label, one-shot memory readout, DEBUG-only tunnel section. The contract gap is a11y identifiers, polled memory, triple-tap gate, and the T4.10 nav stub.
+
+## Scope
+
+Closes out T4.8. Follows the Connections / Rules / Logs precedent merged in PRs #19 / #25 / #26.
+
+### A11y identifiers — inline string literals at callsite (house style; matches `connections.*` / `rules.*` / `logs.*` in existing views)
+
+| Identifier                        | Element                                   |
+| --------------------------------- | ----------------------------------------- |
+| `settings.toggle.allowLan`        | Allow LAN toggle                          |
+| `settings.toggle.ipv6`            | IPv6 toggle                               |
+| `settings.picker.logLevel`        | Log Level picker                          |
+| `settings.field.dohServer`        | DoH Server URL TextField                  |
+| `settings.about.version`          | Version LabeledContent                    |
+| `settings.about.memory`           | Memory LabeledContent                     |
+| `settings.nav.diagnostics`        | NavigationLink → User-Facing Diagnostics  |
+| `settings.debug.diagnosticsPanel` | Triple-tap target / hidden debug nav dest |
+
+### Memory polling
+
+Current `.task { refreshMemory() }` is one-shot. Convert to a periodic refresh. Cadence: **5 s**. Cancel on disappear.
+
+Simplest: a `Timer.publish(every: 5, on: .main, in: .common).autoconnect()` with `.onReceive { Task { await refreshMemory() } }`, or a nested `Task` loop with `try? await Task.sleep(for: .seconds(5))`. Pick whichever feels more natural against the rest of the codebase — no strong preference.
+
+Format: `"<n> MB"` on success, `"—"` while loading / on error (keeps the existing format).
+
+### Triple-tap on version → Debug Diagnostics Panel
+
+Behavior: three successive taps on the version LabeledContent value pushes `DiagnosticsPanelView()` (the T2.6 UIKit-backed diagnostics surface, already referenced by the existing DEBUG section).
+
+- `#if DEBUG` gated. Release builds: no gesture, no nav path.
+- Use a `NavigationLink(isActive: $showDebugPanel)` or equivalent activated by a `TapGesture(count: 3)` setting state.
+- Accept the `MEOW_DEBUG=1` launch-argument path too if trivial; if it requires broader plumbing, defer and note it in the PR description.
+
+### User-Facing Diagnostics navigation stub
+
+Spec says Settings pushes the User-Facing Diagnostics screen (T4.10 territory, depends on T4.8). T4.10 is not yet in flight — ship a stub so the nav entry is present and a11y-queryable.
+
+- `NavigationLink { DiagnosticsStubView() } label: { Label("Diagnostics", systemImage: "stethoscope") }`
+- Destination: `ContentUnavailableView("Diagnostics", systemImage: "stethoscope", description: Text("Coming in T4.10."))` — inline helper or a tiny file, whichever keeps the diff clean.
+- Identifier on the NavigationLink: `settings.nav.diagnostics`.
+- Always-visible (not debug-gated) — spec says T4.10 is "always available."
+
+### DEBUG tunnel section — leave as-is
+
+The `#if DEBUG Section("Debug Tunnel")` block (stage, ingress/egress pkts, connect/disconnect buttons, Open Diagnostics link) is useful dev plumbing. Do not remove. Optional polish: add `settings.debug.stage` / `settings.debug.ingress` / `settings.debug.egress` / `settings.debug.btn.connect` / `settings.debug.btn.disconnect` identifiers only if you want them for future tests. Not required for this PR.
+
+## Out of scope
+
+- DoH URL validation (spec'd in `SettingsScreenTests.testDoHUrlValidation` — still `XCTSkip blocked on T5.8`). Do not add validation in this PR.
+- T4.10 User-Facing Diagnostics content (separate task).
+- iCloud sync, export/import of preferences, profile mgmt (later milestones).
+- Reordering or restyling the Form sections — keep current structure.
+
+## Tests
+
+`MeowUITests/Screens/SettingsScreenTests.swift` is fully `XCTSkip`'d on `T5.8` today. Leave skips in place — T5.8 is the unblocker. No new tests required for this PR; the a11y identifiers are the contract, and T5.8 will drive them.
+
+If the memory-format or version-string tests feel trivially unskippable against the app host, that's a bonus — but do not let it balloon the PR.
+
+## Local gate
+
+Same as T4.5–T4.7 (matches CLAUDE.md "Run lint + tests locally before pushing"):
+
+- `swiftlint --strict` — zero violations
+- `xcodebuild test ... -destination 'platform=iOS Simulator,name=iPhone 17'` against `MeowTests` + `MeowIntegrationTests` — green
+- Manual: verify toggle/picker/field/memory/triple-tap in the running sim before opening the PR
+
+## Merge
+
+- Branch: `feature/t4-8-settings` off latest main (`a75b951` at time of writing).
+- PR title: `feat(settings): T4.8 screen contract + a11y namespace + polled memory`
+- Standard `gh pr merge --rebase --delete-branch` on green (no `--admin` — code PR, full CI).
+
+## Target size
+
+~40–70 LoC delta on `SettingsView.swift` (existing 77 LoC → ~120–150 LoC), plus any tiny stub file. If it's drifting above ~100 LoC delta, push back — scope has crept.
+
+## Out-of-flow questions welcome
+
+If anything above contradicts an in-flight convention that landed after this brief, ping PM before coding around it. The Connections/Rules/Logs shape is the authority — deviate only with reason.


### PR DESCRIPTION
## Summary

Adds `docs/T4.8-SETTINGS-BRIEF.md` — the PM→Dev implementation brief for T4.8 Settings, last of the T4.x UI-screen tasks.

Lives in-repo (not in agent conversation) so it survives the M2→M3 milestone team respawn. Captures a11y namespace, polled-memory semantics, triple-tap debug gate, and a T4.10 navigation stub — matching the Connections/Rules/Logs shape shipped in PRs #19/#25/#26.

## Non-code

Docs-only. Eligible for CLAUDE.md non-code bypass (`--rebase --admin --delete-branch`) — no paths under `App/`, `MeowCore/`, `MeowShared/`, `Meow*Tests/`, `core/`, `scripts/`, `.github/workflows/`, or project manifests touched.

## Test plan

- [x] File is docs-only, bypasses CI per CLAUDE.md