### PR TITLE
fix(settings): swiftformat indent autofix on SettingsView

### DIFF
--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -79,11 +79,11 @@ struct SettingsView: View {
                     .accessibilityIdentifier("settings.debug.diagnosticsPanel")
             }
         #endif
-        .onChange(of: preferences.allowLan) { _, _ in persist() }
-        .onChange(of: preferences.ipv6) { _, _ in persist() }
-        .onChange(of: preferences.logLevel) { _, _ in persist() }
-        .onChange(of: preferences.dohServer) { _, _ in persist() }
-        .task { await pollMemory() }
+            .onChange(of: preferences.allowLan) { _, _ in persist() }
+            .onChange(of: preferences.ipv6) { _, _ in persist() }
+            .onChange(of: preferences.logLevel) { _, _ in persist() }
+            .onChange(of: preferences.dohServer) { _, _ in persist() }
+            .task { await pollMemory() }
     }
 
     private func binding<Value>(_ keyPath: WritableKeyPath<Preferences, Value>) -> Binding<Value> {


### PR DESCRIPTION
## Summary
- Post-merge lint failure on `1c384cf` (CI run 24596288808) — SwiftFormat indent error on `App/Sources/Views/SettingsView.swift:82-86`.
- Root cause: T4.8 Settings code (`f928dfe`) landed via admin-bypass on PR #28 without pre-merge CI (a docs-only PR inadvertently included Dev's in-flight branch via shared-CWD HEAD collision).
- Fix: SwiftFormat autofix on the single file. No behavior change.

## Test plan
- [x] `swiftformat --lint .` → 0/80 files require formatting
- [ ] CI green on this PR