### PR TITLE
fix(packettunnel): surface engine start failure publicly + bundle Country.mmdb

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -48,6 +48,8 @@
 "home.nav.diagnostics" = "Diagnostics";
 "home.error.apiUnavailable" = "API unavailable";
 "home.error.selectFailed" = "select failed";
+"home.error.tunnelFailed.title" = "Couldn't start tunnel";
+"home.error.dismiss" = "Dismiss";
 
 
 /* Subscriptions */

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -52,6 +52,8 @@
 "home.nav.diagnostics" = "Diagnostics";
 "home.error.apiUnavailable" = "API unavailable";
 "home.error.selectFailed" = "select failed";
+"home.error.tunnelFailed.title" = "Couldn't start tunnel";
+"home.error.dismiss" = "Dismiss";
 
 
 /* Subscriptions */

--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -11,6 +11,13 @@ import Observation
 final class VpnManager {
     private(set) var stage: VpnStage = .idle
     private(set) var lastError: String?
+
+    /// Clear the user-visible error banner. Called when the user dismisses it
+    /// or when a new connect attempt starts.
+    func clearError() {
+        lastError = nil
+    }
+
     private var manager: NETunnelProviderManager?
     // nonisolated(unsafe): written only from attach() on MainActor, read from
     // deinit (which is nonisolated). NotificationCenter.removeObserver is
@@ -42,6 +49,7 @@ final class VpnManager {
     /// Kick off a connect. Caller should have already written the selected
     /// profile YAML into the App Group container.
     func connect() async {
+        lastError = nil
         do {
             if manager == nil { await refresh() }
             guard let manager else { return }
@@ -83,6 +91,14 @@ final class VpnManager {
             let status = mgr.connection.status
             Task { @MainActor in
                 self.stage = self.map(status)
+                // When the extension aborts startup (engine.start throws) the
+                // connection transitions straight to .disconnected with no
+                // thrown NEVPNManagerError. The provider writes the Rust error
+                // into shared state before returning — surface it here so the
+                // UI can show the actual reason instead of a silent toggle.
+                if status == .disconnected, let msg = SharedStore.readState()?.errorMessage, !msg.isEmpty {
+                    self.lastError = msg
+                }
             }
         }
     }

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -16,6 +16,9 @@ struct HomeView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
+                if let message = vpnManager.lastError {
+                    errorBanner(message)
+                }
                 primaryCard
                 trafficRow
                 proxyGroupsSection
@@ -29,6 +32,35 @@ struct HomeView: View {
             await refreshGroupsIfConnected()
         }
         .refreshable { await refreshGroupsIfConnected() }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("home.error.tunnelFailed.title")
+                    .font(.subheadline.weight(.semibold))
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            Spacer(minLength: 8)
+            Button {
+                vpnManager.clearError()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("home.error.dismiss")
+            .accessibilityIdentifier("home.error.dismiss")
+        }
+        .padding(12)
+        .background(.regularMaterial, in: .rect(cornerRadius: 12))
+        .accessibilityIdentifier("home.error.banner")
     }
 
     // MARK: - Primary card

--- a/PacketTunnel/Sources/PacketTunnelProvider.swift
+++ b/PacketTunnel/Sources/PacketTunnelProvider.swift
@@ -40,7 +40,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
                 writeState(.connected, profileID: profileID)
                 completionHandler(nil)
             } catch {
-                log.error("engine start failed: \(error.localizedDescription)")
+                log.error("engine start failed: \(error.localizedDescription, privacy: .public)")
                 writeState(.error, errorMessage: error.localizedDescription)
                 completionHandler(error)
             }
@@ -133,7 +133,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             do {
                 try await engine?.reloadConfig()
             } catch {
-                log.error("reload failed: \(error.localizedDescription)")
+                log.error("reload failed: \(error.localizedDescription, privacy: .public)")
             }
         }
     }
@@ -152,7 +152,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             try SharedStore.writeState(state)
             DarwinBridge.post(.state)
         } catch {
-            log.error("failed to write state: \(error.localizedDescription)")
+            log.error("failed to write state: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/PacketTunnel/Sources/TunnelEngine.swift
+++ b/PacketTunnel/Sources/TunnelEngine.swift
@@ -154,7 +154,7 @@ final class TunnelEngine: @unchecked Sendable {
                 try SharedStore.writeTraffic(snapshot)
                 DarwinBridge.post(.traffic)
             } catch {
-                log.error("traffic write failed: \(error.localizedDescription)")
+                log.error("traffic write failed: \(error.localizedDescription, privacy: .public)")
             }
         }
     }
@@ -165,7 +165,16 @@ final class TunnelEngine: @unchecked Sendable {
     }
 }
 
-enum TunnelEngineError: Error {
+enum TunnelEngineError: LocalizedError {
     case engineStartFailed(String)
     case tunStartFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .engineStartFailed(detail):
+            "engine start failed" + (detail.isEmpty ? "" : ": \(detail)")
+        case let .tunStartFailed(detail):
+            "tun start failed" + (detail.isEmpty ? "" : ": \(detail)")
+        }
+    }
 }

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -139,6 +139,8 @@ if [[ "$SKIP_RUST_BUILD" -eq 0 ]]; then
     "$ROOT/scripts/build-rust.sh"
 fi
 
+"$ROOT/scripts/fetch-geo-assets.sh"
+
 DESTINATION="generic/platform=iOS"
 if [[ -n "$DEVICE_ID" ]]; then
     DESTINATION="id=$DEVICE_ID"

--- a/scripts/fetch-geo-assets.sh
+++ b/scripts/fetch-geo-assets.sh
@@ -30,6 +30,16 @@ URL="https://raw.githubusercontent.com/${UPSTREAM_REPO}/${UPSTREAM_COMMIT}/${UPS
 
 mkdir -p "$DEST_DIR"
 
+if [ -f "$DEST_FILE" ]; then
+    EXISTING_SIZE=$(wc -c <"$DEST_FILE" | tr -d ' ')
+    EXISTING_SHA256=$(shasum -a 256 "$DEST_FILE" | awk '{print $1}')
+    if [ "$EXISTING_SIZE" = "$EXPECTED_SIZE_BYTES" ] && [ "$EXISTING_SHA256" = "$EXPECTED_SHA256" ]; then
+        echo "==> Country.mmdb already staged at ${DEST_FILE} (sha256 match) — skipping fetch"
+        exit 0
+    fi
+    echo "==> Existing Country.mmdb does not match pin (size=${EXISTING_SIZE} sha256=${EXISTING_SHA256}); refetching"
+fi
+
 echo "==> Fetching ${URL}"
 curl --fail --silent --show-error --location --output "$TMP_FILE" "$URL"
 


### PR DESCRIPTION
## Summary

- **Error logging**: mark `error.localizedDescription` interpolations `.public` in `PacketTunnelProvider.swift` (engine-start, reload, state-write) and `TunnelEngine.swift` (traffic-write) so `idevicesyslog` / `log stream` show the actual message instead of `<private>`. Diagnostic-critical only; `.debug` sites untouched. Also conform `TunnelEngineError` to `LocalizedError` so the wrapped Rust detail string propagates through `error.localizedDescription` instead of "The operation couldn't be completed".
- **Error surface in UI**: `VpnManager.attach` now reads `SharedStore.readState()?.errorMessage` on `.disconnected` transitions and publishes into `lastError`. `HomeView` renders a dismissible banner bound to `lastError`. Covers the silent-toggle-flipback failure mode the user hit today. New localization keys `home.error.tunnelFailed.title` + `home.error.dismiss` in both `en.lproj` and `zh-Hans.lproj`.
- **Country.mmdb bundling**: the file never shipped in Release IPAs because `scripts/fetch-geo-assets.sh` was never wired into any build path (Debug on the dev machine worked because someone had run the script manually once). Made `fetch-geo-assets.sh` idempotent on matching SHA-256 and invoked from `scripts/build-release.sh` before `xcodebuild`. `App/Resources/geox/*.mmdb` is gitignored so the file still isn't checked in — the download is defense-in-depth. CI workflow wiring (`release.yml` / `ci.yml` archive) is left for the pre-flight fixes task #2 per the workflow-files-require-remote-CI rule.

## Path B attestation

Non-workflow-file code PR. All four checks ran locally against `origin/main`:

1. `swiftformat --lint .` → 0 violations
2. `swiftlint --strict` → 0 violations, 70 files linted
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:<bundle>` → all green
   - MeowTests: 99 tests, 0 failures
   - MeowUITests: 24 tests (23 skipped per existing gating), 0 failures
   - MeowIntegrationTests: 26 tests, 0 failures
4. `scripts/build-rust.sh` → xcframework regenerated OK (device + simulator slices)
5. `git diff origin/main...HEAD --stat` — 8 files, 78 insertions, 5 deletions, no accidental additions

Also verified `scripts/fetch-geo-assets.sh` idempotency: first run fetches + verifies SHA-256, second run detects match + skips.

## Test plan

- [ ] Merge + reinstall on user's iPhone via `scripts/build-release.sh --device <id> --install`
- [ ] User taps connect on a real profile
- [ ] If tunnel still fails: actual Rust error shows up in both `idevicesyslog` and the Home banner
- [ ] Confirm `AssetSeeder: Country.mmdb missing from app bundle` warning no longer fires (mmdb is now staged by the release build)
- [ ] Follow-up PR: use the freshly-surfaced Rust error to root-cause the real engine failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)