### PR TITLE
Use Local.xcconfig for release signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ build-output/
 App/Resources/geox/*.mmdb
 
 # ---- Secrets / local ----
+Local.xcconfig
 local.properties
 *.mobileprovision
 *.certSigningRequest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# meow-ios — Contributor Guide for Codex
+
+## Workflow Rules
+
+### Run lint + tests locally before pushing
+
+To save GitHub Actions minutes and keep the red-main failure mode from coming back, always run lint and the full relevant test suite locally before pushing to the remote.
+
+- Before `git push` on any Swift / Rust / YAML change, run the local equivalents of the CI jobs your diff touches:
+  - **Swift:** `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17'` against the relevant test bundles (`MeowTests`, `MeowUITests`, `MeowIntegrationTests`).
+  - **Rust:** `scripts/build-rust.sh`, plus `cargo test` in `core/rust/mihomo-ios-ffi/` where relevant.
+  - **Swift lint:** `swiftlint` **and** `swiftformat --lint .` at the repo root. CI's `lint` job runs both and fails if either does — passing one is not sufficient. The two tools have non-overlapping rule sets: swiftlint catches style/API-usage issues, swiftformat catches formatting/structural ones (`redundantSelf`, spacing, ordering, etc.). Install via `brew install swiftlint swiftformat` if missing.
+- If a local run fails, fix it before pushing. Do not push "to see what CI says."
+- Docs / infra-only changes (no Swift / Rust / YAML touched) don't need the full suite — skip what isn't relevant.
+- Also check `gh run list --branch main --workflow=ci.yml --limit=1` before opening a PR so you know whether main's baseline is green. "Merging to red main" should be a known condition, not a discovery.
+
+### Admin-bypass rebase-merge (when you can skip waiting for CI)
+
+Two paths use `gh pr merge <n> --rebase --admin --delete-branch` to land a PR without waiting for the remote CI run to finish. Both require `--rebase` (keep commit history linear) and `--admin` (override required-checks). Pick the path that matches the PR's diff; when in doubt, run full CI.
+
+#### Path A — Non-code PRs (docs, static assets, AGENTS.md)
+
+If a PR's diff touches only non-code paths, bypass CI regardless of local test state.
+
+- "Non-code" = no changes under `App/`, `MeowCore/`, `MeowShared/`, `MeowTests/`, `MeowUITests/`, `MeowIntegrationTests/`, `core/`, `scripts/`, `project.yml`, `Cargo.*`, `Package.*`, `Podfile*`. Docs (`*.md`, `docs/`), AGENTS.md, `.gitignore`, README, LICENSE, images, and other static assets are all safe to bypass.
+- **Workflow files under `.github/workflows/*.yml` are NOT non-code for this rule.** Workflow logic can only be validated when the workflow actually runs (i.e., post-merge), so there is no local-CI-green substitute. Workflow-touching PRs always require a full remote CI run before merge.
+
+#### Path B — Code PRs with local-CI-green attestation
+
+If a PR's diff touches code paths (Swift, Rust, project.yml, Podfile, etc.), bypass is permitted **only** when ALL of the following are true and the PR description explicitly attests to each:
+
+1. `swiftformat --lint .` ran locally at the repo root → 0 violations.
+2. `swiftlint` ran locally at the repo root → 0 violations.
+3. The `xcodebuild test` suites matching the diff ran locally on an iOS 26 simulator (e.g., iPhone 17) → all green. For Swift changes: at minimum `MeowTests`; add `MeowUITests` for UI diffs, `MeowIntegrationTests` for service-layer diffs. For Rust / FFI changes: add `scripts/build-rust.sh` + `cargo test` in `core/rust/mihomo-ios-ffi/`.
+4. `git diff origin/main...HEAD --stat` was verified — the file list matches what the PR intends to change and contains no accidental additions. (The PR #28 admin-with-code lesson: bypassing without checking the diff base is how unintended code ends up in a skip-CI merge.)
+5. PR description includes a checklist attesting to (1)-(4), with the concrete command lines that were run.
+
+Caveats:
+- **Workflow files (`.github/workflows/*.yml`) are still excluded from Path B** — same rationale as Path A. If the PR touches both workflow files and code, run full CI.
+- If any of (1)-(4) was skipped or couldn't run cleanly, merge through full remote CI instead. Don't attest to a check you didn't actually run.
+- Path B is a speed optimization, not a quality shortcut. If you're unsure whether a test bundle is relevant, run it — that's cheaper than discovering a regression on main.
+- If a Path B merge surfaces a post-merge CI failure on main (lint, test, or build), the merger owns the immediate fix-forward PR. Bypass speed comes with bypass accountability.
+
+#### When to use which
+
+- Docs-only, AGENTS.md, images, README → Path A.
+- Swift / Rust / project.yml / Podfile → Path B, with attestation.
+- Mixed (docs + code in one PR) → run full CI. (Consider splitting the PR if the docs half is blocking.)
+- Workflow files (alone or mixed) → run full CI. Always.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -30,9 +30,19 @@ rustup target add aarch64-apple-ios aarch64-apple-ios-sim
   Run Locally" identity automatically. Contributors can compile and run on
   any iOS simulator without an Apple Developer account.
 - **Device builds** — open `meow-ios.xcodeproj` in Xcode, select each target
-  under Signing & Capabilities, and pick your team. Alternatively, export
-  `DEVELOPMENT_TEAM=<your-10-char-team-id>` before invoking xcodebuild —
-  Automatic signing style will pick it up.
+  under Signing & Capabilities, and pick your team. For command-line builds,
+  put your local signing overrides in `Local.xcconfig`:
+
+```xcconfig
+// Local build settings — DO NOT COMMIT
+DEVELOPMENT_TEAM = <TEAM_ID>
+APP_STORE_CONNECT_API_KEY_P8 = /absolute/path/to/AuthKey_<ASC_KEY_ID>.p8
+```
+
+  `scripts/build-release.sh` passes `-xcconfig Local.xcconfig` to `xcodebuild`
+  and reads `DEVELOPMENT_TEAM` from there by default. It also reads
+  `APP_STORE_CONNECT_API_KEY_P8` (or `SIGN_KEY_PATH`) so local release
+  credentials live in one place.
 - **CI release** (tag push → `release.yml`) uses App Store Connect API
   secrets (`APP_STORE_CONNECT_API_KEY_P8` / `KEY_ID` / `ISSUER_ID`); no
   team is embedded in the repo.
@@ -94,6 +104,23 @@ so source compiles before the `.a` exists, but link fails without it.
 2. (Optional while UI-only) Build the native lib: `./scripts/build-rust.sh`
 3. Open `meow-ios.xcodeproj`, select the `meow-ios` scheme.
 4. Run on an iOS 26 simulator or a provisioned device.
+
+For a signed device-ready Release build from the command line, use:
+
+```sh
+./scripts/build-release.sh
+```
+
+To build and install onto a connected iPhone:
+
+```sh
+./scripts/build-release.sh --device <device-id> --install
+```
+
+The script writes Xcode outputs into `build/DerivedData`, refreshes Swift
+packages in `build/SourcePackages`, rebuilds `MihomoCore.xcframework` by
+default, and emits the final `.app` path on success. Use `--xcconfig <path>`
+or `--team <TEAM_ID>` only if you need to override `Local.xcconfig`.
 
 When the XCFramework is absent the Swift source still compiles; engine
 operations log a warning and no-op. CI marks the native build required for

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Build the Release iOS app bundle, optionally installing it onto a connected device.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PROJECT_PATH="$ROOT/meow-ios.xcodeproj"
+SCHEME="meow-ios"
+CONFIGURATION="Release"
+DERIVED_DATA_PATH="$ROOT/build/DerivedData"
+SOURCE_PACKAGES_PATH="$ROOT/build/SourcePackages"
+APP_PATH="$DERIVED_DATA_PATH/Build/Products/${CONFIGURATION}-iphoneos/meow-ios.app"
+LOCAL_XCCONFIG_PATH="$ROOT/Local.xcconfig"
+
+DEVICE_ID=""
+INSTALL_APP=0
+SKIP_RUST_BUILD=0
+ALLOW_PROVISIONING_UPDATES=1
+CLEAN_BUILD=0
+TEAM_ID="${DEVELOPMENT_TEAM:-}"
+SIGN_KEY_PATH="${APP_STORE_CONNECT_API_KEY_P8:-}"
+
+read_xcconfig_value() {
+    local key="$1"
+    local file="$2"
+
+    [[ -f "$file" ]] || return 1
+
+    awk -F '=' -v key="$key" '
+        $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+            value = $2
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            gsub(/"/, "", value)
+            print value
+            exit
+        }
+    ' "$file"
+}
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/build-release.sh [options]
+
+Build the meow-ios Release app bundle for iPhoneOS.
+
+Options:
+  --xcconfig <path>              Override the Local.xcconfig path.
+  --team <team-id>               Override DEVELOPMENT_TEAM for signing.
+  --device <device-id>           Build for a specific connected device.
+  --install                      Install the built .app onto the device from --device.
+  --skip-rust-build              Skip rebuilding MihomoCore.xcframework first.
+  --no-provisioning-updates      Do not pass -allowProvisioningUpdates to xcodebuild.
+  --clean                        Remove repo-local DerivedData and SourcePackages first.
+  -h, --help                     Show this help text.
+
+Examples:
+  ./scripts/build-release.sh
+  ./scripts/build-release.sh --xcconfig ./Local.xcconfig
+  ./scripts/build-release.sh --device <device-id> --install
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --xcconfig)
+            LOCAL_XCCONFIG_PATH="${2:-}"
+            shift 2
+            ;;
+        --team)
+            TEAM_ID="${2:-}"
+            shift 2
+            ;;
+        --device)
+            DEVICE_ID="${2:-}"
+            shift 2
+            ;;
+        --install)
+            INSTALL_APP=1
+            shift
+            ;;
+        --skip-rust-build)
+            SKIP_RUST_BUILD=1
+            shift
+            ;;
+        --no-provisioning-updates)
+            ALLOW_PROVISIONING_UPDATES=0
+            shift
+            ;;
+        --clean)
+            CLEAN_BUILD=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -f "$LOCAL_XCCONFIG_PATH" ]]; then
+    if [[ -z "$TEAM_ID" ]]; then
+        TEAM_ID="$(read_xcconfig_value "DEVELOPMENT_TEAM" "$LOCAL_XCCONFIG_PATH" || true)"
+    fi
+    if [[ -z "$SIGN_KEY_PATH" ]]; then
+        SIGN_KEY_PATH="$(read_xcconfig_value "APP_STORE_CONNECT_API_KEY_P8" "$LOCAL_XCCONFIG_PATH" || true)"
+    fi
+    if [[ -z "$SIGN_KEY_PATH" ]]; then
+        SIGN_KEY_PATH="$(read_xcconfig_value "SIGN_KEY_PATH" "$LOCAL_XCCONFIG_PATH" || true)"
+    fi
+fi
+
+if [[ -z "$TEAM_ID" ]]; then
+    echo "note: DEVELOPMENT_TEAM not found in Local.xcconfig or environment; Xcode will use the project's current signing configuration."
+fi
+
+if [[ -n "$SIGN_KEY_PATH" && ! -f "$SIGN_KEY_PATH" ]]; then
+    echo "warning: signing key path from Local.xcconfig does not exist: $SIGN_KEY_PATH" >&2
+fi
+
+if [[ "$INSTALL_APP" -eq 1 && -z "$DEVICE_ID" ]]; then
+    echo "error: --install requires --device <device-id>." >&2
+    exit 1
+fi
+
+if [[ "$CLEAN_BUILD" -eq 1 ]]; then
+    rm -rf "$DERIVED_DATA_PATH" "$SOURCE_PACKAGES_PATH"
+fi
+
+mkdir -p "$ROOT/build"
+
+if [[ "$SKIP_RUST_BUILD" -eq 0 ]]; then
+    "$ROOT/scripts/build-rust.sh"
+fi
+
+DESTINATION="generic/platform=iOS"
+if [[ -n "$DEVICE_ID" ]]; then
+    DESTINATION="id=$DEVICE_ID"
+fi
+
+XCODEBUILD_ARGS=(
+    -project "$PROJECT_PATH"
+    -scheme "$SCHEME"
+    -configuration "$CONFIGURATION"
+    -destination "$DESTINATION"
+    -derivedDataPath "$DERIVED_DATA_PATH"
+    -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH"
+    build
+)
+
+if [[ -f "$LOCAL_XCCONFIG_PATH" ]]; then
+    XCODEBUILD_ARGS=(-xcconfig "$LOCAL_XCCONFIG_PATH" "${XCODEBUILD_ARGS[@]}")
+fi
+
+if [[ "$ALLOW_PROVISIONING_UPDATES" -eq 1 ]]; then
+    XCODEBUILD_ARGS=(-allowProvisioningUpdates "${XCODEBUILD_ARGS[@]}")
+fi
+
+if [[ -n "$TEAM_ID" ]]; then
+    XCODEBUILD_ARGS+=("DEVELOPMENT_TEAM=$TEAM_ID")
+fi
+
+echo "==> Building $SCHEME ($CONFIGURATION)"
+echo "==> Destination: $DESTINATION"
+if [[ -f "$LOCAL_XCCONFIG_PATH" ]]; then
+    echo "==> Local xcconfig: $LOCAL_XCCONFIG_PATH"
+fi
+if [[ -n "$TEAM_ID" ]]; then
+    echo "==> Signing team: $TEAM_ID"
+fi
+if [[ -n "$SIGN_KEY_PATH" ]]; then
+    echo "==> Signing key path: $SIGN_KEY_PATH"
+fi
+xcodebuild "${XCODEBUILD_ARGS[@]}"
+
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "error: expected app bundle missing at $APP_PATH" >&2
+    exit 1
+fi
+
+echo "==> Release app bundle: $APP_PATH"
+
+if [[ "$INSTALL_APP" -eq 1 ]]; then
+    echo "==> Installing app onto device $DEVICE_ID"
+    xcrun devicectl device install app --device "$DEVICE_ID" "$APP_PATH"
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/build-release.sh` to build a signed Release `.app` bundle using a gitignored `Local.xcconfig` for team/identity/profile settings.
- Document the release build flow in `docs/BUILD.md` and add operator notes to `AGENTS.md`.
- Ignore `Local.xcconfig` so local signing material doesn't leak into the repo.

## Test plan
- [ ] `scripts/build-release.sh` produces a signed `.app` against a valid `Local.xcconfig`.
- [ ] Fresh clone without `Local.xcconfig` fails with a clear error from the script.
- [ ] `docs/BUILD.md` steps reproduce the build on a clean machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)