### PR TITLE
feat(a11y): T5.3 Accessibility & Dynamic Type audit

### DIFF
--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -410,6 +410,7 @@ private struct ProxyGroupCard: View {
             DelayBadge(delay: child.delay, isLoading: inflight.contains(child.name))
                 .onTapGesture { onPing(child.name) }
         }
+        .frame(minHeight: 44)
         .contentShape(Rectangle())
         .onTapGesture { onSelect(child.name) }
         .accessibilityIdentifier("home.proxy.\(group.id.identifierSlug).\(child.name.identifierSlug)")

--- a/App/Sources/Views/ProvidersView.swift
+++ b/App/Sources/Views/ProvidersView.swift
@@ -56,6 +56,7 @@ struct ProvidersView: View {
                 }
             } label: {
                 Image(systemName: "bolt.fill")
+                    .frame(minWidth: 44, minHeight: 44)
             }
             .buttonStyle(.borderless)
             .accessibilityLabel("Health check \(provider.name)")
@@ -91,6 +92,7 @@ struct ProvidersView: View {
                     }
                 } label: {
                     Image(systemName: "bolt")
+                        .frame(minWidth: 44, minHeight: 44)
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Test \(proxy.name)")

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -25,7 +25,9 @@ struct SubscriptionsView: View {
                             Task { try? await service.refresh(profile) }
                         } label: {
                             Image(systemName: "arrow.clockwise")
+                                .frame(minWidth: 44, minHeight: 44)
                         }
+                        .accessibilityLabel("Refresh \(profile.name)")
                     }
                 }
                 .listRowBackground(Color.clear)
@@ -51,6 +53,7 @@ struct SubscriptionsView: View {
                 } label: {
                     Image(systemName: "plus")
                 }
+                .accessibilityLabel("Add subscription")
             }
         }
         .sheet(isPresented: $showingAdd) {

--- a/App/Sources/Views/UserDiagnosticsView.swift
+++ b/App/Sources/Views/UserDiagnosticsView.swift
@@ -105,6 +105,7 @@ private struct DirectTcpCard: View {
                 .keyboardType(.URL)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled(true)
+                .accessibilityLabel("Host and port")
                 .accessibilityIdentifier("userDiagnostics.directTcp.input")
             HStack {
                 Button(running ? "Testing…" : "Test", action: runTest)
@@ -160,6 +161,7 @@ private struct ProxyHttpCard: View {
                 .keyboardType(.URL)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled(true)
+                .accessibilityLabel("HTTP URL")
                 .accessibilityIdentifier("userDiagnostics.proxyHttp.input")
             HStack {
                 Button(running ? "Testing…" : "Test", action: runTest)
@@ -200,6 +202,7 @@ private struct DnsCard: View {
                 .keyboardType(.URL)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled(true)
+                .accessibilityLabel("Domain name")
                 .accessibilityIdentifier("userDiagnostics.dns.input")
             HStack {
                 Button(running ? "Testing…" : "Test", action: runTest)

--- a/App/Sources/Views/YamlEditorView.swift
+++ b/App/Sources/Views/YamlEditorView.swift
@@ -114,7 +114,8 @@ struct CodeTextView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UITextView {
         let view = UITextView()
-        view.font = .monospacedSystemFont(ofSize: 14, weight: .regular)
+        view.font = UIFontMetrics.default.scaledFont(for: .monospacedSystemFont(ofSize: 14, weight: .regular))
+        view.adjustsFontForContentSizeCategory = true
         view.autocapitalizationType = .none
         view.autocorrectionType = .no
         view.smartQuotesType = .no


### PR DESCRIPTION
## Summary

Audit-and-annotate pass across 13 app views per T5.3. Findings:

- **Dynamic Type**: all 39 `.font(...)` calls are already semantic (`.body`, `.headline`, `.caption`, `.subheadline`, `.title3`, `.footnote`). No `.font(.system(size:))` to fix. Only change here is `CodeTextView` (UIKit, monospace) — now wraps the font in `UIFontMetrics.default.scaledFont(for:)` and sets `adjustsFontForContentSizeCategory = true`.
- **VoiceOver labels**: added on icon-only controls that previously had no spoken label — SubscriptionsView refresh button, SubscriptionsView add button, 3 UserDiagnosticsView TextFields (placeholder ≠ persistent VO label).
- **44pt tap targets**: added `minWidth:44, minHeight:44` on ProvidersView's 2 borderless bolt Buttons and `minHeight: 44` on HomeView's proxyRow.

Intentionally left alone:

- `DiagnosticsViewController` — fixed 18pt monospace is required per PRD §4.4 "pixel-stable OCR harness positions". Explicit constraint, not an oversight.
- `LogsView` Auto-scroll Toggle with `.labelsHidden()` — Apple's `labelsHidden()` retains the accessibility label for VoiceOver; only hides visual presentation. No change needed.
- `GlassCard` — no fixed heights, no fixed font sizes. Dynamic Type safe as-is.
- Controls where a visible Text provides the VO label (`Button("Disconnect")`, `Toggle("Allow LAN", ...)`, `Picker("Log Level", ...)`, `NavigationLink("Diagnostics", ...)`, toolbar `Button("Close All")`, etc.) — already compliant.

Flagged for follow-up (not in this PR):

- HomeView `proxyRow`: two nested `.onTapGesture` handlers (select on row, ping on DelayBadge). VO can reach both but can't distinguish. Fixing properly means converting the inner tap to an `.accessibilityAction(named: "Test")` — that's a behavior change, not an audit annotation.

## Path B attestation

- [x] (1) `swiftformat --lint .` ran locally at repo root → 0 violations (0/83 files require formatting, 14 skipped)
- [x] (2) `swiftlint` ran locally at repo root → 0 violations (0 violations, 0 serious in 70 files)
- [x] (3) `xcodebuild test` ran locally on iPhone 17 / iOS 26 sim → green
  - `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` → ** TEST SUCCEEDED ** (99 tests in 20 suites)
  - `xcodebuild test ... -only-testing:MeowUITests` → ** TEST SUCCEEDED ** (24 tests, 23 skipped blocked on future tickets, 0 failures)
- [x] (4) `git diff origin/main...HEAD --stat` verified — 5 files, all under `App/Sources/Views/`, +11/-1. No accidental additions.
- [x] (5) This checklist.

## Not verified by me (out of headless-session capability)

- Interactive VoiceOver spot-check with Accessibility Inspector (suggested by brief — reviewer's call whether to run in sim).
- Visual inspection at XXL text size. The additive modifiers are audit-only and shouldn't affect baseline layout at regular sizes; the `UIFontMetrics` scaling in `CodeTextView` is the only change that actively participates in Dynamic Type.

## Test plan

- [ ] Reviewer runs VoiceOver in sim and confirms: Subscriptions refresh/add buttons read as "Refresh <name>" / "Add subscription"; UserDiagnostics TextFields read as "Host and port" / "HTTP URL" / "Domain name"; ProvidersView bolt buttons are focus-reachable.
- [ ] Reviewer bumps text size to XXL and confirms no clipped labels / broken layouts. CodeTextView should scale up with Dynamic Type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)