### PR TITLE
feat(yaml-editor): T4.9 screen contract — a11y namespace, empty state, error banner

### DIFF
--- a/App/Sources/Views/YamlEditorView.swift
+++ b/App/Sources/Views/YamlEditorView.swift
@@ -108,7 +108,7 @@ struct CodeTextView: UIViewRepresentable {
     let accessibilityIdentifier: String?
 
     init(text: Binding<String>, accessibilityIdentifier: String? = nil) {
-        self._text = text
+        _text = text
         self.accessibilityIdentifier = accessibilityIdentifier
     }
 

--- a/App/Sources/Views/YamlEditorView.swift
+++ b/App/Sources/Views/YamlEditorView.swift
@@ -10,23 +10,40 @@ struct YamlEditorView: View {
     @State private var saving = false
 
     var body: some View {
-        CodeTextView(text: $text)
+        CodeTextView(text: $text, accessibilityIdentifier: "yamlEditor.editor")
+            .overlay {
+                if text.isEmpty {
+                    ContentUnavailableView(
+                        "Empty config",
+                        systemImage: "doc.text",
+                        description: Text("Paste a Clash YAML config to start editing."),
+                    )
+                    .accessibilityIdentifier("yamlEditor.emptyState")
+                }
+            }
+            .safeAreaInset(edge: .top) {
+                if let error {
+                    errorBanner(error)
+                }
+            }
             .navigationTitle("Edit Config")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Revert") { text = profile.yamlBackup }
+                        .accessibilityLabel("Revert to last saved config")
+                        .accessibilityIdentifier("yamlEditor.revertButton")
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(saving ? "Saving…" : "Save", action: save)
-                        .disabled(saving)
+                        .disabled(saving || text.isEmpty)
+                        .accessibilityLabel("Save config")
+                        .accessibilityIdentifier("yamlEditor.saveButton")
                 }
             }
             .onAppear { text = profile.yamlContent }
-            .alert("Save failed", isPresented: .constant(error != nil)) {
-                Button("OK") { error = nil }
-            } message: {
-                Text(error ?? "")
+            .onChange(of: text) { _, _ in
+                if error != nil { error = nil }
             }
     }
 
@@ -42,6 +59,22 @@ struct YamlEditorView: View {
         } catch {
             self.error = error.localizedDescription
         }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
+        .padding(.horizontal)
+        .accessibilityIdentifier("yamlEditor.errorBanner")
     }
 }
 
@@ -72,6 +105,12 @@ enum MihomoConfigError: LocalizedError {
 /// will replace this with CodeEditView once the YAML editor milestone lands.
 struct CodeTextView: UIViewRepresentable {
     @Binding var text: String
+    let accessibilityIdentifier: String?
+
+    init(text: Binding<String>, accessibilityIdentifier: String? = nil) {
+        self._text = text
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
 
     func makeUIView(context: Context) -> UITextView {
         let view = UITextView()
@@ -83,6 +122,7 @@ struct CodeTextView: UIViewRepresentable {
         view.smartInsertDeleteType = .no
         view.delegate = context.coordinator
         view.backgroundColor = .clear
+        view.accessibilityIdentifier = accessibilityIdentifier
         return view
     }
 


### PR DESCRIPTION
## Summary
Brings `YamlEditorView` up to the same screen-contract veneer as `ProvidersView` (T4.11) and `SettingsView` (T4.8):

- **a11y identifiers** under the `yamlEditor.*` inline-string namespace:
  - `yamlEditor.editor` — set on the wrapped `UITextView` inside `makeUIView` (SwiftUI's `.accessibilityIdentifier` doesn't reliably propagate through a `UIViewRepresentable`).
  - `yamlEditor.saveButton`, `yamlEditor.revertButton` (with `accessibilityLabel` for VoiceOver).
  - `yamlEditor.emptyState`, `yamlEditor.errorBanner`.
- **Empty state** via `ContentUnavailableView` overlay when `text.isEmpty` — covers both "profile has empty yamlContent" and "user cleared the editor". Save button also disables when empty.
- **Error banner** replaces the modal `.alert("Save failed", …)` with the `safeAreaInset(edge: .top)` + `HStack + regularMaterial` pattern from `ProvidersView`. Banner auto-clears on the next text edit so it doesn't linger while the user fixes the issue.

## Out of scope (preserved intentionally)
- No FFI / Rust changes; `MihomoConfigValidator` and `meow_engine_validate_config` unchanged.
- No `SubscriptionService` changes; persistence stays.
- No validation-UX expansion (no inline lint, no gutter markers, no real-time validation) — contract is Save → validate → banner-on-failure.
- `MeowUITests/Flows/YamlEditorFlowTests.swift` tests stay `XCTSkip`'d (still gated on T5.9).
- No `CodeTextView` syntax-highlighting upgrade — that's a separate future swap.
- Pre-existing Swift warnings (non-Sendable NE capture, deprecated `String(cString:)`) untouched.

## Test plan
- [x] `swiftlint`: 0 violations across 68 files.
- [x] `xcodebuild test` on `meow-ios` scheme (MeowTests + MeowUITests + MeowIntegrationTests): 26 tests PASS, same T2.9-blocked protocol tests skipped as before.
- [x] Single-file diff — nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)