### PR TITLE
docs: fix FFI symbol drift — set_home_dir + traffic

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -120,11 +120,11 @@ Remote proxy server
 **Complete C API surface:**
 ```c
 // Engine lifecycle
-void  meow_engine_set_home_dir(const char *dir);
+void  meow_core_set_home_dir(const char *dir);
 int   meow_engine_start(const char *config_path, const char *api_addr, const char *secret);
 void  meow_engine_stop(void);
 int   meow_engine_is_running(void);
-void  meow_engine_get_traffic(long long *upload, long long *download);
+void  meow_engine_traffic(long long *upload, long long *download);
 int   meow_engine_validate_config(const char *yaml, int len);
 int   meow_engine_convert_subscription(const char *raw, int len, char *dst, int cap);
 int   meow_engine_last_error(char *dst, int cap);

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -61,7 +61,7 @@ This plan translates the PRD milestones into a concrete, dependency-ordered task
 - Remove `jni` crate and all `Java_*` JNI function signatures
 - Add mihomo-rust workspace crates as Cargo dependencies: `mihomo-common`, `mihomo-proxy`, `mihomo-rules`, `mihomo-dns`, `mihomo-tunnel`, `mihomo-config`, `mihomo-api`
 - Note: `mihomo-listener` is **not** included — no loopback listener needed in the in-process path
-- Implement `engine.rs` wrapping mihomo-rust startup: `meow_engine_set_home_dir()`, `meow_engine_start()`, `meow_engine_stop()`, `meow_engine_is_running()`, `meow_engine_get_traffic()`
+- Implement `engine.rs` wrapping mihomo-rust startup: `meow_core_set_home_dir()`, `meow_engine_start()`, `meow_engine_stop()`, `meow_engine_is_running()`, `meow_engine_traffic()`
 - Implement `src/subscription.rs`: node list → Clash YAML conversion using `mihomo-config` crate (replaces Go `convert.go`)
 - Implement `src/diagnostics.rs`: direct TCP test, proxy HTTP test, DNS resolver test (replaces Go `diagnostics.go`)
 - Export full C ABI (see PRD §2.4); run `cbindgen` to generate `mihomo_core.h`
@@ -106,7 +106,7 @@ This plan translates the PRD milestones into a concrete, dependency-ordered task
 - **Depends on:** T2.1
 
 #### T2.3 — Rust Engine Lifecycle
-- On start: call `meow_engine_set_home_dir()`, `meow_engine_start(config_path, api_addr, secret)`
+- On start: call `meow_core_set_home_dir()`, `meow_engine_start(config_path, api_addr, secret)`
 - Verify engine running: `meow_engine_is_running()`
 - On stop: call `meow_engine_stop()`
 - Error propagation: `meow_engine_last_error()` → `completionHandler(error)`
@@ -149,7 +149,7 @@ This plan translates the PRD milestones into a concrete, dependency-ordered task
 - Register CFNotificationCenter observers: `com.meow.vpn.command`
 - On command notification: read intent from shared UserDefaults, dispatch to engine
 - On state change: write state to shared container, post `com.meow.vpn.state`
-- Traffic update timer: every 500ms, call `meow_engine_get_traffic(&upload, &download)`, write to shared container, post `com.meow.vpn.traffic`
+- Traffic update timer: every 500ms, call `meow_engine_traffic(&upload, &download)`, write to shared container, post `com.meow.vpn.traffic`
 - **Depends on:** T0.3, T2.3
 
 #### T2.8 — Manual Device Smoke (user-owned)

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -68,11 +68,11 @@ Full exported surface per PRD §2.4. All exports return `int` status codes and w
 
 | Subject | What to assert | Notes |
 |---------|---------------|-------|
-| `meow_engine_set_home_dir` | Accepts UTF-8 path; idempotent; handles empty string | Fuzz with non-ASCII |
+| `meow_core_set_home_dir` | Accepts UTF-8 path; idempotent; handles empty string | Fuzz with non-ASCII |
 | `meow_engine_start` | Valid config → 0; missing config → non-zero + populated `last_error` | Seed tmp config.yaml in test bundle |
 | `meow_engine_is_running` | Reflects state after start/stop | |
 | `meow_engine_stop` | Safe to call without prior start (no-op) | |
-| `meow_engine_get_traffic` | Non-negative; monotonic within session; rebases to 0 on restart | |
+| `meow_engine_traffic` | Non-negative; monotonic within session; rebases to 0 on restart | |
 | `meow_engine_validate_config` | Valid YAML → 0; malformed → non-zero with specific error; empty → error | Fixtures in `MeowTests/Fixtures/yaml/` |
 | `meow_engine_convert_subscription` | v2rayN base64 nodelist → Clash YAML; buffer-too-small returns required size | Fixture `MeowTests/Fixtures/nodelist/` |
 | `meow_engine_last_error` | Empty before any error; populated after forced failure; truncates cleanly at `cap` | |


### PR DESCRIPTION
## Summary
Two header-authority drifts swept across the docs tree, same family as PR #31's T4.10 fix.

| Drifted (docs) | Correct (header) | Header source |
|---|---|---|
| `meow_engine_set_home_dir` | `meow_core_set_home_dir` | `core/rust/mihomo-ios-ffi/include/mihomo_core.h:34` |
| `meow_engine_get_traffic` | `meow_engine_traffic` (no `get_`) | `core/rust/mihomo-ios-ffi/include/mihomo_core.h:77` |

Cross-confirmed in `core/rust/mihomo-ios-ffi/src/lib.rs:96` and `PacketTunnel/Sources/TunnelEngine.swift:41`.

## Scope
- `docs/PROJECT_PLAN.md`: §T1.1 line 64 (both symbols), §T2.3 line 109 (set_home_dir), §T2.7 line 152 (traffic)
- `docs/PRD.md`: §2.4 C API surface, lines 123 + 127
- `docs/TEST_STRATEGY.md`: FFI surface assertion table, lines 71 + 75

Docs-only. Eligible for `--admin --rebase` bypass per CLAUDE.md.

## Test plan
- [x] Post-edit grep across `docs/` for both old symbols — zero hits
- [x] `git diff origin/main...HEAD --name-only` shows exactly the three docs files
- [x] Header-authority rule per `feedback_header_symbol_authority`

🤖 Generated with [Claude Code](https://claude.com/claude-code)