### PR TITLE
feat(traffic): T4.4 Traffic Screen — a11y namespace + empty state

### DIFF
--- a/App/Sources/Views/TrafficView.swift
+++ b/App/Sources/Views/TrafficView.swift
@@ -10,44 +10,12 @@ struct TrafficView: View {
     private let window: TimeInterval = 60
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 16) {
-                GlassCard {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Speed")
-                            .font(.caption.smallCaps())
-                            .foregroundStyle(.secondary)
-                        Chart(samples) { sample in
-                            LineMark(x: .value("t", sample.timestamp), y: .value("up", sample.uploadRate))
-                                .foregroundStyle(by: .value("series", "Upload"))
-                            LineMark(x: .value("t", sample.timestamp), y: .value("down", sample.downloadRate))
-                                .foregroundStyle(by: .value("series", "Download"))
-                        }
-                        .frame(height: 180)
-                    }
-                }
-
-                HStack(spacing: 12) {
-                    TotalsTile(title: "Today", tx: todayTotals.tx, rx: todayTotals.rx)
-                    TotalsTile(title: "This Month", tx: monthTotals.tx, rx: monthTotals.rx)
-                }
-
-                GlassCard {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Last 7 Days")
-                            .font(.caption.smallCaps())
-                            .foregroundStyle(.secondary)
-                        Chart(last7Days) { day in
-                            BarMark(x: .value("day", day.date), y: .value("tx", day.txBytes))
-                                .foregroundStyle(by: .value("series", "Upload"))
-                            BarMark(x: .value("day", day.date), y: .value("rx", day.rxBytes))
-                                .foregroundStyle(by: .value("series", "Download"))
-                        }
-                        .frame(height: 180)
-                    }
-                }
+        Group {
+            if isEmpty {
+                emptyState
+            } else {
+                chartsScrollView
             }
-            .padding()
         }
         .navigationTitle("Traffic")
         .onChange(of: ipcBridge.currentTraffic) { _, snapshot in
@@ -59,6 +27,79 @@ struct TrafficView: View {
             samples.append(sample)
             let cutoff = Date().addingTimeInterval(-window)
             samples.removeAll { $0.timestamp < cutoff }
+        }
+    }
+
+    private var isEmpty: Bool {
+        daily.isEmpty && samples.isEmpty
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No traffic data yet",
+            systemImage: "chart.line.uptrend.xyaxis",
+            description: Text("Start the VPN to begin recording usage."),
+        )
+        .accessibilityIdentifier("traffic.emptyState")
+    }
+
+    private var chartsScrollView: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                speedCard
+                HStack(spacing: 12) {
+                    TotalsTile(
+                        title: "Today",
+                        tx: todayTotals.tx,
+                        rx: todayTotals.rx,
+                        identifier: "traffic.todayTile",
+                    )
+                    TotalsTile(
+                        title: "This Month",
+                        tx: monthTotals.tx,
+                        rx: monthTotals.rx,
+                        identifier: "traffic.monthTile",
+                    )
+                }
+                historyCard
+            }
+            .padding()
+        }
+    }
+
+    private var speedCard: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Speed")
+                    .font(.caption.smallCaps())
+                    .foregroundStyle(.secondary)
+                Chart(samples) { sample in
+                    LineMark(x: .value("t", sample.timestamp), y: .value("up", sample.uploadRate))
+                        .foregroundStyle(by: .value("series", "Upload"))
+                    LineMark(x: .value("t", sample.timestamp), y: .value("down", sample.downloadRate))
+                        .foregroundStyle(by: .value("series", "Download"))
+                }
+                .frame(height: 180)
+                .accessibilityIdentifier("traffic.speedChart")
+            }
+        }
+    }
+
+    private var historyCard: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Last 7 Days")
+                    .font(.caption.smallCaps())
+                    .foregroundStyle(.secondary)
+                Chart(last7Days) { day in
+                    BarMark(x: .value("day", day.date), y: .value("tx", day.txBytes))
+                        .foregroundStyle(by: .value("series", "Upload"))
+                    BarMark(x: .value("day", day.date), y: .value("rx", day.rxBytes))
+                        .foregroundStyle(by: .value("series", "Download"))
+                }
+                .frame(height: 180)
+                .accessibilityIdentifier("traffic.historyChart")
+            }
         }
     }
 
@@ -94,14 +135,19 @@ private struct TotalsTile: View {
     let title: String
     let tx: Int64
     let rx: Int64
+    let identifier: String
+
     var body: some View {
         GlassCard {
             VStack(alignment: .leading, spacing: 6) {
                 Text(title).font(.caption.smallCaps()).foregroundStyle(.secondary)
                 Label(ByteCountFormatter.string(fromByteCount: tx, countStyle: .binary), systemImage: "arrow.up")
+                    .accessibilityIdentifier("\(identifier).tx")
                 Label(ByteCountFormatter.string(fromByteCount: rx, countStyle: .binary), systemImage: "arrow.down")
+                    .accessibilityIdentifier("\(identifier).rx")
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .accessibilityIdentifier(identifier)
     }
 }

--- a/MeowUITests/Screens/TrafficScreenTests.swift
+++ b/MeowUITests/Screens/TrafficScreenTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+final class TrafficScreenTests: XCTestCase {
+    func testEmptyStateShowsOnFreshInstall() {
+        let meow = MeowApp(resetState: true)
+        meow.launch()
+        meow.trafficTab.tap()
+        let emptyState = meow.app.descendants(matching: .any)["traffic.emptyState"]
+        XCTAssertTrue(emptyState.waitForExistence(timeout: 5))
+    }
+}


### PR DESCRIPTION
## Summary

Apply the T4.9 / T4.10 screen-contract pattern to the pre-scaffolded `TrafficView`:

- **A11y namespace `traffic.*`**: `traffic.speedChart`, `traffic.historyChart`, `traffic.todayTile` (+ `.tx` / `.rx`), `traffic.monthTile` (+ `.tx` / `.rx`), `traffic.emptyState`.
- **Empty state**: when `daily.isEmpty && samples.isEmpty`, replace the charts (don't overlay — empty-axis charts look like broken charts) with `ContentUnavailableView("No traffic data yet", systemImage: "chart.line.uptrend.xyaxis", description: "Start the VPN to begin recording usage.")`.
- **No error banner** — by design. See below.
- **No IPC / model / xcframework changes.** Data source (`ipcBridge.currentTraffic` + SwiftData `DailyTraffic`) already wired by T3.3 / T3.6.

## Error banner decision (flagged in brief)

Traffic data flows: `DarwinBridge` notification → `AppIPCBridge.reloadTraffic()` → `SharedStore.readTraffic()`. On IO failure, the `if let` in `reloadTraffic` silently preserves the last snapshot. There's no error field on `TrafficSnapshot` and no reported failure for the `@Query<DailyTraffic>` path. Per brief: "If no error surface, skip the banner — don't invent an error path just to match the template." Skipped. If a future sub-task surfaces a real error (e.g. model migration failure), wire it with `.safeAreaInset(edge: .top)` and a11y id `traffic.errorBanner`.

## Verification

Added `MeowUITests/Screens/TrafficScreenTests.swift` with one test:

```swift
func testEmptyStateShowsOnFreshInstall() {
    let meow = MeowApp(resetState: true)
    meow.launch()
    meow.trafficTab.tap()
    let emptyState = meow.app.descendants(matching: .any)["traffic.emptyState"]
    XCTAssertTrue(emptyState.waitForExistence(timeout: 5))
}
```

Passes on iPhone 17 / iOS 26.4 simulator. Doubles as regression guard for the screen contract.

Live speed-chart behaviour under a real VPN session is not automatable in sim (NE doesn't deliver packets in the simulator). Manual sim smoke confirmed: app launches, Home renders, tabbing to Traffic on fresh `-ResetState` install shows the empty-state overlay; the `@Observable` `currentTraffic` path is unchanged from T3.3 / T3.6 so live updates inherit their coverage.

## Local pre-push gate

- `swiftformat --lint .` → 0/83 files require formatting ✅
- `swiftlint` → 0 violations ✅
- `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -only-testing:MeowIntegrationTests` → `** TEST SUCCEEDED **` ✅

## Test plan

- [x] Lint gate clean locally
- [x] MeowTests + MeowUITests + MeowIntegrationTests green locally on iPhone 17 / iOS 26.4
- [x] `TrafficScreenTests.testEmptyStateShowsOnFreshInstall` passes
- [ ] CI lint ✅
- [ ] CI build-core ✅
- [ ] CI ui-test ✅
- [ ] CI unit-test ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)