### PR TITLE
docs(plan): fix T4.10 FFI symbol names to match header

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -292,7 +292,7 @@ This plan translates the PRD milestones into a concrete, dependency-ordered task
 - Pushed from Settings
 - Three test cards: Direct TCP, Proxy HTTP, DNS Resolver (user-supplied inputs)
 - Each with host/URL input field and "Test" button; results show latency or error
-- Calls `meow_test_direct_tcp()`, `meow_test_proxy_http()`, `meow_test_dns_resolver()` C FFI (backed by `src/diagnostics.rs` in Rust)
+- Calls `meow_engine_test_direct_tcp()`, `meow_engine_test_proxy_http()`, `meow_engine_test_dns()` C FFI (backed by `src/diagnostics.rs` in Rust)
 - Distinct from T2.6 (debug-build diagnostics for manual smoke): T4.10 is the shipping user-facing diagnostics view, always available
 - **Depends on:** T1.4, T4.8
 


### PR DESCRIPTION
## Summary
- PROJECT_PLAN §T4.10 referenced `meow_test_direct_tcp()` / `meow_test_proxy_http()` / `meow_test_dns_resolver()`.
- Actual C ABI in `core/rust/mihomo-ios-ffi/include/mihomo_core.h` is `meow_engine_test_direct_tcp()` / `meow_engine_test_proxy_http()` / `meow_engine_test_dns()` (note third is `_dns`, not `_dns_resolver`).
- Header is authority (per `feedback_header_symbol_authority`); plan drifted.

## Scope
- Single-line edit in `docs/PROJECT_PLAN.md`. Docs-only PR — no code/CI-surface changes. Eligible for `--admin --rebase` bypass per CLAUDE.md.

## Test plan
- [x] `git diff origin/main...HEAD` shows only `docs/PROJECT_PLAN.md`
- [x] Symbol names verified against header at lines 99 / 107 / 117

🤖 Generated with [Claude Code](https://claude.com/claude-code)