### PR TITLE
fix(vpn): exclude LAN routes so local devices stay reachable

### DIFF
--- a/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
+++ b/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
@@ -1,0 +1,68 @@
+import NetworkExtension
+import XCTest
+
+// `TunnelSettings.swift` is compiled into this test bundle directly (see
+// project.yml MeowIntegrationTests sources). App extensions are bundled
+// binaries, not linkable libraries, so @testable import PacketTunnel fails
+// at link time; shared-source target membership is the standard Xcode
+// pattern for exercising extension-internal code from a unit test.
+
+/// Offline, deterministic verification that `TunnelSettings.make(...)` emits
+/// the LAN-exclusion routes we promise users. If any route in the expected
+/// set is dropped, or a stray route sneaks in, this test fails — no device
+/// or packet capture required. Pair with a manual VPN-on/LAN-access smoke
+/// on device before ship.
+final class TunnelSettingsLANExclusionTests: XCTestCase {
+    func testMakeAppliesIPv4LANExcludedRoutesInDeclaredOrder() {
+        let expected: [(String, String)] = [
+            ("10.0.0.0", "255.0.0.0"),
+            ("172.16.0.0", "255.240.0.0"),
+            ("192.168.0.0", "255.255.0.0"),
+            ("169.254.0.0", "255.255.0.0"),
+            ("127.0.0.0", "255.0.0.0"),
+            ("224.0.0.0", "240.0.0.0"),
+            ("255.255.255.255", "255.255.255.255"),
+        ]
+
+        let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
+        let routes = settings.ipv4Settings?.excludedRoutes ?? []
+
+        XCTAssertEqual(routes.count, expected.count, "excludedRoutes count mismatch")
+        for (index, (address, mask)) in expected.enumerated() {
+            let route = routes[index]
+            XCTAssertEqual(route.destinationAddress, address, "index \(index) destinationAddress")
+            XCTAssertEqual(route.destinationSubnetMask, mask, "index \(index) destinationSubnetMask")
+        }
+    }
+
+    func testMakeAppliesIPv6LANExcludedRoutesInDeclaredOrder() {
+        let expected: [(String, Int)] = [
+            ("fc00::", 7),
+            ("fe80::", 10),
+            ("::1", 128),
+            ("ff00::", 8),
+        ]
+
+        let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
+        let routes = settings.ipv6Settings?.excludedRoutes ?? []
+
+        XCTAssertEqual(routes.count, expected.count, "excludedRoutes count mismatch")
+        for (index, (address, prefix)) in expected.enumerated() {
+            let route = routes[index]
+            XCTAssertEqual(route.destinationAddress, address, "index \(index) destinationAddress")
+            XCTAssertEqual(route.destinationNetworkPrefixLength.intValue, prefix, "index \(index) prefix length")
+        }
+    }
+
+    func testMakeStillRoutesAllTrafficByDefault() {
+        let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
+
+        let ipv4Included = settings.ipv4Settings?.includedRoutes ?? []
+        XCTAssertEqual(ipv4Included.count, 1, "catch-all default route should remain")
+        XCTAssertEqual(ipv4Included.first?.destinationAddress, "0.0.0.0")
+
+        let ipv6Included = settings.ipv6Settings?.includedRoutes ?? []
+        XCTAssertEqual(ipv6Included.count, 1)
+        XCTAssertEqual(ipv6Included.first?.destinationAddress, "::")
+    }
+}

--- a/PacketTunnel/Sources/TunnelSettings.swift
+++ b/PacketTunnel/Sources/TunnelSettings.swift
@@ -2,16 +2,47 @@ import Foundation
 import NetworkExtension
 
 enum TunnelSettings {
+    /// RFC 1918 private + link-local + loopback + multicast + broadcast.
+    /// Excluded from the tunnel so LAN (router, printer, NAS, AirPlay/Bonjour,
+    /// mDNS) stays reachable while the VPN is up. `gatewayAddress = nil` tells
+    /// iOS to route these direct via the interface default.
+    ///
+    /// Exposed as a computed property because `NEIPv4Route` is a non-Sendable
+    /// ObjC class and Swift 6 strict concurrency rejects a `static let` of it.
+    static var ipv4LanExcludedRoutes: [NEIPv4Route] {
+        [
+            route(address: "10.0.0.0", mask: "255.0.0.0"), // RFC 1918 Class A
+            route(address: "172.16.0.0", mask: "255.240.0.0"), // RFC 1918 Class B (172.16-172.31)
+            route(address: "192.168.0.0", mask: "255.255.0.0"), // RFC 1918 Class C
+            route(address: "169.254.0.0", mask: "255.255.0.0"), // Link-local (DHCP fallback)
+            route(address: "127.0.0.0", mask: "255.0.0.0"), // Loopback
+            route(address: "224.0.0.0", mask: "240.0.0.0"), // Multicast (mDNS, Bonjour, AirPlay)
+            route(address: "255.255.255.255", mask: "255.255.255.255"), // Limited broadcast
+        ]
+    }
+
+    /// IPv6 equivalents: ULA + link-local + loopback + multicast. Computed
+    /// for the same Sendable reason as `ipv4LanExcludedRoutes`.
+    static var ipv6LanExcludedRoutes: [NEIPv6Route] {
+        [
+            route6(address: "fc00::", prefix: 7), // Unique Local Addresses (ULA)
+            route6(address: "fe80::", prefix: 10), // Link-local
+            route6(address: "::1", prefix: 128), // Loopback
+            route6(address: "ff00::", prefix: 8), // Multicast
+        ]
+    }
+
     static func make(serverAddress: String) -> NEPacketTunnelNetworkSettings {
         let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: serverAddress)
 
         let ipv4 = NEIPv4Settings(addresses: ["172.19.0.1"], subnetMasks: ["255.255.255.252"])
         ipv4.includedRoutes = [NEIPv4Route.default()]
-        ipv4.excludedRoutes = []
+        ipv4.excludedRoutes = ipv4LanExcludedRoutes
         settings.ipv4Settings = ipv4
 
         let ipv6 = NEIPv6Settings(addresses: ["fdfe:dcba:9876::1"], networkPrefixLengths: [126])
         ipv6.includedRoutes = [NEIPv6Route.default()]
+        ipv6.excludedRoutes = ipv6LanExcludedRoutes
         settings.ipv6Settings = ipv6
 
         let dns = NEDNSSettings(servers: ["172.19.0.2"])
@@ -20,5 +51,13 @@ enum TunnelSettings {
 
         settings.mtu = 1500
         return settings
+    }
+
+    private static func route(address: String, mask: String) -> NEIPv4Route {
+        NEIPv4Route(destinationAddress: address, subnetMask: mask)
+    }
+
+    private static func route6(address: String, prefix: Int) -> NEIPv6Route {
+        NEIPv6Route(destinationAddress: address, networkPrefixLength: NSNumber(value: prefix))
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -160,6 +160,8 @@ targets:
       - path: MeowIntegrationTests
         excludes:
           - "README.md"
+      - path: PacketTunnel/Sources/TunnelSettings.swift
+        group: PacketTunnel/Sources
     dependencies:
       - target: meow-ios
       - package: MeowShared


### PR DESCRIPTION
## Summary

When the VPN is up, the default route (0.0.0.0/0 and ::/0) currently lifts *all* traffic into the tunnel — including packets bound for the user's own Wi-Fi router, printer, NAS, AirPlay/Bonjour discovery, and mDNS. Anything proxied through mihomo that targets a LAN host either black-holes or round-trips through the proxy, so local services break for as long as the VPN is connected.

Add explicit `excludedRoutes` for the ranges iOS should route around via the interface default rather than the tunnel. Split across two properties on `TunnelSettings`:

- `ipv4LanExcludedRoutes` → `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC 1918 private), `169.254.0.0/16` (link-local / DHCP fallback), `127.0.0.0/8` (loopback), `224.0.0.0/4` (multicast — mDNS/Bonjour/AirPlay), `255.255.255.255/32` (limited broadcast).
- `ipv6LanExcludedRoutes` → `fc00::/7` (ULA), `fe80::/10` (link-local), `::1/128` (loopback), `ff00::/8` (multicast).

Both are exposed as computed properties rather than `static let`. `NEIPv4Route` and `NEIPv6Route` are non-Sendable ObjC classes, and Swift 6 strict concurrency rejects a static-let of a non-Sendable element type. Computed access returns fresh instances per call — no shared state, no annotation needed, and the call sites inside `make()` allocate once per tunnel start so cost is nil.

Follow-up to PR #52 (which landed the `tunnelRemoteAddress` half of the scope expansion on task #7 before this half was ready).

## Test plan

Offline, deterministic — `MeowIntegrationTests/TunnelSettingsLANExclusionTests`:

- `testMakeAppliesIPv4LANExcludedRoutesInDeclaredOrder` — asserts count, addresses, and subnet masks of `ipv4Settings.excludedRoutes` match the v4 list above, in order.
- `testMakeAppliesIPv6LANExcludedRoutesInDeclaredOrder` — asserts count, addresses, and prefix lengths of `ipv6Settings.excludedRoutes` match the v6 list above, in order.
- `testMakeStillRoutesAllTrafficByDefault` — regression guard: the catch-all `includedRoutes` (`0.0.0.0/0`, `::/0`) is still present, so the tunnel continues to carry everything non-LAN.

`TunnelSettings.swift` is compiled into `MeowIntegrationTests` via shared-source target membership (`project.yml`) — app-extension targets aren't linkable as libraries into a test bundle, so `@testable import PacketTunnel` fails at link time. This is the standard Xcode pattern for exercising extension-internal code from a unit test.

On-device smoke (post-merge): install via `scripts/build-release.sh --device <id> --install`, connect VPN, verify router admin page + AirPlay discovery + printer LAN still reachable while public traffic goes through the proxy.

## Path B attestation

Non-workflow-file code PR. All four checks ran locally against `origin/main` (`b521fb3`):

1. `swiftformat --lint .` → 0 violations (80 files, 17 skipped)
2. `swiftlint --strict` → 0 violations, 71 files linted
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → MeowTests 99/99, MeowIntegrationTests 26/26 (including 3 new TunnelSettingsLANExclusionTests)
4. No Rust / FFI changes — `scripts/build-rust.sh` and cargo not relevant per CLAUDE.md Path B rule ("For Rust / FFI changes: add ...")
5. `git diff origin/main...HEAD --stat` — 3 files (TunnelSettings.swift, project.yml, TunnelSettingsLANExclusionTests.swift), +110/-1, no accidental additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)