### PR TITLE
chore(tests): exclude retired E2E fixtures from MeowUITests compile

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -142,6 +142,13 @@ targets:
       - path: MeowUITests
         excludes:
           - "README.md"
+          # Retired E2E fixtures — v1.4 scope collapse (see PROJECT_PLAN §T6.5).
+          # Files stay in tree per user directive; excluded from compile to
+          # prevent silent build/discovery of retired scenarios.
+          - "Flows/LocalE2ETests.swift"
+          - "Flows/E2E5CheckGateTests.swift"
+          - "Support/VPhone.swift"
+          - "Support/FiveCheckGateDriver.swift"
     dependencies:
       - target: meow-ios
       - package: MeowShared


### PR DESCRIPTION
## Summary
- Four retired fixtures (`LocalE2ETests.swift`, `E2E5CheckGateTests.swift`, `VPhone.swift`, `FiveCheckGateDriver.swift`) were being silently compiled into the `MeowUITests` target because `project.yml` swept the whole `MeowUITests/` path with only `README.md` excluded. This PR adds them to the excludes list so stale scenarios aren't built or discovered.
- **Files are NOT deleted** — v1.4 scope collapse directive (2026-04-18) is "files stay in tree." This PR only removes them from the compile set, matching the `nightly.yml`/`scripts/test-e2e-ios.sh` disposition (retired, kept in-tree as harmless dead code).

## Rationale
- Cross-reference check (QA, read-only): only these four files reference each other. `LocalE2ETests` and `E2E5CheckGateTests` import `VPhone`; `E2E5CheckGateTests` imports `FiveCheckGateDriver`. **No surviving UI test** references `VPhone` or `FiveCheckGateDriver`, so excluding the four as a unit has no downstream impact.
- Removes build-surface bloat and prevents XCUITest discovery from surfacing stale retired scenarios.

## Test plan
- [x] `swiftformat --lint .` — 0 files require formatting.
- [x] `swiftlint` — 0 violations, 0 serious in 68 files.
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowUITests` — 23/23 passed, `** TEST SUCCEEDED **`.
- [x] Regenerated `meow-ios.xcodeproj/project.pbxproj` shows zero references to the four files in the `MeowUITests` build phase.
- [x] Test discovery confirms `LocalE2ETests` and `E2E5CheckGateTests` no longer run in the MeowUITests suite.
- [ ] CI green on push (standard pipeline, no admin bypass — `project.yml` is code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)