### PR TITLE
docs(claude): clarify Swift lint gate runs both swiftlint and swiftformat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ To save GitHub Actions minutes and keep the red-main failure mode from coming ba
 - Before `git push` on any Swift / Rust / YAML change, run the local equivalents of the CI jobs your diff touches:
   - **Swift:** `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17'` against the relevant test bundles (`MeowTests`, `MeowUITests`, `MeowIntegrationTests`).
   - **Rust:** `scripts/build-rust.sh`, plus `cargo test` in `core/rust/mihomo-ios-ffi/` where relevant.
-  - **Lint:** `swiftlint` at the repo root.
+  - **Swift lint:** `swiftlint` **and** `swiftformat --lint .` at the repo root. CI's `lint` job runs both and fails if either does — passing one is not sufficient. The two tools have non-overlapping rule sets: swiftlint catches style/API-usage issues, swiftformat catches formatting/structural ones (`redundantSelf`, spacing, ordering, etc.). Install via `brew install swiftlint swiftformat` if missing.
 - If a local run fails, fix it before pushing. Do not push "to see what CI says."
 - Docs / infra-only changes (no Swift / Rust / YAML touched) don't need the full suite — skip what isn't relevant.
 - Also check `gh run list --branch main --workflow=ci.yml --limit=1` before opening a PR so you know whether main's baseline is green. "Merging to red main" should be a known condition, not a discovery.


### PR DESCRIPTION
## Summary
Updates CLAUDE.md's pre-push Swift lint gate to list both `swiftlint` AND `swiftformat --lint .` — the CI `lint` job runs both, but the workflow rule only named `swiftlint`. Passing one is not sufficient.

## Motivation
Surfaced on PR #36 (T4.9 YAML editor) on 2026-04-18: local `swiftlint` was clean but CI `swiftformat --lint` failed on `redundantSelf` at a single line. Wasted one full CI cycle (~7 min for the four non-lint jobs to also run on the bad commit) plus a follow-up commit for a one-char fix. Both human devs and future agents will hit the same gap as long as CLAUDE.md under-states the gate.

## Change
Single-line edit to the "**Lint:**" bullet in "Run lint + tests locally before pushing". Now names both tools, explains they have non-overlapping rule sets (swiftlint = style/API-usage; swiftformat = formatting/structural like `redundantSelf`), and gives the `brew install` hint.

## Test plan
- [x] Diff is CLAUDE.md only (docs path, strictly non-code — eligible for `--admin --rebase --delete-branch` per CLAUDE.md's own non-code bypass rule).
- [x] Verified: `gh pr view <n> --json files --jq '.files[].path'` returns only `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)