### PR TITLE
feat(diagnostics): T4.10 User-Facing Diagnostics Screen over IPC

### DIFF
--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -36,11 +36,7 @@ struct SettingsView: View {
             }
             Section("Diagnostics") {
                 NavigationLink {
-                    ContentUnavailableView(
-                        "Diagnostics",
-                        systemImage: "stethoscope",
-                        description: Text("Coming in T4.10."),
-                    )
+                    UserDiagnosticsView()
                 } label: {
                     Label("Diagnostics", systemImage: "stethoscope")
                 }

--- a/App/Sources/Views/UserDiagnosticsView.swift
+++ b/App/Sources/Views/UserDiagnosticsView.swift
@@ -1,0 +1,330 @@
+import MeowIPC
+import MeowModels
+import NetworkExtension
+import SwiftUI
+
+/// T4.10 — User-Facing Diagnostics Screen. Pushed from Settings. Three test
+/// cards (Direct TCP, Proxy HTTP, DNS Resolver) with user-supplied inputs
+/// and per-card latency-or-error results.
+///
+/// Process-affinity split (see `docs/PROJECT_PLAN.md §T4.10 addendum` and
+/// `feedback_verify_ffi_process_affinity.md`):
+///
+/// - `meow_engine_test_direct_tcp` does not gate on `engine::tunnel()` in
+///   the Rust FFI, so the Direct TCP card calls it in-process from the app
+///   and stays enabled even when the tunnel is down.
+/// - `meow_engine_test_proxy_http` and `meow_engine_test_dns` both require
+///   `engine::tunnel()` which is `Some` only inside the PacketTunnel
+///   extension process. Those two cards route via `DiagnosticsIPC`'s
+///   user-request tag (`0x02`) → `PacketTunnelProvider.handleAppMessage`
+///   → `DiagnosticsRunner.runUser(request:)`.
+///
+/// When the tunnel is not `.connected`, the whole Proxy+DNS section is
+/// replaced with a single `ContentUnavailableView("VPN required")` rather
+/// than per-card disabled states — two unusable cards side-by-side is a
+/// worse signal than one clear "needs VPN" message.
+struct UserDiagnosticsView: View {
+    @Environment(VpnManager.self) private var vpnManager
+    @State private var error: String?
+
+    var body: some View {
+        Form {
+            directTcpSection
+            if vpnManager.stage == .connected {
+                proxyHttpSection
+                dnsSection
+            } else {
+                vpnRequiredSection
+            }
+        }
+        .safeAreaInset(edge: .top) {
+            if let error {
+                errorBanner(error)
+            }
+        }
+        .navigationTitle("Diagnostics")
+    }
+
+    private var directTcpSection: some View {
+        Section("Direct TCP") {
+            DirectTcpCard(errorSink: $error)
+        }
+    }
+
+    private var proxyHttpSection: some View {
+        Section("Proxy HTTP") {
+            ProxyHttpCard(errorSink: $error)
+        }
+    }
+
+    private var dnsSection: some View {
+        Section("DNS Resolver") {
+            DnsCard(errorSink: $error)
+        }
+    }
+
+    private var vpnRequiredSection: some View {
+        Section {
+            ContentUnavailableView(
+                "VPN required",
+                systemImage: "network.slash",
+                description: Text("Connect to the proxy to run Proxy HTTP and DNS Resolver checks."),
+            )
+            .accessibilityIdentifier("userDiagnostics.emptyState")
+        }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
+        .padding(.horizontal)
+        .accessibilityIdentifier("userDiagnostics.errorBanner")
+    }
+}
+
+// MARK: - Cards
+
+private struct DirectTcpCard: View {
+    @Binding var errorSink: String?
+    @State private var input: String = ""
+    @State private var result: UserDiagnosticsCardResult?
+    @State private var running = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField("1.1.1.1:443", text: $input)
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .accessibilityIdentifier("userDiagnostics.directTcp.input")
+            HStack {
+                Button(running ? "Testing…" : "Test", action: runTest)
+                    .disabled(running || input.isEmpty)
+                    .accessibilityIdentifier("userDiagnostics.directTcp.button")
+                Spacer()
+                if let result {
+                    resultLabel(result)
+                        .accessibilityIdentifier("userDiagnostics.directTcp.result")
+                }
+            }
+        }
+    }
+
+    private func runTest() {
+        let snapshot = input.trimmingCharacters(in: .whitespaces)
+        guard !snapshot.isEmpty else { return }
+        let parsed = parseHostPort(snapshot)
+        guard let (host, port) = parsed else {
+            errorSink = "Expected host:port (e.g. 1.1.1.1:443)"
+            return
+        }
+        errorSink = nil
+        running = true
+        result = nil
+        Task {
+            let response = await Task.detached(priority: .userInitiated) {
+                UserDiagnosticsExec.directTcp(host: host, port: port, timeoutMs: 5000)
+            }.value
+            result = UserDiagnosticsCardResult(response: response)
+            running = false
+        }
+    }
+
+    private func parseHostPort(_ text: String) -> (String, Int32)? {
+        guard let colon = text.lastIndex(of: ":") else { return nil }
+        let host = String(text[..<colon])
+        let portText = String(text[text.index(after: colon)...])
+        guard !host.isEmpty, let port = Int32(portText), port > 0, port <= 65535 else { return nil }
+        return (host, port)
+    }
+}
+
+private struct ProxyHttpCard: View {
+    @Binding var errorSink: String?
+    @State private var input: String = ""
+    @State private var result: UserDiagnosticsCardResult?
+    @State private var running = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField("https://www.gstatic.com/generate_204", text: $input)
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .accessibilityIdentifier("userDiagnostics.proxyHttp.input")
+            HStack {
+                Button(running ? "Testing…" : "Test", action: runTest)
+                    .disabled(running || input.isEmpty)
+                    .accessibilityIdentifier("userDiagnostics.proxyHttp.button")
+                Spacer()
+                if let result {
+                    resultLabel(result)
+                        .accessibilityIdentifier("userDiagnostics.proxyHttp.result")
+                }
+            }
+        }
+    }
+
+    private func runTest() {
+        let snapshot = input.trimmingCharacters(in: .whitespaces)
+        guard !snapshot.isEmpty else { return }
+        errorSink = nil
+        running = true
+        result = nil
+        Task {
+            let response = await UserDiagnosticsClient.send(.proxyHttp(url: snapshot, timeoutMs: 5000))
+            result = UserDiagnosticsCardResult(response: response)
+            running = false
+        }
+    }
+}
+
+private struct DnsCard: View {
+    @Binding var errorSink: String?
+    @State private var input: String = ""
+    @State private var result: UserDiagnosticsCardResult?
+    @State private var running = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField("example.com", text: $input)
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .accessibilityIdentifier("userDiagnostics.dns.input")
+            HStack {
+                Button(running ? "Testing…" : "Test", action: runTest)
+                    .disabled(running || input.isEmpty)
+                    .accessibilityIdentifier("userDiagnostics.dns.button")
+                Spacer()
+                if let result {
+                    resultLabel(result)
+                        .accessibilityIdentifier("userDiagnostics.dns.result")
+                }
+            }
+        }
+    }
+
+    private func runTest() {
+        let snapshot = input.trimmingCharacters(in: .whitespaces)
+        guard !snapshot.isEmpty else { return }
+        errorSink = nil
+        running = true
+        result = nil
+        Task {
+            let response = await UserDiagnosticsClient.send(.dns(host: snapshot, timeoutMs: 3000))
+            result = UserDiagnosticsCardResult(response: response)
+            running = false
+        }
+    }
+}
+
+// MARK: - Result rendering
+
+private enum UserDiagnosticsCardResult {
+    case success(latencyMs: Int64, httpStatus: Int32?)
+    case failure(reason: String)
+
+    init(response: UserDiagnosticsResponse) {
+        if response.success, let latency = response.latencyMs {
+            self = .success(latencyMs: latency, httpStatus: response.httpStatus)
+        } else {
+            self = .failure(reason: response.errorReason ?? "unknown_error")
+        }
+    }
+}
+
+@ViewBuilder
+private func resultLabel(_ result: UserDiagnosticsCardResult) -> some View {
+    switch result {
+    case let .success(latencyMs, httpStatus):
+        if let httpStatus {
+            Text("\(httpStatus) · \(latencyMs) ms")
+                .font(.caption.monospaced())
+                .foregroundStyle(httpStatus >= 200 && httpStatus < 400 ? .green : .orange)
+        } else {
+            Text("\(latencyMs) ms")
+                .font(.caption.monospaced())
+                .foregroundStyle(.green)
+        }
+    case let .failure(reason):
+        Text(reason)
+            .font(.caption.monospaced())
+            .foregroundStyle(.red)
+            .lineLimit(2)
+    }
+}
+
+// MARK: - In-app Direct TCP executor
+
+/// Non-main-actor helper for the Direct TCP FFI, called from a detached
+/// Task so the blocking C call doesn't stall the SwiftUI main actor.
+enum UserDiagnosticsExec {
+    static func directTcp(host: String, port: Int32, timeoutMs: Int32) -> UserDiagnosticsResponse {
+        var ms: Int64 = 0
+        let rc = host.withCString { ptr in
+            meow_engine_test_direct_tcp(ptr, port, timeoutMs, &ms)
+        }
+        if rc < 0 {
+            return .failure(reason: lastRustErrorReason(fallback: "connect_failed"))
+        }
+        return .success(latencyMs: ms)
+    }
+
+    private static func lastRustErrorReason(fallback: String) -> String {
+        guard let cstr = meow_core_last_error() else { return fallback }
+        let msg = String(cString: cstr)
+        return msg.isEmpty ? fallback : msg
+    }
+}
+
+// MARK: - IPC client
+
+/// App-side client for the T4.10 user-diagnostics IPC. Sends a
+/// `UserDiagnosticsRequest` to the PacketTunnel extension via
+/// `NETunnelProviderSession.sendProviderMessage`. If the extension is not
+/// reachable (no session, not running, send throws), returns a synthetic
+/// `tunnel_not_running` failure — same convention the T2.6
+/// `DiagnosticsClient` uses.
+enum UserDiagnosticsClient {
+    static func send(_ request: UserDiagnosticsRequest) async -> UserDiagnosticsResponse {
+        let unreachable = UserDiagnosticsResponse.failure(reason: "tunnel_not_running")
+        let managers: [NETunnelProviderManager]
+        do {
+            managers = try await NETunnelProviderManager.loadAllFromPreferences()
+        } catch {
+            return unreachable
+        }
+        guard let session = managers.first?.connection as? NETunnelProviderSession else {
+            return unreachable
+        }
+        let payload: Data
+        do {
+            payload = try DiagnosticsIPC.encodeUserRequest(request)
+        } catch {
+            return .failure(reason: "encode_failed")
+        }
+        return await withCheckedContinuation { (cont: CheckedContinuation<UserDiagnosticsResponse, Never>) in
+            do {
+                try session.sendProviderMessage(payload) { data in
+                    guard let data, let response = try? DiagnosticsIPC.decodeUserResponse(data) else {
+                        cont.resume(returning: unreachable)
+                        return
+                    }
+                    cont.resume(returning: response)
+                }
+            } catch {
+                cont.resume(returning: unreachable)
+            }
+        }
+    }
+}

--- a/MeowShared/Sources/MeowIPC/DiagnosticsIPC.swift
+++ b/MeowShared/Sources/MeowIPC/DiagnosticsIPC.swift
@@ -6,12 +6,25 @@ import MeowModels
 /// process that can answer the PRD §4.4 checks: four of them need the
 /// mihomo-rust engine runtime, and `MEM_OK` needs `task_info` on the
 /// extension's own mach task.
+///
+/// The protocol is tag-dispatched on the first byte of the request payload:
+///
+/// - `0x01` (exactly one byte) — "run the canned T2.6 report." Response is
+///   a JSON-encoded ``DiagnosticsReport``.
+/// - `0x02` (one byte tag, followed by JSON) — "run one user-initiated
+///   diagnostics request." Payload body decodes to ``UserDiagnosticsRequest``
+///   and the response is a JSON-encoded ``UserDiagnosticsResponse``.
+///
+/// Two tags share one `sendProviderMessage` channel because the extension
+/// only exposes a single `handleAppMessage` entry point; the tag byte lets
+/// the dispatcher route without spinning up a second IPC mailbox.
 public enum DiagnosticsIPC {
     public static let messageTag: UInt8 = 0x01
+    public static let userMessageTag: UInt8 = 0x02
 
-    /// Encodes a "please run diagnostics" request as a single-byte tag so the
-    /// extension can dispatch without instantiating a codec just for this one
-    /// control plane.
+    /// Encodes a "please run canned diagnostics" request as a single-byte tag
+    /// so the extension can dispatch without instantiating a codec just for
+    /// this one control plane.
     public static func encodeRequest() -> Data {
         Data([messageTag])
     }
@@ -27,6 +40,43 @@ public enum DiagnosticsIPC {
     public static func decodeResponse(_ data: Data) throws -> DiagnosticsReport {
         try JSONDecoder().decode(DiagnosticsReport.self, from: data)
     }
+
+    // MARK: - User-initiated diagnostics (T4.10)
+
+    /// Encodes a user-initiated diagnostics request. Wire format is `[0x02,
+    /// ...json...]` — one tag byte followed by a JSON-encoded
+    /// ``UserDiagnosticsRequest``. The tag byte is cheap dispatch; JSON
+    /// keeps the payload schema easy to extend with new cases later.
+    public static func encodeUserRequest(_ request: UserDiagnosticsRequest) throws -> Data {
+        let body = try JSONEncoder().encode(request)
+        var data = Data([userMessageTag])
+        data.append(body)
+        return data
+    }
+
+    public static func isUserRequest(_ data: Data) -> Bool {
+        data.count >= 2 && data[0] == userMessageTag
+    }
+
+    public static func decodeUserRequest(_ data: Data) throws -> UserDiagnosticsRequest {
+        guard isUserRequest(data) else {
+            throw DiagnosticsIPCError.tagMismatch
+        }
+        let body = data.subdata(in: 1 ..< data.count)
+        return try JSONDecoder().decode(UserDiagnosticsRequest.self, from: body)
+    }
+
+    public static func encodeUserResponse(_ payload: UserDiagnosticsResponse) throws -> Data {
+        try JSONEncoder().encode(payload)
+    }
+
+    public static func decodeUserResponse(_ data: Data) throws -> UserDiagnosticsResponse {
+        try JSONDecoder().decode(UserDiagnosticsResponse.self, from: data)
+    }
+}
+
+public enum DiagnosticsIPCError: Error, Sendable {
+    case tagMismatch
 }
 
 /// Carries one `DiagnosticsResult` per `DiagnosticsCheck`, plus the extension
@@ -83,5 +133,47 @@ public struct DiagnosticsResultWire: Codable, Sendable {
 
     public var result: DiagnosticsResult {
         pass ? .pass : .fail(reason: reason)
+    }
+}
+
+/// Request shape for user-initiated diagnostics (T4.10). Direct-TCP is
+/// absent because that FFI is safe to call from the host app process and
+/// never needs to round-trip through IPC. The `proxyHttp` and `dns` cases
+/// gate on `engine::tunnel()` inside the Rust FFI, so they must run inside
+/// the PacketTunnel extension.
+public enum UserDiagnosticsRequest: Codable, Sendable {
+    case proxyHttp(url: String, timeoutMs: UInt32)
+    case dns(host: String, timeoutMs: UInt32)
+}
+
+/// Response shape for user-initiated diagnostics (T4.10). `httpStatus` is
+/// populated only for `proxyHttp` requests; `latencyMs` is populated on
+/// success for both. A `success == false` response carries an
+/// `errorReason` string suitable for rendering directly in the UI — the
+/// Rust error is already sanitized by `DiagnosticsRunner.sanitizeReason`.
+public struct UserDiagnosticsResponse: Codable, Sendable {
+    public var success: Bool
+    public var latencyMs: Int64?
+    public var errorReason: String?
+    public var httpStatus: Int32?
+
+    public init(
+        success: Bool,
+        latencyMs: Int64? = nil,
+        errorReason: String? = nil,
+        httpStatus: Int32? = nil,
+    ) {
+        self.success = success
+        self.latencyMs = latencyMs
+        self.errorReason = errorReason
+        self.httpStatus = httpStatus
+    }
+
+    public static func success(latencyMs: Int64, httpStatus: Int32? = nil) -> UserDiagnosticsResponse {
+        UserDiagnosticsResponse(success: true, latencyMs: latencyMs, httpStatus: httpStatus)
+    }
+
+    public static func failure(reason: String, httpStatus: Int32? = nil) -> UserDiagnosticsResponse {
+        UserDiagnosticsResponse(success: false, errorReason: reason, httpStatus: httpStatus)
     }
 }

--- a/MeowShared/Tests/MeowSharedTests/DiagnosticsIPCTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/DiagnosticsIPCTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+@testable import MeowIPC
+@testable import MeowModels
+import Testing
+
+@Suite("DiagnosticsIPC wire format")
+struct DiagnosticsIPCTests {
+    // MARK: - Canned request (tag 0x01)
+
+    @Test
+    func `canned request is exactly one byte with tag 0x01`() {
+        let data = DiagnosticsIPC.encodeRequest()
+        #expect(data.count == 1)
+        #expect(data[0] == 0x01)
+    }
+
+    @Test
+    func `isRequest only accepts exactly [0x01]`() {
+        #expect(DiagnosticsIPC.isRequest(Data([0x01])))
+        #expect(!DiagnosticsIPC.isRequest(Data()))
+        #expect(!DiagnosticsIPC.isRequest(Data([0x02])))
+        #expect(!DiagnosticsIPC.isRequest(Data([0x01, 0x02])))
+    }
+
+    @Test
+    func `canned response roundtrips through JSON`() throws {
+        let report = DiagnosticsReport(
+            tunExists: .pass,
+            dnsOk: .fail("resolve_failed"),
+            tcpProxyOk: .pass,
+            http204Ok: .fail("status=500"),
+            memOk: .pass,
+        )
+        let data = try DiagnosticsIPC.encodeResponse(report)
+        let decoded = try DiagnosticsIPC.decodeResponse(data)
+        #expect(decoded.tunExists.pass)
+        #expect(!decoded.dnsOk.pass)
+        #expect(decoded.dnsOk.reason == "resolve_failed")
+        #expect(decoded.http204Ok.reason == "status=500")
+    }
+
+    // MARK: - User request (tag 0x02, T4.10)
+
+    @Test
+    func `user request begins with tag 0x02 followed by JSON`() throws {
+        let data = try DiagnosticsIPC.encodeUserRequest(.dns(host: "example.com", timeoutMs: 3000))
+        #expect(data.count >= 2)
+        #expect(data[0] == 0x02)
+        // JSON body must be parseable on its own (no leading tag).
+        let bodyStart = data.index(after: data.startIndex)
+        let body = data.subdata(in: bodyStart ..< data.endIndex)
+        #expect(!body.isEmpty)
+        #expect(body.first == UInt8(ascii: "{"))
+    }
+
+    @Test
+    func `user request isUserRequest disambiguates from canned`() throws {
+        let cannedData = DiagnosticsIPC.encodeRequest()
+        let userData = try DiagnosticsIPC.encodeUserRequest(.dns(host: "example.com", timeoutMs: 3000))
+        #expect(DiagnosticsIPC.isRequest(cannedData))
+        #expect(!DiagnosticsIPC.isUserRequest(cannedData))
+        #expect(!DiagnosticsIPC.isRequest(userData))
+        #expect(DiagnosticsIPC.isUserRequest(userData))
+        #expect(!DiagnosticsIPC.isUserRequest(Data([0x02])))
+        #expect(!DiagnosticsIPC.isUserRequest(Data()))
+    }
+
+    @Test
+    func `user request proxyHttp roundtrips`() throws {
+        let original = UserDiagnosticsRequest.proxyHttp(
+            url: "https://www.gstatic.com/generate_204",
+            timeoutMs: 5000,
+        )
+        let data = try DiagnosticsIPC.encodeUserRequest(original)
+        let decoded = try DiagnosticsIPC.decodeUserRequest(data)
+        guard case let .proxyHttp(url, timeoutMs) = decoded else {
+            Issue.record("expected .proxyHttp, got \(decoded)")
+            return
+        }
+        #expect(url == "https://www.gstatic.com/generate_204")
+        #expect(timeoutMs == 5000)
+    }
+
+    @Test
+    func `user request dns roundtrips`() throws {
+        let original = UserDiagnosticsRequest.dns(host: "example.com", timeoutMs: 3000)
+        let data = try DiagnosticsIPC.encodeUserRequest(original)
+        let decoded = try DiagnosticsIPC.decodeUserRequest(data)
+        guard case let .dns(host, timeoutMs) = decoded else {
+            Issue.record("expected .dns, got \(decoded)")
+            return
+        }
+        #expect(host == "example.com")
+        #expect(timeoutMs == 3000)
+    }
+
+    @Test
+    func `decodeUserRequest rejects payload without 0x02 tag`() {
+        // Valid JSON but no tag byte — must surface as tagMismatch, not decode
+        // silently against a shifted byte offset.
+        let rawJson = Data(#"{"dns":{"host":"example.com","timeoutMs":3000}}"#.utf8)
+        #expect(throws: DiagnosticsIPCError.self) {
+            _ = try DiagnosticsIPC.decodeUserRequest(rawJson)
+        }
+    }
+
+    // MARK: - User response
+
+    @Test
+    func `user response success roundtrips`() throws {
+        let original = UserDiagnosticsResponse.success(latencyMs: 42, httpStatus: 204)
+        let data = try DiagnosticsIPC.encodeUserResponse(original)
+        let decoded = try DiagnosticsIPC.decodeUserResponse(data)
+        #expect(decoded.success)
+        #expect(decoded.latencyMs == 42)
+        #expect(decoded.httpStatus == 204)
+        #expect(decoded.errorReason == nil)
+    }
+
+    @Test
+    func `user response failure roundtrips`() throws {
+        let original = UserDiagnosticsResponse.failure(reason: "engine not running")
+        let data = try DiagnosticsIPC.encodeUserResponse(original)
+        let decoded = try DiagnosticsIPC.decodeUserResponse(data)
+        #expect(!decoded.success)
+        #expect(decoded.errorReason == "engine not running")
+        #expect(decoded.latencyMs == nil)
+        #expect(decoded.httpStatus == nil)
+    }
+
+    @Test
+    func `user response success without httpStatus roundtrips (dns case)`() throws {
+        let original = UserDiagnosticsResponse.success(latencyMs: 18)
+        let data = try DiagnosticsIPC.encodeUserResponse(original)
+        let decoded = try DiagnosticsIPC.decodeUserResponse(data)
+        #expect(decoded.success)
+        #expect(decoded.latencyMs == 18)
+        #expect(decoded.httpStatus == nil)
+    }
+}

--- a/PacketTunnel/Sources/DiagnosticsRunner.swift
+++ b/PacketTunnel/Sources/DiagnosticsRunner.swift
@@ -72,6 +72,52 @@ enum DiagnosticsRunner {
         return .fail("mem=\(mb)mb>=\(memoryFailLimitMB)mb")
     }
 
+    // MARK: - User-initiated diagnostics (T4.10)
+
+    /// Dispatcher for user-initiated diagnostics. Only `proxyHttp` and `dns`
+    /// route through here — `directTcp` runs in-process on the app side and
+    /// never reaches the extension.
+    static func runUser(request: UserDiagnosticsRequest) -> UserDiagnosticsResponse {
+        switch request {
+        case let .proxyHttp(url, timeoutMs):
+            userProxyHttp(url: url, timeoutMs: timeoutMs)
+        case let .dns(host, timeoutMs):
+            userDns(host: host, timeoutMs: timeoutMs)
+        }
+    }
+
+    static func userProxyHttp(url: String, timeoutMs: UInt32) -> UserDiagnosticsResponse {
+        var status: Int32 = 0
+        var ms: Int64 = 0
+        let rc = url.withCString { ptr in
+            meow_engine_test_proxy_http(ptr, Int32(clamping: timeoutMs), &status, &ms)
+        }
+        if rc < 0 {
+            return .failure(reason: lastRustError(fallback: "request_failed"))
+        }
+        return .success(latencyMs: ms, httpStatus: status)
+    }
+
+    static func userDns(host: String, timeoutMs: UInt32) -> UserDiagnosticsResponse {
+        var buf = [CChar](repeating: 0, count: 512)
+        var ms: Int64 = 0
+        let before = Date()
+        let rc = buf.withUnsafeMutableBufferPointer { buf -> Int32 in
+            host.withCString { ptr in
+                meow_engine_test_dns(ptr, Int32(clamping: timeoutMs), buf.baseAddress, Int32(buf.count))
+            }
+        }
+        ms = Int64(Date().timeIntervalSince(before) * 1000)
+        if rc < 0 {
+            return .failure(reason: lastRustError(fallback: "resolve_failed"))
+        }
+        let answer = String(cString: buf)
+        if answer.isEmpty {
+            return .failure(reason: "empty_answer")
+        }
+        return .success(latencyMs: ms)
+    }
+
     // MARK: - Helpers
 
     /// Returns resident memory in MB for the current mach task, or -1 on

--- a/PacketTunnel/Sources/PacketTunnelProvider.swift
+++ b/PacketTunnel/Sources/PacketTunnelProvider.swift
@@ -48,28 +48,44 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {
-        guard DiagnosticsIPC.isRequest(messageData) else {
-            completionHandler?(nil)
+        // Diagnostics checks (both canned T2.6 and T4.10 user-initiated) call
+        // into blocking Rust FFI (DNS, TCP connect, HTTP fetch). Run off the
+        // provider queue on a GCD-managed worker so we don't stall
+        // `handleAppMessage`'s caller. The NE completion handler is not
+        // @Sendable, so we can't hop through a Task; GCD is the correct tool
+        // here.
+        if DiagnosticsIPC.isRequest(messageData) {
+            let engine = engine
+            let handler = UnsafeSendableBox(completionHandler)
+            DispatchQueue.global(qos: .userInitiated).async {
+                let report = engine?.runDiagnostics() ?? DiagnosticsReport(
+                    tunExists: .fail("engine_not_running"),
+                    dnsOk: .fail("engine_not_running"),
+                    tcpProxyOk: .fail("engine_not_running"),
+                    http204Ok: .fail("engine_not_running"),
+                    memOk: .fail("engine_not_running"),
+                )
+                let data = (try? DiagnosticsIPC.encodeResponse(report)) ?? Data()
+                handler.value?(data)
+            }
             return
         }
-        // Diagnostics checks call into blocking Rust FFI (DNS, TCP connect,
-        // HTTP fetch). Run off the provider queue on a GCD-managed worker so
-        // we don't stall `handleAppMessage`'s caller. The NE completion
-        // handler is not @Sendable, so we can't hop through a Task; GCD is
-        // the correct tool here.
-        let engine = engine
-        let handler = UnsafeSendableBox(completionHandler)
-        DispatchQueue.global(qos: .userInitiated).async {
-            let report = engine?.runDiagnostics() ?? DiagnosticsReport(
-                tunExists: .fail("engine_not_running"),
-                dnsOk: .fail("engine_not_running"),
-                tcpProxyOk: .fail("engine_not_running"),
-                http204Ok: .fail("engine_not_running"),
-                memOk: .fail("engine_not_running"),
-            )
-            let data = (try? DiagnosticsIPC.encodeResponse(report)) ?? Data()
-            handler.value?(data)
+
+        if DiagnosticsIPC.isUserRequest(messageData) {
+            guard let request = try? DiagnosticsIPC.decodeUserRequest(messageData) else {
+                completionHandler?(nil)
+                return
+            }
+            let handler = UnsafeSendableBox(completionHandler)
+            DispatchQueue.global(qos: .userInitiated).async {
+                let response = DiagnosticsRunner.runUser(request: request)
+                let data = (try? DiagnosticsIPC.encodeUserResponse(response)) ?? Data()
+                handler.value?(data)
+            }
+            return
         }
+
+        completionHandler?(nil)
     }
 
     /// `NEPacketTunnelProvider.handleAppMessage` hands us a non-Sendable


### PR DESCRIPTION
## Summary

Implements **T4.10 User-Facing Diagnostics Screen** (deferred from M4 per `docs/PROJECT_PLAN.md §T4.10 addendum` at `34576eb`). Replaces the "Coming in T4.10" stub in `SettingsView` with a SwiftUI screen carrying three test cards — Direct TCP, Proxy HTTP, DNS Resolver — each with user-supplied input and per-card latency-or-error results.

## Process-affinity split

Per `feedback_verify_ffi_process_affinity.md` and confirmed by grepping `core/rust/mihomo-ios-ffi/src/lib.rs`:

- `meow_engine_test_direct_tcp` — no `engine::tunnel()` gate; callable from host app process. Direct TCP card runs it in-process on a detached Task so the blocking C call doesn't stall the main actor. Card stays enabled even when the tunnel is down.
- `meow_engine_test_proxy_http` (gates at `lib.rs:294`) and `meow_engine_test_dns` (gates at `lib.rs:334`) — both require `engine::tunnel()` which is `Some` only inside the PacketTunnel extension. Those two cards route through an extended `DiagnosticsIPC`.

## IPC extension (not a fork)

The existing `DiagnosticsIPC` shipped as a single-tag (`0x01`) "run canned T2.6 report" protocol. This PR adds a second tag:

- `0x02` carries a JSON-encoded `UserDiagnosticsRequest` enum (`proxyHttp(url:timeoutMs:)` / `dns(host:timeoutMs:)`).
- Response is a JSON-encoded `UserDiagnosticsResponse` (`success`, `latencyMs?`, `errorReason?`, `httpStatus?`).
- Canned tag `0x01` keeps exact-byte equality — the `isRequest` check remains `data.count == 1 && data[0] == 0x01`, so nothing on the T2.6 path moves.
- `PacketTunnelProvider.handleAppMessage` dispatches by tag; both paths run on a GCD user-initiated queue so the blocking Rust FFI doesn't stall the NE provider queue.
- `DiagnosticsRunner` gains `runUser(request:)`, `userProxyHttp`, and `userDns` helpers that reuse `lastRustError` / `sanitizeReason` from the T2.6 path.

## UX (screen contract)

Matches the M4 T4.x contract pattern (T4.7/T4.8/T4.9/T4.11):

- `ContentUnavailableView("VPN required", systemImage: "network.slash")` covers the whole Proxy HTTP + DNS section when `VpnManager.stage != .connected`, rather than per-card disabled states (two greyed-out cards is a worse signal than one clear empty state).
- `.safeAreaInset(edge: .top)` error banner copies the YAML-editor pattern for invalid-input surfacing.
- A11y namespace `userDiagnostics.*`: `userDiagnostics.{directTcp,proxyHttp,dns}.{input,button,result}`, `userDiagnostics.emptyState`, `userDiagnostics.errorBanner`.
- Placeholders (not pre-fills): `1.1.1.1:443`, `https://www.gstatic.com/generate_204`, `example.com`. Empty input disables the Test button.

## Tests

`MeowSharedTests/DiagnosticsIPCTests` — 11 roundtrip tests in `swift test`:

- Tag-byte dispatch (canned `[0x01]` is exactly one byte, user request starts with `0x02` followed by JSON).
- `isRequest` vs `isUserRequest` disambiguation.
- Request roundtrip for both `proxyHttp` and `dns` cases.
- Response roundtrip for success (with and without `httpStatus`) and failure shapes.
- `tagMismatch` rejection when a JSON payload arrives without the `0x02` tag prefix.

Full iOS test suite (`MeowTests` + `MeowIntegrationTests`) still green.

## Test plan

- [x] `swift test --filter DiagnosticsIPCTests` → 11/11 pass
- [x] `xcodebuild test -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → TEST SUCCEEDED
- [x] `swiftformat --lint .` → 0 violations
- [x] `swiftlint` → 0 violations
- [ ] CI green
- [ ] Manual smoke on device (user) — navigate Settings → Diagnostics, try Direct TCP while disconnected, connect VPN, verify Proxy HTTP / DNS cards appear and return latency