### PR TITLE
fix(vpn): use RFC 5737 placeholder for tunnelRemoteAddress on iOS 26

### DIFF
--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -69,7 +69,11 @@ final class VpnManager {
     private func configureIfNeeded(_ mgr: NETunnelProviderManager) {
         let proto = (mgr.protocolConfiguration as? NETunnelProviderProtocol) ?? NETunnelProviderProtocol()
         proto.providerBundleIdentifier = "io.github.madeye.meow.PacketTunnel"
-        proto.serverAddress = "meow"
+        // RFC 5737 TEST-NET-1 placeholder — iOS 26 rejects non-RFC strings
+        // (e.g. "meow") at NEPacketTunnelNetworkSettings construction with
+        // "invalid tunnel remote address". The real proxy endpoint lives in
+        // the profile YAML consumed by the Rust engine, not here.
+        proto.serverAddress = "192.0.2.1"
         proto.providerConfiguration = [
             "appGroup": AppGroup.identifier,
         ]

--- a/PacketTunnel/Sources/PacketTunnelProvider.swift
+++ b/PacketTunnel/Sources/PacketTunnelProvider.swift
@@ -18,7 +18,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     ) {
         log.info("startTunnel")
 
-        let settings = TunnelSettings.make(serverAddress: protocolConfiguration.serverAddress ?? "meow")
+        let settings = TunnelSettings.make(serverAddress: protocolConfiguration.serverAddress ?? "192.0.2.1")
         let profileID = options?["profileID"] as? String
         Task { [weak self] in
             guard let self else {


### PR DESCRIPTION
## Summary

Root cause of the VPN connect failure surfaced by #51's banner: iOS 26 enforces RFC validity on the string passed to `NEPacketTunnelNetworkSettings(tunnelRemoteAddress:)`. The existing placeholder `"meow"` is neither a valid hostname label nor an IP, so the constructor rejects it with `"invalid tunnel remote address"` and the extension's `applySettings` throws before `engine.start` ever runs. Earlier iOS versions accepted any non-empty string — that's why Debug builds on older simulators happened to work; iOS 26 on device surfaces the real contract.

Two sites changed, both swap `"meow"` → `"192.0.2.1"` (RFC 5737 TEST-NET-1 reserved documentation range, conveys "placeholder, not a real endpoint" without implying localhost):

- `App/Sources/Services/VpnManager.swift:72` — `proto.serverAddress` written into `NETunnelProviderProtocol`
- `PacketTunnel/Sources/PacketTunnelProvider.swift:21` — fallback when `protocolConfiguration.serverAddress` is nil

The real proxy endpoint lives in the profile YAML consumed by the Rust engine; `tunnelRemoteAddress` is a placeholder for the NE framework and never dialed. No tunnel settings beyond that string are touched. Kept the fallback in PacketTunnelProvider rather than force-unwrapping — VpnManager does always set it, but a nil path through a non-controlled `NETunnelProviderProtocol` shouldn't crash the extension.

Credit: diagnosis was possible thanks to #51 (log privacy + `LocalizedError` conformance + in-app banner). Without that we'd still be staring at `<private>` in syslog.

## Out of scope (flagged for follow-up)

Parsing the profile YAML to derive the actual proxy server IP and wire it into `serverAddress` is a correctness improvement (would let Settings → General → VPN → Connections display the real endpoint), but it's meaningfully bigger — YAML parse in the app process, error handling for malformed profiles, UI for "no profile selected yet". Not required for v1.0 functional correctness; file a task if worth picking up post-ship.

## Path B attestation

Non-workflow-file code PR. All four checks ran locally against `origin/main` (739c7d7):

1. `swiftformat --lint .` → 0 violations
2. `swiftlint --strict` → 0 violations, 70 files linted
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -only-testing:MeowIntegrationTests` → all green (MeowTests 99/99, MeowUITests 24/24 with 23 pre-existing skipped, MeowIntegrationTests 26/26)
4. `scripts/build-rust.sh` → xcframework regenerated OK (device + simulator slices)
5. `git diff origin/main...HEAD --stat` — 2 files, +6/-2, no accidental additions

## Test plan

- [ ] Admin-merge + rebuild via `scripts/build-release.sh --device <id> --install`
- [ ] User taps connect — should transition `.connecting` → `.connected` without the error banner firing
- [ ] If a different error surfaces, #51's banner + `idevicesyslog` will show it; loop again

🤖 Generated with [Claude Code](https://claude.com/claude-code)