### PR TITLE
feat(providers): T4.11 screen contract — accessibility IDs, empty state, error banner

### DIFF
--- a/App/Sources/Services/MihomoAPI.swift
+++ b/App/Sources/Services/MihomoAPI.swift
@@ -62,6 +62,15 @@ final class MihomoAPI: @unchecked Sendable {
         try await get("/providers/proxies")
     }
 
+    /// Triggers mihomo's bulk health-check for every proxy in a provider
+    /// (`GET /providers/proxies/{name}/healthcheck`). The endpoint returns
+    /// 204 on success; fresh delays are surfaced on the next `getProviders()`.
+    func healthCheckProvider(name: String) async throws {
+        let url = baseURL.appending(path: "/providers/proxies/\(name.urlEscaped)/healthcheck")
+        let (_, resp) = try await session.data(for: request(for: url))
+        try throwIfHTTPError(resp)
+    }
+
     func getMemory() async throws -> MemoryResponse {
         try await get("/memory")
     }

--- a/App/Sources/Views/ProvidersView.swift
+++ b/App/Sources/Views/ProvidersView.swift
@@ -1,46 +1,130 @@
+import MeowModels
 import SwiftUI
 
 struct ProvidersView: View {
     @Environment(MihomoAPI.self) private var api
     @State private var providers: [Provider] = []
+    @State private var errorMessage: String?
 
     var body: some View {
         List {
             ForEach(providers, id: \.name) { provider in
-                Section(provider.name) {
+                Section {
                     ForEach(provider.proxies ?? []) { proxy in
-                        HStack {
-                            Text(proxy.name)
-                            Spacer()
-                            if let delay = proxy.history?.last?.delay {
-                                Text("\(delay) ms")
-                                    .font(.caption.monospaced())
-                                    .foregroundStyle(delay > 500 ? .red : .green)
-                            }
-                            Button {
-                                Task {
-                                    _ = try? await api.testDelay(
-                                        proxy: proxy.name,
-                                        url: "http://www.gstatic.com/generate_204",
-                                    )
-                                    await load()
-                                }
-                            } label: {
-                                Image(systemName: "bolt")
-                            }
-                        }
+                        row(for: proxy, providerSlug: provider.name.identifierSlug)
                     }
+                } header: {
+                    sectionHeader(for: provider)
                 }
             }
         }
-        .navigationTitle("Providers")
+        .listStyle(.plain)
+        .overlay {
+            if providers.isEmpty {
+                ContentUnavailableView(
+                    "No providers",
+                    systemImage: "tray",
+                    description: Text("Providers appear when a profile is loaded."),
+                )
+                .accessibilityIdentifier("providers.emptyState")
+            }
+        }
+        .safeAreaInset(edge: .top) {
+            if let errorMessage {
+                errorBanner(errorMessage)
+            }
+        }
+        .navigationTitle("Providers (\(providers.count))")
         .task { await load() }
         .refreshable { await load() }
     }
 
+    private func sectionHeader(for provider: Provider) -> some View {
+        let slug = provider.name.identifierSlug
+        return HStack {
+            Text(provider.name)
+                .accessibilityIdentifier("providers.section.\(slug).header")
+            Spacer()
+            Button {
+                Task {
+                    do {
+                        try await api.healthCheckProvider(name: provider.name)
+                        await load()
+                    } catch {
+                        errorMessage = error.localizedDescription
+                    }
+                }
+            } label: {
+                Image(systemName: "bolt.fill")
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel("Health check \(provider.name)")
+            .accessibilityIdentifier("providers.section.\(slug).healthCheck")
+        }
+    }
+
+    private func row(for proxy: Proxy, providerSlug: String) -> some View {
+        let proxySlug = proxy.name.identifierSlug
+        return GlassCard {
+            HStack {
+                Text(proxy.name)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("providers.row.\(providerSlug).\(proxySlug).name")
+                Spacer()
+                if let delay = proxy.history?.last?.delay {
+                    Text("\(delay) ms")
+                        .font(.caption.monospaced())
+                        .foregroundStyle(delay > 500 ? .red : .green)
+                        .accessibilityIdentifier("providers.row.\(providerSlug).\(proxySlug).delay")
+                }
+                Button {
+                    Task {
+                        do {
+                            _ = try await api.testDelay(
+                                proxy: proxy.name,
+                                url: "http://www.gstatic.com/generate_204",
+                            )
+                            await load()
+                        } catch {
+                            errorMessage = error.localizedDescription
+                        }
+                    }
+                } label: {
+                    Image(systemName: "bolt")
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("Test \(proxy.name)")
+                .accessibilityIdentifier("providers.row.\(providerSlug).\(proxySlug).testButton")
+            }
+        }
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .accessibilityIdentifier("providers.row.\(providerSlug).\(proxySlug)")
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
+        .padding(.horizontal)
+        .accessibilityIdentifier("providers.errorBanner")
+    }
+
     private func load() async {
-        if let resp = try? await api.getProviders() {
+        do {
+            let resp = try await api.getProviders()
             providers = Array(resp.providers.values).sorted { $0.name < $1.name }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 }


### PR DESCRIPTION
## Summary

Fills the T4.11 Providers screen contract following the T4.5 Connections / T4.6 Rules / T4.7 Logs / T4.8 Settings precedent (PRs #19 / #25 / #26 / #27).

- **Accessibility IDs** namespaced under `providers.*`:
  - `providers.section.<slug>.header` (provider name text)
  - `providers.section.<slug>.healthCheck` (per-provider bolt button)
  - `providers.row.<providerSlug>.<proxySlug>` row anchor + `.name`, `.delay`, `.testButton`
  - `providers.emptyState`, `providers.errorBanner`
  - Slugs go through `String.identifierSlug` (MeowModels) — stable for names containing spaces / punctuation.
- **Empty state** via `ContentUnavailableView` when the providers dict is empty. Replaces the previous bare empty List.
- **Error banner** in `.safeAreaInset(edge: .top)` surfaces `getProviders()` + `healthCheckProvider()` failures; clears on next successful load. Replaces the previous silent `try?` drop.
- **Navigation title** carries count suffix ("Providers (N)"), matching Connections / Rules / Logs.
- **Per-provider health-check** button in the section header (`bolt.fill`) alongside the existing per-proxy delay test (`bolt`). Backed by a new `MihomoAPI.healthCheckProvider(name:)` that calls `GET /providers/proxies/{name}/healthcheck` — fresh delays surface on the next `getProviders()` load.
- **Visual shape** matches Rules: `.listStyle(.plain)` + `GlassCard` rows with clear list-row background and hidden separators.

## Preserved from existing UX

Default-sorted-by-name provider ordering, per-proxy bolt test with the `gstatic.com/generate_204` URL, red/green delay styling at the >500 ms threshold.

## Local gate (iPhone 17 sim / iOS 26)

- `swiftformat --lint` — 0/2 files require formatting
- `swiftlint --strict` — 0 violations in 68 files
- `xcodebuild test` MeowTests + MeowIntegrationTests — **TEST SUCCEEDED**
- No Rust touched; skipped `scripts/build-rust.sh` and cargo gates.

## Test plan

- [ ] CI green on this PR (swift build + lint + MeowTests + MeowIntegrationTests).
- [ ] Manual smoke on device: navigate Home → Providers; verify section headers render with health-check bolt, per-proxy delays + bolt button behave as before, empty state / error banner surface correctly.
- [ ] QA: wire up XCUITest selectors under `providers.*` when the T4.x hosted-view harness unblocks (skeleton tests — if any are added later — should stay `.disabled("blocked on T4.11")` matching the T4.5/T4.6 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)