### PR TITLE
feat(l10n): T5.4 Localization scaffold — en base + zh-Hans placeholder

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,153 @@
+/* meow-ios — English base strings.
+   Key namespacing by screen (matches accessibilityIdentifier namespaces where sensible).
+
+   Strings deliberately NOT localized and therefore NOT in this file:
+   - HomeView.stageBadgeText — QA harness pins on lowercase ASCII ("disconnected", "connecting", "connected", "disconnecting").
+   - DiagnosticsViewController row content — OCR harness pins on uppercase ASCII "CHECK: PASS/FAIL" format.
+   - UserDiagnosticsView error reason codes ("tunnel_not_running", "connect_failed", "encode_failed", "unknown_error") — stable diagnostic identifiers.
+   - Chart axis raw values ("t", "up", "down", "series", "day", "tx", "rx") — internal chart bindings, not displayed text.
+   - TextField placeholders showing example values ("1.1.1.1:443", "example.com", "https://…/generate_204", "https://1.1.1.1/dns-query") — URL/address examples, not prose.
+   - Log-level tag values ("debug", "info", "warning", "error", "silent") in Picker .tag() — model values, not display text. Display labels ARE localized. */
+
+
+/* Tab bar */
+"tabs.home" = "Home";
+"tabs.subscriptions" = "Subscriptions";
+"tabs.traffic" = "Traffic";
+"tabs.logs" = "Logs";
+"tabs.settings" = "Settings";
+
+
+/* Common */
+"common.ok" = "OK";
+"common.cancel" = "Cancel";
+"common.close" = "Close";
+"common.error" = "Error";
+"common.delete" = "Delete";
+
+
+/* Home screen */
+"home.nav.title" = "meow";
+"home.profile.none" = "No Profile";
+"home.toggle.connect" = "Connect";
+"home.toggle.connecting" = "Connecting…";
+"home.toggle.disconnect" = "Disconnect";
+"home.toggle.disconnecting" = "Disconnecting…";
+"home.packet.ingress" = "Ingress";
+"home.packet.egress" = "Egress";
+"home.traffic.upload" = "Upload";
+"home.traffic.download" = "Download";
+"home.traffic.total %@" = "Total %@";
+"home.proxyGroups.header" = "Proxy Groups";
+"home.proxyGroups.placeholder.connected" = "Loading groups…";
+"home.proxyGroups.placeholder.connecting" = "Connecting — groups appear when the engine is up.";
+"home.proxyGroups.placeholder.disconnected" = "Connect to populate available groups.";
+"home.nav.connections" = "Connections";
+"home.nav.rules" = "Rules";
+"home.nav.providers" = "Providers";
+"home.nav.diagnostics" = "Diagnostics";
+"home.error.apiUnavailable" = "API unavailable";
+"home.error.selectFailed" = "select failed";
+
+
+/* Subscriptions */
+"subscriptions.nav.title" = "Subscriptions";
+"subscriptions.add.nav.title" = "Add Subscription";
+"subscriptions.add.field.name" = "Name";
+"subscriptions.add.field.url" = "URL";
+"subscriptions.add.button.add" = "Add";
+"subscriptions.add.button.adding" = "Adding…";
+"subscriptions.import.errorTitle" = "Couldn't import subscription";
+"subscriptions.row.updatedAgo %@" = "Updated %@ ago";
+
+
+/* Connections */
+"connections.empty.title" = "No connections";
+"connections.empty.description" = "Active traffic will appear here.";
+"connections.toolbar.closeAll" = "Close All";
+"connections.swipe.close" = "Close";
+"connections.nav.titleFormat %lld" = "Connections (%lld)";
+
+
+/* Rules */
+"rules.empty.title" = "No rules";
+"rules.empty.description" = "Rules appear when a profile is loaded.";
+"rules.nav.titleFormat %lld" = "Rules (%lld)";
+
+
+/* Logs */
+"logs.picker.level" = "Level";
+"logs.level.debug" = "debug";
+"logs.level.info" = "info";
+"logs.level.warning" = "warning";
+"logs.level.error" = "error";
+"logs.toggle.autoScroll" = "Auto-scroll";
+"logs.empty.title" = "No logs";
+"logs.empty.description" = "Logs appear when the tunnel is active.";
+"logs.nav.titleFormat %lld" = "Logs (%lld)";
+
+
+/* Providers */
+"providers.empty.title" = "No providers";
+"providers.empty.description" = "Providers appear when a profile is loaded.";
+"providers.nav.titleFormat %lld" = "Providers (%lld)";
+"providers.a11y.healthCheck %@" = "Health check %@";
+"providers.a11y.test %@" = "Test %@";
+
+
+/* Yaml Editor */
+"yamlEditor.nav.title" = "Edit Config";
+"yamlEditor.empty.title" = "Empty config";
+"yamlEditor.empty.description" = "Paste a Clash YAML config to start editing.";
+"yamlEditor.button.revert" = "Revert";
+"yamlEditor.button.save" = "Save";
+"yamlEditor.button.saving" = "Saving…";
+"yamlEditor.a11y.revert" = "Revert to last saved config";
+"yamlEditor.a11y.save" = "Save config";
+"yamlEditor.error.invalid" = "Invalid config";
+
+
+/* Settings */
+"settings.nav.title" = "Settings";
+"settings.section.general" = "General";
+"settings.toggle.allowLan" = "Allow LAN";
+"settings.toggle.ipv6" = "IPv6";
+"settings.picker.logLevel" = "Log Level";
+"settings.logLevel.debug" = "Debug";
+"settings.logLevel.info" = "Info";
+"settings.logLevel.warning" = "Warning";
+"settings.logLevel.error" = "Error";
+"settings.logLevel.silent" = "Silent";
+"settings.section.dns" = "DNS";
+"settings.field.dohServer" = "DoH Server";
+"settings.section.diagnostics" = "Diagnostics";
+"settings.label.diagnostics" = "Diagnostics";
+"settings.section.about" = "About";
+"settings.about.version" = "Version";
+"settings.about.memory" = "Memory";
+
+
+/* User Diagnostics */
+"userDiagnostics.nav.title" = "Diagnostics";
+"userDiagnostics.section.directTcp" = "Direct TCP";
+"userDiagnostics.section.proxyHttp" = "Proxy HTTP";
+"userDiagnostics.section.dns" = "DNS Resolver";
+"userDiagnostics.empty.title" = "VPN required";
+"userDiagnostics.empty.description" = "Connect to the proxy to run Proxy HTTP and DNS Resolver checks.";
+"userDiagnostics.button.test" = "Test";
+"userDiagnostics.button.testing" = "Testing…";
+"userDiagnostics.error.parseHostPort" = "Expected host:port (e.g. 1.1.1.1:443)";
+
+
+/* Traffic */
+"traffic.nav.title" = "Traffic";
+"traffic.empty.title" = "No traffic data yet";
+"traffic.empty.description" = "Start the VPN to begin recording usage.";
+"traffic.label.speed" = "Speed";
+"traffic.label.last7Days" = "Last 7 Days";
+"traffic.tile.today" = "Today";
+"traffic.tile.thisMonth" = "This Month";
+
+
+/* Fullscreen diagnostics overlay (ContentView) */
+"content.diagnostics.nav.title" = "Diagnostics";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,157 @@
+/* meow-ios — Simplified Chinese (zh-Hans) localization scaffold.
+
+   This file is an IDENTITY PLACEHOLDER: every key carries its English value.
+   It proves the zh-Hans.lproj wiring works end-to-end (Xcode compiles the
+   catalog, strings bundle ships in the .app, runtime picks it up when the
+   device locale = zh-Hans) without committing to a translation round yet.
+
+   Translators: overwrite every value on the right-hand side. Keys are frozen
+   per screen namespace (tabs.*, home.*, subscriptions.*, etc.) and must match
+   the en.lproj key set 1:1. Do NOT localize strings deliberately omitted from
+   en.lproj — see that file's header for the exclusion list (QA/OCR harness
+   pins, stable diagnostic reason codes, internal chart bindings, etc.).
+
+   Source for future translation: /Volumes/DATA/workspace/mihomo-android/mobile/src/main/res/values-zh/strings.xml (canonical zh_CN for the Android sibling). */
+
+
+/* Tab bar */
+"tabs.home" = "Home";
+"tabs.subscriptions" = "Subscriptions";
+"tabs.traffic" = "Traffic";
+"tabs.logs" = "Logs";
+"tabs.settings" = "Settings";
+
+
+/* Common */
+"common.ok" = "OK";
+"common.cancel" = "Cancel";
+"common.close" = "Close";
+"common.error" = "Error";
+"common.delete" = "Delete";
+
+
+/* Home screen */
+"home.nav.title" = "meow";
+"home.profile.none" = "No Profile";
+"home.toggle.connect" = "Connect";
+"home.toggle.connecting" = "Connecting…";
+"home.toggle.disconnect" = "Disconnect";
+"home.toggle.disconnecting" = "Disconnecting…";
+"home.packet.ingress" = "Ingress";
+"home.packet.egress" = "Egress";
+"home.traffic.upload" = "Upload";
+"home.traffic.download" = "Download";
+"home.traffic.total %@" = "Total %@";
+"home.proxyGroups.header" = "Proxy Groups";
+"home.proxyGroups.placeholder.connected" = "Loading groups…";
+"home.proxyGroups.placeholder.connecting" = "Connecting — groups appear when the engine is up.";
+"home.proxyGroups.placeholder.disconnected" = "Connect to populate available groups.";
+"home.nav.connections" = "Connections";
+"home.nav.rules" = "Rules";
+"home.nav.providers" = "Providers";
+"home.nav.diagnostics" = "Diagnostics";
+"home.error.apiUnavailable" = "API unavailable";
+"home.error.selectFailed" = "select failed";
+
+
+/* Subscriptions */
+"subscriptions.nav.title" = "Subscriptions";
+"subscriptions.add.nav.title" = "Add Subscription";
+"subscriptions.add.field.name" = "Name";
+"subscriptions.add.field.url" = "URL";
+"subscriptions.add.button.add" = "Add";
+"subscriptions.add.button.adding" = "Adding…";
+"subscriptions.import.errorTitle" = "Couldn't import subscription";
+"subscriptions.row.updatedAgo %@" = "Updated %@ ago";
+
+
+/* Connections */
+"connections.empty.title" = "No connections";
+"connections.empty.description" = "Active traffic will appear here.";
+"connections.toolbar.closeAll" = "Close All";
+"connections.swipe.close" = "Close";
+"connections.nav.titleFormat %lld" = "Connections (%lld)";
+
+
+/* Rules */
+"rules.empty.title" = "No rules";
+"rules.empty.description" = "Rules appear when a profile is loaded.";
+"rules.nav.titleFormat %lld" = "Rules (%lld)";
+
+
+/* Logs */
+"logs.picker.level" = "Level";
+"logs.level.debug" = "debug";
+"logs.level.info" = "info";
+"logs.level.warning" = "warning";
+"logs.level.error" = "error";
+"logs.toggle.autoScroll" = "Auto-scroll";
+"logs.empty.title" = "No logs";
+"logs.empty.description" = "Logs appear when the tunnel is active.";
+"logs.nav.titleFormat %lld" = "Logs (%lld)";
+
+
+/* Providers */
+"providers.empty.title" = "No providers";
+"providers.empty.description" = "Providers appear when a profile is loaded.";
+"providers.nav.titleFormat %lld" = "Providers (%lld)";
+"providers.a11y.healthCheck %@" = "Health check %@";
+"providers.a11y.test %@" = "Test %@";
+
+
+/* Yaml Editor */
+"yamlEditor.nav.title" = "Edit Config";
+"yamlEditor.empty.title" = "Empty config";
+"yamlEditor.empty.description" = "Paste a Clash YAML config to start editing.";
+"yamlEditor.button.revert" = "Revert";
+"yamlEditor.button.save" = "Save";
+"yamlEditor.button.saving" = "Saving…";
+"yamlEditor.a11y.revert" = "Revert to last saved config";
+"yamlEditor.a11y.save" = "Save config";
+"yamlEditor.error.invalid" = "Invalid config";
+
+
+/* Settings */
+"settings.nav.title" = "Settings";
+"settings.section.general" = "General";
+"settings.toggle.allowLan" = "Allow LAN";
+"settings.toggle.ipv6" = "IPv6";
+"settings.picker.logLevel" = "Log Level";
+"settings.logLevel.debug" = "Debug";
+"settings.logLevel.info" = "Info";
+"settings.logLevel.warning" = "Warning";
+"settings.logLevel.error" = "Error";
+"settings.logLevel.silent" = "Silent";
+"settings.section.dns" = "DNS";
+"settings.field.dohServer" = "DoH Server";
+"settings.section.diagnostics" = "Diagnostics";
+"settings.label.diagnostics" = "Diagnostics";
+"settings.section.about" = "About";
+"settings.about.version" = "Version";
+"settings.about.memory" = "Memory";
+
+
+/* User Diagnostics */
+"userDiagnostics.nav.title" = "Diagnostics";
+"userDiagnostics.section.directTcp" = "Direct TCP";
+"userDiagnostics.section.proxyHttp" = "Proxy HTTP";
+"userDiagnostics.section.dns" = "DNS Resolver";
+"userDiagnostics.empty.title" = "VPN required";
+"userDiagnostics.empty.description" = "Connect to the proxy to run Proxy HTTP and DNS Resolver checks.";
+"userDiagnostics.button.test" = "Test";
+"userDiagnostics.button.testing" = "Testing…";
+"userDiagnostics.error.parseHostPort" = "Expected host:port (e.g. 1.1.1.1:443)";
+
+
+/* Traffic */
+"traffic.nav.title" = "Traffic";
+"traffic.empty.title" = "No traffic data yet";
+"traffic.empty.description" = "Start the VPN to begin recording usage.";
+"traffic.label.speed" = "Speed";
+"traffic.label.last7Days" = "Last 7 Days";
+"traffic.tile.today" = "Today";
+"traffic.tile.thisMonth" = "This Month";
+
+
+/* Fullscreen diagnostics overlay (ContentView) */
+"content.diagnostics.nav.title" = "Diagnostics";

--- a/App/Sources/Views/ConnectionsView.swift
+++ b/App/Sources/Views/ConnectionsView.swift
@@ -17,9 +17,9 @@ struct ConnectionsView: View {
         .overlay {
             if connections.isEmpty {
                 ContentUnavailableView(
-                    "No connections",
+                    "connections.empty.title",
                     systemImage: "link",
-                    description: Text("Active traffic will appear here."),
+                    description: Text("connections.empty.description"),
                 )
                 .accessibilityIdentifier("connections.emptyState")
             } else if filtered.isEmpty {
@@ -33,10 +33,13 @@ struct ConnectionsView: View {
             }
         }
         .searchable(text: $query)
-        .navigationTitle("Connections (\(connections.count))")
+        .navigationTitle(Text(
+            "connections.nav.titleFormat \(connections.count)",
+            comment: "Connections screen navigation title; %lld = current count",
+        ))
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button("Close All") {
+                Button("connections.toolbar.closeAll") {
                     Task { try? await api.closeAllConnections() }
                 }
                 .accessibilityIdentifier("connections.toolbar.closeAll")
@@ -86,7 +89,7 @@ struct ConnectionsView: View {
             Button(role: .destructive) {
                 Task { try? await api.closeConnection(id: conn.id) }
             } label: {
-                Label("Close", systemImage: "xmark")
+                Label("connections.swipe.close", systemImage: "xmark")
             }
             .accessibilityIdentifier("connections.row.\(slug).close")
         }

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -8,19 +8,19 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
-            Tab("Home", systemImage: "house.fill") {
+            Tab("tabs.home", systemImage: "house.fill") {
                 NavigationStack { HomeView() }
             }
-            Tab("Subscriptions", systemImage: "text.document.fill") {
+            Tab("tabs.subscriptions", systemImage: "text.document.fill") {
                 NavigationStack { SubscriptionsView() }
             }
-            Tab("Traffic", systemImage: "chart.bar.fill") {
+            Tab("tabs.traffic", systemImage: "chart.bar.fill") {
                 NavigationStack { TrafficView() }
             }
-            Tab("Logs", systemImage: "list.bullet.rectangle.fill") {
+            Tab("tabs.logs", systemImage: "list.bullet.rectangle.fill") {
                 NavigationStack { LogsView() }
             }
-            Tab("Settings", systemImage: "gearshape.fill") {
+            Tab("tabs.settings", systemImage: "gearshape.fill") {
                 NavigationStack { SettingsView() }
             }
         }
@@ -37,17 +37,17 @@ struct ContentView: View {
             NavigationStack {
                 DiagnosticsPanelView()
                     .ignoresSafeArea(edges: .bottom)
-                    .navigationTitle("Diagnostics")
+                    .navigationTitle("content.diagnostics.nav.title")
                     .navigationBarTitleDisplayMode(.inline)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
-                            Button("Close") { showDiagnostics = false }
+                            Button("common.close") { showDiagnostics = false }
                         }
                     }
             }
         }
-        .alert("Couldn't import subscription", isPresented: .constant(importError != nil)) {
-            Button("OK") { importError = nil }
+        .alert("subscriptions.import.errorTitle", isPresented: .constant(importError != nil)) {
+            Button("common.ok") { importError = nil }
         } message: {
             Text(importError ?? "")
         }

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -24,7 +24,7 @@ struct HomeView: View {
             .padding(16)
         }
         .scrollContentBackground(.hidden)
-        .navigationTitle("meow")
+        .navigationTitle("home.nav.title")
         .task(id: vpnManager.stage) {
             await refreshGroupsIfConnected()
         }
@@ -53,12 +53,12 @@ struct HomeView: View {
                     PacketStat(
                         systemImage: "arrow.down.to.line.square",
                         count: ipcBridge.currentTraffic.ingressPackets,
-                        label: "Ingress",
+                        label: "home.packet.ingress",
                     )
                     PacketStat(
                         systemImage: "arrow.up.to.line.square",
                         count: ipcBridge.currentTraffic.egressPackets,
-                        label: "Egress",
+                        label: "home.packet.egress",
                     )
                     Spacer()
                 }
@@ -92,13 +92,13 @@ struct HomeView: View {
     private var trafficRow: some View {
         HStack(spacing: 12) {
             TrafficTile(
-                title: "Upload",
+                title: "home.traffic.upload",
                 bytes: ipcBridge.currentTraffic.uploadBytes,
                 rate: ipcBridge.currentTraffic.uploadRate,
                 systemImage: "arrow.up",
             )
             TrafficTile(
-                title: "Download",
+                title: "home.traffic.download",
                 bytes: ipcBridge.currentTraffic.downloadBytes,
                 rate: ipcBridge.currentTraffic.downloadRate,
                 systemImage: "arrow.down",
@@ -111,7 +111,7 @@ struct HomeView: View {
     private var proxyGroupsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Text("Proxy Groups")
+                Text("home.proxyGroups.header")
                     .font(.caption.smallCaps())
                     .foregroundStyle(.secondary)
                 Spacer()
@@ -129,7 +129,7 @@ struct HomeView: View {
                     HStack(spacing: 8) {
                         Image(systemName: "network.slash")
                             .foregroundStyle(.secondary)
-                        Text(placeholderText)
+                        Text(placeholderKey)
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                         Spacer()
@@ -158,11 +158,11 @@ struct HomeView: View {
         }
     }
 
-    private var placeholderText: String {
+    private var placeholderKey: LocalizedStringKey {
         switch vpnManager.stage {
-        case .connected: "Loading groups…"
-        case .connecting: "Connecting — groups appear when the engine is up."
-        default: "Connect to populate available groups."
+        case .connected: "home.proxyGroups.placeholder.connected"
+        case .connecting: "home.proxyGroups.placeholder.connecting"
+        default: "home.proxyGroups.placeholder.disconnected"
         }
     }
 
@@ -171,31 +171,31 @@ struct HomeView: View {
     private var auxiliaryNavSection: some View {
         VStack(spacing: 10) {
             NavRow(
-                title: "Connections",
+                title: "home.nav.connections",
                 systemImage: "chevron.right.square",
                 identifier: "home.nav.connections",
             ) { ConnectionsView() }
 
             NavRow(
-                title: "Rules",
+                title: "home.nav.rules",
                 systemImage: "arrow.triangle.branch",
                 identifier: "home.nav.rules",
             ) { RulesView() }
 
             NavRow(
-                title: "Providers",
+                title: "home.nav.providers",
                 systemImage: "tray.full",
                 identifier: "home.nav.providers",
             ) { ProvidersView() }
 
             NavRow(
-                title: "Diagnostics",
+                title: "home.nav.diagnostics",
                 systemImage: "stethoscope",
                 identifier: "home.nav.diagnostics",
             ) {
                 DiagnosticsPanelView()
                     .ignoresSafeArea(edges: .bottom)
-                    .navigationTitle("Diagnostics")
+                    .navigationTitle("home.nav.diagnostics")
                     .navigationBarTitleDisplayMode(.inline)
             }
         }
@@ -204,7 +204,10 @@ struct HomeView: View {
     // MARK: - Derived state
 
     private var profileName: String {
-        selected.first?.name ?? "No Profile"
+        selected.first?.name ?? String(
+            localized: "home.profile.none",
+            comment: "Placeholder shown in profile-name slot on Home when no subscription profile is selected",
+        )
     }
 
     private var isConnected: Bool {
@@ -227,12 +230,12 @@ struct HomeView: View {
         }
     }
 
-    private var toggleTitle: String {
+    private var toggleTitle: LocalizedStringKey {
         switch vpnManager.stage {
-        case .connected: "Disconnect"
-        case .connecting: "Connecting…"
-        case .stopping: "Disconnecting…"
-        default: "Connect"
+        case .connected: "home.toggle.disconnect"
+        case .connecting: "home.toggle.connecting"
+        case .stopping: "home.toggle.disconnecting"
+        default: "home.toggle.connect"
         }
     }
 
@@ -274,7 +277,10 @@ struct HomeView: View {
             groups = ProxyGroupModel.build(from: resp.proxies)
             groupsLoadError = nil
         } catch {
-            groupsLoadError = "API unavailable"
+            groupsLoadError = String(
+                localized: "home.error.apiUnavailable",
+                comment: "Inline error shown in Proxy Groups header when mihomo API is not reachable",
+            )
         }
     }
 
@@ -283,7 +289,10 @@ struct HomeView: View {
             try await mihomoAPI.selectProxy(group: group, name: proxy)
             await refreshGroupsIfConnected()
         } catch {
-            groupsLoadError = "select failed"
+            groupsLoadError = String(
+                localized: "home.error.selectFailed",
+                comment: "Inline error shown in Proxy Groups header when selecting a proxy fails",
+            )
         }
     }
 
@@ -462,7 +471,7 @@ private struct DelayBadge: View {
 private struct PacketStat: View {
     let systemImage: String
     let count: Int64
-    let label: String
+    let label: LocalizedStringKey
 
     var body: some View {
         HStack(spacing: 6) {
@@ -500,7 +509,7 @@ private struct StageDot: View {
 }
 
 private struct TrafficTile: View {
-    let title: String
+    let title: LocalizedStringKey
     let bytes: Int64
     let rate: Int64
     let systemImage: String
@@ -514,9 +523,12 @@ private struct TrafficTile: View {
                 Text(ByteCountFormatter.string(fromByteCount: rate, countStyle: .binary) + "/s")
                     .font(.title3.bold())
                     .monospacedDigit()
-                Text("Total " + ByteCountFormatter.string(fromByteCount: bytes, countStyle: .binary))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Text(
+                    "home.traffic.total \(ByteCountFormatter.string(fromByteCount: bytes, countStyle: .binary))",
+                    comment: "Total bytes label under the rate display; %@ = formatted byte count",
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -524,7 +536,7 @@ private struct TrafficTile: View {
 }
 
 private struct NavRow<Destination: View>: View {
-    let title: String
+    let title: LocalizedStringKey
     let systemImage: String
     let identifier: String
     @ViewBuilder let destination: () -> Destination

--- a/App/Sources/Views/LogsView.swift
+++ b/App/Sources/Views/LogsView.swift
@@ -11,15 +11,15 @@ struct LogsView: View {
     var body: some View {
         VStack {
             HStack {
-                Picker("Level", selection: $level) {
-                    Text("debug").tag("debug")
-                    Text("info").tag("info")
-                    Text("warning").tag("warning")
-                    Text("error").tag("error")
+                Picker("logs.picker.level", selection: $level) {
+                    Text("logs.level.debug").tag("debug")
+                    Text("logs.level.info").tag("info")
+                    Text("logs.level.warning").tag("warning")
+                    Text("logs.level.error").tag("error")
                 }
                 .pickerStyle(.segmented)
                 .accessibilityIdentifier("logs.levelPicker")
-                Toggle("Auto-scroll", isOn: $autoScroll)
+                Toggle("logs.toggle.autoScroll", isOn: $autoScroll)
                     .labelsHidden()
                     .toggleStyle(.button)
                     .accessibilityIdentifier("logs.autoScrollToggle")
@@ -35,9 +35,9 @@ struct LogsView: View {
                 .overlay {
                     if entries.isEmpty {
                         ContentUnavailableView(
-                            "No logs",
+                            "logs.empty.title",
                             systemImage: "text.alignleft",
-                            description: Text("Logs appear when the tunnel is active."),
+                            description: Text("logs.empty.description"),
                         )
                         .accessibilityIdentifier("logs.emptyState")
                     }
@@ -55,7 +55,10 @@ struct LogsView: View {
                 errorBanner(errorMessage)
             }
         }
-        .navigationTitle("Logs (\(entries.count))")
+        .navigationTitle(Text(
+            "logs.nav.titleFormat \(entries.count)",
+            comment: "Logs screen navigation title; %lld = entry count",
+        ))
         .task(id: level) { await subscribe() }
     }
 

--- a/App/Sources/Views/ProvidersView.swift
+++ b/App/Sources/Views/ProvidersView.swift
@@ -22,9 +22,9 @@ struct ProvidersView: View {
         .overlay {
             if providers.isEmpty {
                 ContentUnavailableView(
-                    "No providers",
+                    "providers.empty.title",
                     systemImage: "tray",
-                    description: Text("Providers appear when a profile is loaded."),
+                    description: Text("providers.empty.description"),
                 )
                 .accessibilityIdentifier("providers.emptyState")
             }
@@ -34,7 +34,10 @@ struct ProvidersView: View {
                 errorBanner(errorMessage)
             }
         }
-        .navigationTitle("Providers (\(providers.count))")
+        .navigationTitle(Text(
+            "providers.nav.titleFormat \(providers.count)",
+            comment: "Providers screen navigation title; %lld = provider count",
+        ))
         .task { await load() }
         .refreshable { await load() }
     }
@@ -59,7 +62,10 @@ struct ProvidersView: View {
                     .frame(minWidth: 44, minHeight: 44)
             }
             .buttonStyle(.borderless)
-            .accessibilityLabel("Health check \(provider.name)")
+            .accessibilityLabel(Text(
+                "providers.a11y.healthCheck \(provider.name)",
+                comment: "Providers section health-check button a11y label; %@ = provider name",
+            ))
             .accessibilityIdentifier("providers.section.\(slug).healthCheck")
         }
     }
@@ -95,7 +101,10 @@ struct ProvidersView: View {
                         .frame(minWidth: 44, minHeight: 44)
                 }
                 .buttonStyle(.borderless)
-                .accessibilityLabel("Test \(proxy.name)")
+                .accessibilityLabel(Text(
+                    "providers.a11y.test \(proxy.name)",
+                    comment: "Providers row test-delay button a11y label; %@ = proxy name",
+                ))
                 .accessibilityIdentifier("providers.row.\(providerSlug).\(proxySlug).testButton")
             }
         }

--- a/App/Sources/Views/RulesView.swift
+++ b/App/Sources/Views/RulesView.swift
@@ -16,9 +16,9 @@ struct RulesView: View {
         .overlay {
             if rules.isEmpty {
                 ContentUnavailableView(
-                    "No rules",
+                    "rules.empty.title",
                     systemImage: "arrow.triangle.branch",
-                    description: Text("Rules appear when a profile is loaded."),
+                    description: Text("rules.empty.description"),
                 )
                 .accessibilityIdentifier("rules.emptyState")
             }
@@ -28,7 +28,10 @@ struct RulesView: View {
                 errorBanner(errorMessage)
             }
         }
-        .navigationTitle("Rules (\(rules.count))")
+        .navigationTitle(Text(
+            "rules.nav.titleFormat \(rules.count)",
+            comment: "Rules screen navigation title; %lld = rule count",
+        ))
         .refreshable { await load() }
         .task { await load() }
     }

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -13,43 +13,47 @@ struct SettingsView: View {
 
     var body: some View {
         Form {
-            Section("General") {
-                Toggle("Allow LAN", isOn: binding(\.allowLan))
+            Section("settings.section.general") {
+                Toggle("settings.toggle.allowLan", isOn: binding(\.allowLan))
                     .accessibilityIdentifier("settings.toggle.allowLan")
-                Toggle("IPv6", isOn: binding(\.ipv6))
+                Toggle("settings.toggle.ipv6", isOn: binding(\.ipv6))
                     .accessibilityIdentifier("settings.toggle.ipv6")
-                Picker("Log Level", selection: binding(\.logLevel)) {
-                    Text("Debug").tag("debug")
-                    Text("Info").tag("info")
-                    Text("Warning").tag("warning")
-                    Text("Error").tag("error")
-                    Text("Silent").tag("silent")
+                Picker("settings.picker.logLevel", selection: binding(\.logLevel)) {
+                    Text("settings.logLevel.debug").tag("debug")
+                    Text("settings.logLevel.info").tag("info")
+                    Text("settings.logLevel.warning").tag("warning")
+                    Text("settings.logLevel.error").tag("error")
+                    Text("settings.logLevel.silent").tag("silent")
                 }
                 .accessibilityIdentifier("settings.picker.logLevel")
             }
-            Section("DNS") {
-                TextField("DoH Server", text: binding(\.dohServer), prompt: Text("https://1.1.1.1/dns-query"))
-                    .keyboardType(.URL)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled(true)
-                    .accessibilityIdentifier("settings.field.dohServer")
+            Section("settings.section.dns") {
+                TextField(
+                    "settings.field.dohServer",
+                    text: binding(\.dohServer),
+                    prompt: Text("https://1.1.1.1/dns-query"),
+                )
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .accessibilityIdentifier("settings.field.dohServer")
             }
-            Section("Diagnostics") {
+            Section("settings.section.diagnostics") {
                 NavigationLink {
                     UserDiagnosticsView()
                 } label: {
-                    Label("Diagnostics", systemImage: "stethoscope")
+                    Label("settings.label.diagnostics", systemImage: "stethoscope")
                 }
                 .accessibilityIdentifier("settings.nav.diagnostics")
             }
-            Section("About") {
-                LabeledContent("Version", value: appVersion)
+            Section("settings.section.about") {
+                LabeledContent("settings.about.version", value: appVersion)
                     .contentShape(Rectangle())
                     .accessibilityIdentifier("settings.about.version")
                 #if DEBUG
                     .onTapGesture(count: 3) { showDebugPanel = true }
                 #endif
-                LabeledContent("Memory", value: memoryMB.map { "\($0) MB" } ?? "—")
+                LabeledContent("settings.about.memory", value: memoryMB.map { "\($0) MB" } ?? "—")
                     .accessibilityIdentifier("settings.about.memory")
             }
             #if DEBUG
@@ -67,7 +71,7 @@ struct SettingsView: View {
                 }
             #endif
         }
-        .navigationTitle("Settings")
+        .navigationTitle("settings.nav.title")
         #if DEBUG
             .navigationDestination(isPresented: $showDebugPanel) {
                 DiagnosticsPanelView()

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -16,9 +16,12 @@ struct SubscriptionsView: View {
                             .foregroundStyle(profile.isSelected ? .green : .secondary)
                         VStack(alignment: .leading, spacing: 4) {
                             Text(profile.name).font(.headline)
-                            Text("Updated \(profile.lastUpdated, style: .relative) ago")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            Text(
+                                "subscriptions.row.updatedAgo \(profile.lastUpdated, style: .relative)",
+                                comment: "Subscription row subtitle; %@ = relative time since last update",
+                            )
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                         }
                         Spacer()
                         Button {
@@ -38,14 +41,14 @@ struct SubscriptionsView: View {
                     Button(role: .destructive) {
                         try? service.delete(profile)
                     } label: {
-                        Label("Delete", systemImage: "trash")
+                        Label("common.delete", systemImage: "trash")
                     }
                 }
             }
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
-        .navigationTitle("Subscriptions")
+        .navigationTitle("subscriptions.nav.title")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {
@@ -59,8 +62,8 @@ struct SubscriptionsView: View {
         .sheet(isPresented: $showingAdd) {
             AddSubscriptionSheet(error: $error)
         }
-        .alert("Error", isPresented: .constant(error != nil)) {
-            Button("OK") { error = nil }
+        .alert("common.error", isPresented: .constant(error != nil)) {
+            Button("common.ok") { error = nil }
         } message: {
             Text(error ?? "")
         }
@@ -79,20 +82,22 @@ private struct AddSubscriptionSheet: View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Name", text: $name)
-                    TextField("URL", text: $url)
+                    TextField("subscriptions.add.field.name", text: $name)
+                    TextField("subscriptions.add.field.url", text: $url)
                         .keyboardType(.URL)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled(true)
                 }
             }
-            .navigationTitle("Add Subscription")
+            .navigationTitle("subscriptions.add.nav.title")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("common.cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(submitting ? "Adding…" : "Add") {
+                    Button(LocalizedStringKey(
+                        submitting ? "subscriptions.add.button.adding" : "subscriptions.add.button.add",
+                    )) {
                         submitting = true
                         Task {
                             do {

--- a/App/Sources/Views/TrafficView.swift
+++ b/App/Sources/Views/TrafficView.swift
@@ -17,7 +17,7 @@ struct TrafficView: View {
                 chartsScrollView
             }
         }
-        .navigationTitle("Traffic")
+        .navigationTitle("traffic.nav.title")
         .onChange(of: ipcBridge.currentTraffic) { _, snapshot in
             let sample = RateSample(
                 timestamp: snapshot.timestamp,
@@ -36,9 +36,9 @@ struct TrafficView: View {
 
     private var emptyState: some View {
         ContentUnavailableView(
-            "No traffic data yet",
+            "traffic.empty.title",
             systemImage: "chart.line.uptrend.xyaxis",
-            description: Text("Start the VPN to begin recording usage."),
+            description: Text("traffic.empty.description"),
         )
         .accessibilityIdentifier("traffic.emptyState")
     }
@@ -49,13 +49,13 @@ struct TrafficView: View {
                 speedCard
                 HStack(spacing: 12) {
                     TotalsTile(
-                        title: "Today",
+                        title: "traffic.tile.today",
                         tx: todayTotals.tx,
                         rx: todayTotals.rx,
                         identifier: "traffic.todayTile",
                     )
                     TotalsTile(
-                        title: "This Month",
+                        title: "traffic.tile.thisMonth",
                         tx: monthTotals.tx,
                         rx: monthTotals.rx,
                         identifier: "traffic.monthTile",
@@ -70,7 +70,7 @@ struct TrafficView: View {
     private var speedCard: some View {
         GlassCard {
             VStack(alignment: .leading, spacing: 8) {
-                Text("Speed")
+                Text("traffic.label.speed")
                     .font(.caption.smallCaps())
                     .foregroundStyle(.secondary)
                 Chart(samples) { sample in
@@ -88,7 +88,7 @@ struct TrafficView: View {
     private var historyCard: some View {
         GlassCard {
             VStack(alignment: .leading, spacing: 8) {
-                Text("Last 7 Days")
+                Text("traffic.label.last7Days")
                     .font(.caption.smallCaps())
                     .foregroundStyle(.secondary)
                 Chart(last7Days) { day in
@@ -132,7 +132,7 @@ struct TrafficView: View {
 }
 
 private struct TotalsTile: View {
-    let title: String
+    let title: LocalizedStringKey
     let tx: Int64
     let rx: Int64
     let identifier: String

--- a/App/Sources/Views/UserDiagnosticsView.swift
+++ b/App/Sources/Views/UserDiagnosticsView.swift
@@ -42,23 +42,23 @@ struct UserDiagnosticsView: View {
                 errorBanner(error)
             }
         }
-        .navigationTitle("Diagnostics")
+        .navigationTitle("userDiagnostics.nav.title")
     }
 
     private var directTcpSection: some View {
-        Section("Direct TCP") {
+        Section("userDiagnostics.section.directTcp") {
             DirectTcpCard(errorSink: $error)
         }
     }
 
     private var proxyHttpSection: some View {
-        Section("Proxy HTTP") {
+        Section("userDiagnostics.section.proxyHttp") {
             ProxyHttpCard(errorSink: $error)
         }
     }
 
     private var dnsSection: some View {
-        Section("DNS Resolver") {
+        Section("userDiagnostics.section.dns") {
             DnsCard(errorSink: $error)
         }
     }
@@ -66,9 +66,9 @@ struct UserDiagnosticsView: View {
     private var vpnRequiredSection: some View {
         Section {
             ContentUnavailableView(
-                "VPN required",
+                "userDiagnostics.empty.title",
                 systemImage: "network.slash",
-                description: Text("Connect to the proxy to run Proxy HTTP and DNS Resolver checks."),
+                description: Text("userDiagnostics.empty.description"),
             )
             .accessibilityIdentifier("userDiagnostics.emptyState")
         }
@@ -108,9 +108,12 @@ private struct DirectTcpCard: View {
                 .accessibilityLabel("Host and port")
                 .accessibilityIdentifier("userDiagnostics.directTcp.input")
             HStack {
-                Button(running ? "Testing…" : "Test", action: runTest)
-                    .disabled(running || input.isEmpty)
-                    .accessibilityIdentifier("userDiagnostics.directTcp.button")
+                Button(
+                    LocalizedStringKey(running ? "userDiagnostics.button.testing" : "userDiagnostics.button.test"),
+                    action: runTest,
+                )
+                .disabled(running || input.isEmpty)
+                .accessibilityIdentifier("userDiagnostics.directTcp.button")
                 Spacer()
                 if let result {
                     resultLabel(result)
@@ -125,7 +128,10 @@ private struct DirectTcpCard: View {
         guard !snapshot.isEmpty else { return }
         let parsed = parseHostPort(snapshot)
         guard let (host, port) = parsed else {
-            errorSink = "Expected host:port (e.g. 1.1.1.1:443)"
+            errorSink = String(
+                localized: "userDiagnostics.error.parseHostPort",
+                comment: "Shown when user-entered Direct TCP target doesn't parse as host:port",
+            )
             return
         }
         errorSink = nil
@@ -164,9 +170,12 @@ private struct ProxyHttpCard: View {
                 .accessibilityLabel("HTTP URL")
                 .accessibilityIdentifier("userDiagnostics.proxyHttp.input")
             HStack {
-                Button(running ? "Testing…" : "Test", action: runTest)
-                    .disabled(running || input.isEmpty)
-                    .accessibilityIdentifier("userDiagnostics.proxyHttp.button")
+                Button(
+                    LocalizedStringKey(running ? "userDiagnostics.button.testing" : "userDiagnostics.button.test"),
+                    action: runTest,
+                )
+                .disabled(running || input.isEmpty)
+                .accessibilityIdentifier("userDiagnostics.proxyHttp.button")
                 Spacer()
                 if let result {
                     resultLabel(result)
@@ -205,9 +214,12 @@ private struct DnsCard: View {
                 .accessibilityLabel("Domain name")
                 .accessibilityIdentifier("userDiagnostics.dns.input")
             HStack {
-                Button(running ? "Testing…" : "Test", action: runTest)
-                    .disabled(running || input.isEmpty)
-                    .accessibilityIdentifier("userDiagnostics.dns.button")
+                Button(
+                    LocalizedStringKey(running ? "userDiagnostics.button.testing" : "userDiagnostics.button.test"),
+                    action: runTest,
+                )
+                .disabled(running || input.isEmpty)
+                .accessibilityIdentifier("userDiagnostics.dns.button")
                 Spacer()
                 if let result {
                     resultLabel(result)

--- a/App/Sources/Views/YamlEditorView.swift
+++ b/App/Sources/Views/YamlEditorView.swift
@@ -14,9 +14,9 @@ struct YamlEditorView: View {
             .overlay {
                 if text.isEmpty {
                     ContentUnavailableView(
-                        "Empty config",
+                        "yamlEditor.empty.title",
                         systemImage: "doc.text",
-                        description: Text("Paste a Clash YAML config to start editing."),
+                        description: Text("yamlEditor.empty.description"),
                     )
                     .accessibilityIdentifier("yamlEditor.emptyState")
                 }
@@ -26,19 +26,22 @@ struct YamlEditorView: View {
                     errorBanner(error)
                 }
             }
-            .navigationTitle("Edit Config")
+            .navigationTitle("yamlEditor.nav.title")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Revert") { text = profile.yamlBackup }
-                        .accessibilityLabel("Revert to last saved config")
+                    Button("yamlEditor.button.revert") { text = profile.yamlBackup }
+                        .accessibilityLabel("yamlEditor.a11y.revert")
                         .accessibilityIdentifier("yamlEditor.revertButton")
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(saving ? "Saving…" : "Save", action: save)
-                        .disabled(saving || text.isEmpty)
-                        .accessibilityLabel("Save config")
-                        .accessibilityIdentifier("yamlEditor.saveButton")
+                    Button(
+                        LocalizedStringKey(saving ? "yamlEditor.button.saving" : "yamlEditor.button.save"),
+                        action: save,
+                    )
+                    .disabled(saving || text.isEmpty)
+                    .accessibilityLabel("yamlEditor.a11y.save")
+                    .accessibilityIdentifier("yamlEditor.saveButton")
                 }
             }
             .onAppear { text = profile.yamlContent }
@@ -96,8 +99,12 @@ enum MihomoConfigValidator {
 enum MihomoConfigError: LocalizedError {
     case invalid(String)
     var errorDescription: String? {
-        if case let .invalid(msg) = self { return msg.isEmpty ? "Invalid config" : msg }
-        return "Invalid config"
+        let fallback = String(
+            localized: "yamlEditor.error.invalid",
+            comment: "Fallback message when config validation fails without engine detail",
+        )
+        if case let .invalid(msg) = self { return msg.isEmpty ? fallback : msg }
+        return fallback
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `App/Resources/en.lproj/Localizable.strings` as English source-of-truth with screen-namespaced keys (`tabs.*`, `home.*`, `subscriptions.*`, `connections.*`, `rules.*`, `logs.*`, `providers.*`, `yamlEditor.*`, `settings.*`, `userDiagnostics.*`, `traffic.*`, `content.*`, `common.*`).
- Add `App/Resources/zh-Hans.lproj/Localizable.strings` as identity placeholder (English copies) so zh-Hans locale exercises the `.lproj` wiring end-to-end. Translators overwrite values; keys stay frozen per screen namespace.
- Refactor 11 SwiftUI views to use `LocalizedStringKey` / `String(localized:)` / `Text(_:comment:)` — struct field types widened to `LocalizedStringKey` where needed (PacketStat, TrafficTile, NavRow, TotalsTile).

## Deliberately not localized
Documented in en.lproj header:
- `HomeView.stageBadgeText` — QA harness pins on lowercase ASCII ("disconnected" / "connecting" / "connected" / "disconnecting").
- `DiagnosticsViewController` rows — OCR harness pins on uppercase ASCII "CHECK: PASS/FAIL" format.
- `UserDiagnosticsView` error reason codes (`tunnel_not_running`, `connect_failed`, `encode_failed`, `unknown_error`) — stable diagnostic IDs.
- Chart axis raw values (`t`, `up`, `down`, `series`, `day`, `tx`, `rx`) — internal chart bindings, not displayed text.
- `TextField` placeholder examples (`1.1.1.1:443`, `example.com`, `https://…/generate_204`, `https://1.1.1.1/dns-query`) — URL/address examples, not prose.
- Log-level `Picker .tag()` values — model keys, not display text (display labels ARE localized).
- T5.3 a11y labels added in parallel (`"Refresh \(name)"`, `"Add subscription"`, `"Host and port"`, `"HTTP URL"`, `"Hostname"`) — out-of-scope for T5.4 extraction sweep; follow-up pass can fold these in.

## Coordination
Rebased onto `origin/main` 5725369 (Dev's T5.3 Accessibility & Dynamic Type audit). Auto-merge succeeded cleanly; Dev's `frame(minWidth: 44, minHeight: 44)` hit-target sizing and accessibility labels preserved on top.

## Path B admin-bypass attestation (per CLAUDE.md 93144cb)
1. `swiftformat --lint .` → 0 violations (run at repo root of `meow-ios-qa-t5-4` worktree).
2. `swiftlint` → 0 violations (70 files linted, 0 serious).
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` → **TEST SUCCEEDED** (99 tests, 20 suites). Same for `-only-testing:MeowUITests` → **TEST SUCCEEDED** (24 tests, 23 skipped per gate markers).
4. `git diff origin/main --stat` verified — 13 files: 11 view files + 2 new `.lproj/Localizable.strings`. No accidental additions.
5. This checklist with concrete command lines.

## Test plan
- [x] swiftformat --lint clean
- [x] swiftlint clean
- [x] MeowTests suite green on iPhone 17 / iOS 26
- [x] MeowUITests suite green on iPhone 17 / iOS 26
- [x] `project.yml` needs no edits — `App/Resources` already in `App` target sources; `.lproj` subdirs auto-included by xcodegen.
- [ ] Visual check on iPhone 17 simulator (English locale) + locale toggle to Simplified Chinese (expect identity-English display confirming zh-Hans.lproj wire-up) — deferred to post-merge smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)