### PR TITLE
feat(assets): T4.12 bundle Country.mmdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ MeowCore/Frameworks/*.a
 MeowCore/include/generated/
 build-output/
 
+# ---- Bundled geo assets (fetched via scripts/fetch-geo-assets.sh) ----
+App/Resources/geox/*.mmdb
+
 # ---- Secrets / local ----
 local.properties
 *.mobileprovision

--- a/App/Resources/geox/README.md
+++ b/App/Resources/geox/README.md
@@ -1,0 +1,48 @@
+# Bundled geo assets
+
+This directory stages `Country.mmdb` for inclusion in the app bundle. The
+mmdb itself is **not** committed to git — it's fetched from upstream by
+`scripts/fetch-geo-assets.sh` (run once per developer, and once in CI before
+archiving a release).
+
+## Why a single file
+
+Only `Country.mmdb` is bundled. The engine's other geo databases
+(`geoip.metadb`, `geosite.dat`) are fetched at runtime via the `geox-url:`
+block that `EffectiveConfigWriter` injects into the effective YAML (jsDelivr
+mirrors of the same `MetaCubeX/meta-rules-dat@release` branch). Bundling only
+`Country.mmdb` matches the Android client's pattern and keeps the IPA under
+budget.
+
+## Why commit-SHA pinning (not tag)
+
+`MetaCubeX/meta-rules-dat` does not publish stable release tags — the only
+tag upstream is `latest`, which is reassigned roughly hourly, and the
+`release` branch is force-pushed on the same cadence. Neither is a stable
+pin. Commit SHAs are immutable and content-addressed; combined with an
+artifact SHA-256 check, this is a stronger guarantee than any upstream tag
+would provide.
+
+## Current pin
+
+| Field                | Value                                                                |
+|----------------------|----------------------------------------------------------------------|
+| Upstream repo        | `MetaCubeX/meta-rules-dat`                                           |
+| Pinned commit        | `f6d744b8a4a9073899d77be8de5a6fcd2fb0e755` (`release` branch HEAD)   |
+| Artifact             | `country.mmdb` (renamed to `Country.mmdb` locally to match the engine's lookup casing) |
+| SHA-256              | `7640321a66b2bf8fa23b599a14d473e4c98c10f173add1717b7f7cb34ae5c864`   |
+| Size                 | 8,639,163 bytes (8.24 MiB)                                           |
+| Fetch date           | 2026-04-18                                                           |
+| Upstream license     | MIT — data repackaged by MetaCubeX from MaxMind's GeoLite2 dataset   |
+
+## How to refresh
+
+1. Fetch the current `release` branch HEAD SHA:
+   `git ls-remote --heads https://github.com/MetaCubeX/meta-rules-dat release`
+2. Download `country.mmdb` at that SHA, compute the SHA-256 and byte count.
+3. Update `UPSTREAM_COMMIT`, `EXPECTED_SHA256`, and `EXPECTED_SIZE_BYTES`
+   in `scripts/fetch-geo-assets.sh`.
+4. Update the "Current pin" table above, including the fetch date.
+5. Run `scripts/fetch-geo-assets.sh` locally to re-stage the file.
+6. Open a PR with both number changes in the same diff so reviewers can
+   visually confirm the pin and the hash line up.

--- a/App/Sources/Services/AssetSeeder.swift
+++ b/App/Sources/Services/AssetSeeder.swift
@@ -1,34 +1,35 @@
 import Foundation
 import MeowModels
 
-/// Copies geoip/geosite/country databases from the app bundle into the App
-/// Group container on first launch so both the app and the extension can
-/// read them. Safe to call on every launch — it skips files that are already
-/// in place.
+/// Seeds the bundled `Country.mmdb` into the App Group container so
+/// `mihomo-config::default_geoip_path()` resolves (via `XDG_CONFIG_HOME`) to
+/// a real file on both the app and the extension's first launch. Idempotent —
+/// it skips if the destination already matches the bundled size, and
+/// overwrites on a mismatch so a refreshed bundle beats a stale seeded copy.
 enum AssetSeeder {
-    private static let bundled: [(bundleName: String, destination: URL)] = [
-        ("geoip", AppGroup.geoIPURL),
-        ("geosite", AppGroup.geositeURL),
-        ("country", AppGroup.countryURL),
-    ]
-
     static func seedIfNeeded() async {
-        try? FileManager.default.createDirectory(at: AppGroup.assetsDir, withIntermediateDirectories: true)
-        for (name, dst) in bundled {
-            guard !FileManager.default.fileExists(atPath: dst.path) else { continue }
-            guard let src = urlForBundledAsset(named: name) else { continue }
-            do {
-                try FileManager.default.copyItem(at: src, to: dst)
-            } catch {
-                NSLog("AssetSeeder: failed to copy %@: %@", name, String(describing: error))
+        guard let src = Bundle.main.url(forResource: "Country", withExtension: "mmdb") else {
+            NSLog("AssetSeeder: Country.mmdb missing from app bundle — GEOIP lookups will fall back to geox-url")
+            return
+        }
+        let dst = AppGroup.countryMmdbURL
+        try? FileManager.default.createDirectory(at: AppGroup.mihomoConfigDir, withIntermediateDirectories: true)
+
+        if let srcSize = fileSize(at: src), let dstSize = fileSize(at: dst), srcSize == dstSize {
+            return
+        }
+
+        do {
+            if FileManager.default.fileExists(atPath: dst.path) {
+                try FileManager.default.removeItem(at: dst)
             }
+            try FileManager.default.copyItem(at: src, to: dst)
+        } catch {
+            NSLog("AssetSeeder: failed to seed Country.mmdb: %@", String(describing: error))
         }
     }
 
-    private static func urlForBundledAsset(named name: String) -> URL? {
-        let bundle = Bundle.main
-        return bundle.url(forResource: name, withExtension: "metadb")
-            ?? bundle.url(forResource: name, withExtension: "dat")
-            ?? bundle.url(forResource: name, withExtension: "mmdb")
+    private static func fileSize(at url: URL) -> Int? {
+        (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
     }
 }

--- a/MeowShared/Sources/MeowModels/AppGroup.swift
+++ b/MeowShared/Sources/MeowModels/AppGroup.swift
@@ -33,20 +33,18 @@ public enum AppGroup {
         containerURL.appending(path: "traffic.json")
     }
 
-    public static var assetsDir: URL {
-        containerURL.appending(path: "assets", directoryHint: .isDirectory)
+    /// Directory the engine treats as its "config home": mirrors the layout
+    /// `mihomo-config` expects under `$XDG_CONFIG_HOME/mihomo`, which the FFI
+    /// layer points at `containerURL` via `meow_core_set_home_dir`.
+    public static var mihomoConfigDir: URL {
+        containerURL.appending(path: "mihomo", directoryHint: .isDirectory)
     }
 
-    public static var geoIPURL: URL {
-        assetsDir.appending(path: "geoip.metadb")
-    }
-
-    public static var geositeURL: URL {
-        assetsDir.appending(path: "geosite.dat")
-    }
-
-    public static var countryURL: URL {
-        assetsDir.appending(path: "country.mmdb")
+    /// Location `mihomo-config::default_geoip_path()` resolves to once
+    /// `XDG_CONFIG_HOME=containerURL` is exported. Capital-C filename matches
+    /// the engine's lookup.
+    public static var countryMmdbURL: URL {
+        mihomoConfigDir.appending(path: "Country.mmdb")
     }
 
     /// UserDefaults suite shared between app and extension. Force-unwrap is

--- a/project.yml
+++ b/project.yml
@@ -35,9 +35,10 @@ targets:
     platform: iOS
     sources:
       - path: App/Sources
-    resources:
       - path: App/Resources
         optional: true
+        excludes:
+          - "**/*.md"
     info:
       path: App/Info.plist
       properties:

--- a/scripts/fetch-geo-assets.sh
+++ b/scripts/fetch-geo-assets.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fetches Country.mmdb from MetaCubeX/meta-rules-dat and stages it for the
+# app bundle. We pin by **commit SHA + artifact SHA-256**, not tag: upstream
+# uses only a rolling `latest` tag (reassigned hourly) and a rolling `release`
+# branch (force-pushed), so there is no stable upstream tag to point at.
+# Commit SHAs are immutable; the artifact hash is defense-in-depth against
+# tampering or orphaned-commit GC.
+#
+# To refresh: bump UPSTREAM_COMMIT to the new `release` branch HEAD, download
+# the artifact manually, recompute its SHA-256, update EXPECTED_SHA256 and
+# App/Resources/geox/README.md's fetch-date line, then land the SHA bumps
+# and README update in a single PR so the diff shows both numbers changing
+# together.
+
+set -euo pipefail
+
+UPSTREAM_REPO="MetaCubeX/meta-rules-dat"
+UPSTREAM_COMMIT="f6d744b8a4a9073899d77be8de5a6fcd2fb0e755"
+UPSTREAM_ARTIFACT="country.mmdb"
+EXPECTED_SHA256="7640321a66b2bf8fa23b599a14d473e4c98c10f173add1717b7f7cb34ae5c864"
+EXPECTED_SIZE_BYTES=8639163
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_DIR="$REPO_ROOT/App/Resources/geox"
+DEST_FILE="$DEST_DIR/Country.mmdb"
+TMP_FILE="$(mktemp -t country.mmdb.XXXXXX)"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+URL="https://raw.githubusercontent.com/${UPSTREAM_REPO}/${UPSTREAM_COMMIT}/${UPSTREAM_ARTIFACT}"
+
+mkdir -p "$DEST_DIR"
+
+echo "==> Fetching ${URL}"
+curl --fail --silent --show-error --location --output "$TMP_FILE" "$URL"
+
+ACTUAL_SIZE=$(wc -c <"$TMP_FILE" | tr -d ' ')
+if [ "$ACTUAL_SIZE" != "$EXPECTED_SIZE_BYTES" ]; then
+    echo "ERROR: size mismatch. expected=${EXPECTED_SIZE_BYTES} actual=${ACTUAL_SIZE}" >&2
+    exit 1
+fi
+
+ACTUAL_SHA256=$(shasum -a 256 "$TMP_FILE" | awk '{print $1}')
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo "ERROR: SHA-256 mismatch. expected=${EXPECTED_SHA256} actual=${ACTUAL_SHA256}" >&2
+    exit 1
+fi
+
+mv "$TMP_FILE" "$DEST_FILE"
+trap - EXIT
+
+echo "==> Verified Country.mmdb (${ACTUAL_SIZE} bytes, sha256=${ACTUAL_SHA256})"
+echo "==> Staged at ${DEST_FILE}"


### PR DESCRIPTION
## Summary
- Bundles `Country.mmdb` so `mihomo-config::default_geoip_path()` (resolves to `$XDG_CONFIG_HOME/mihomo/Country.mmdb` via the `meow_core_set_home_dir` wiring from #34/T4.x-#26) finds a real file on first launch in both App and PacketTunnel processes.
- Keeps `geoip.metadb` + `geosite.dat` on the runtime `geox-url:` jsDelivr fallback that `EffectiveConfigWriter` already injects — Country-only bundled scope per team-lead Decision 1(a).

## Upstream pin — commit-SHA + artifact-hash
`MetaCubeX/meta-rules-dat` publishes only a rolling `latest` tag and a force-pushed `release` branch. Neither is a stable pin, so this PR uses the strongest guarantee available:

- Commit: `f6d744b8a4a9073899d77be8de5a6fcd2fb0e755` (`release` HEAD as of 2026-04-18)
- Artifact: `country.mmdb` (renamed to `Country.mmdb` locally to match engine lookup casing)
- SHA-256: `7640321a66b2bf8fa23b599a14d473e4c98c10f173add1717b7f7cb34ae5c864`
- Size: 8,639,163 bytes (8.24 MiB)

Rationale + refresh instructions captured inline in `scripts/fetch-geo-assets.sh` and `App/Resources/geox/README.md`.

## Files
- `scripts/fetch-geo-assets.sh` — curl + size/SHA-256 assert, fail-loud on mismatch
- `App/Resources/geox/README.md` — provenance (URL, commit, hash, size, date, MIT license, pin rationale)
- `App/Resources/geox/Country.mmdb` — gitignored; fetched by the script
- `.gitignore` — ignore `App/Resources/geox/*.mmdb`
- `project.yml` — fold `App/Resources` into target `sources:`, exclude `**/*.md` from bundle
- `MeowShared/Sources/MeowModels/AppGroup.swift` — rename `assetsDir` → `mihomoConfigDir`; drop `geoIPURL`, `geositeURL`, lowercase `countryURL`; expose only `countryMmdbURL` at `mihomo/Country.mmdb`
- `App/Sources/Services/AssetSeeder.swift` — DOA multi-file loop → single-file seed of bundled `Country.mmdb` with size-match idempotence + refresh-on-mismatch

## Test plan
- [x] `swiftlint` (0 violations)
- [x] `xcodebuild test` on `meow-ios` scheme — MeowTests + MeowUITests + MeowIntegrationTests all pass
- [x] `swift test` in `MeowShared/` — all 11 tests pass (EffectiveConfigWriter still emits jsDelivr `geox-url:` as designed)
- [x] Built `.app` contains `Country.mmdb` at bundle root, 8,639,163 bytes
- [x] `scripts/fetch-geo-assets.sh` dry-run: size + SHA-256 both match on fresh fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)