### PR TITLE
fix(vpn): narrow LAN exclusion to skip tunnel's own 172.19/16

### DIFF
--- a/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
+++ b/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
@@ -14,9 +14,16 @@ import XCTest
 /// on device before ship.
 final class TunnelSettingsLANExclusionTests: XCTestCase {
     func testMakeAppliesIPv4LANExcludedRoutesInDeclaredOrder() {
+        // The 172.16/12 RFC 1918 block is split four ways so that 172.19/16
+        // (the tunnel's own virtual interface + DNS server) stays routed
+        // through the tunnel. A single 172.16.0.0/255.240.0.0 entry here would
+        // shadow the tunnel DNS and stop traffic.
         let expected: [(String, String)] = [
             ("10.0.0.0", "255.0.0.0"),
-            ("172.16.0.0", "255.240.0.0"),
+            ("172.16.0.0", "255.254.0.0"),
+            ("172.18.0.0", "255.255.0.0"),
+            ("172.20.0.0", "255.252.0.0"),
+            ("172.24.0.0", "255.248.0.0"),
             ("192.168.0.0", "255.255.0.0"),
             ("169.254.0.0", "255.255.0.0"),
             ("127.0.0.0", "255.0.0.0"),
@@ -35,9 +42,35 @@ final class TunnelSettingsLANExclusionTests: XCTestCase {
         }
     }
 
+    /// Regression guard: if anyone re-introduces a broad 172.16/12 exclusion
+    /// (mask 255.240.0.0), this test fails. That exact exclusion is what
+    /// swallowed the tunnel DNS server 172.19.0.2 in the original LAN-exclusion
+    /// shipment and killed all traffic.
+    func testMakeDoesNotExcludeTunnelSubnet() {
+        let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
+        let routes = settings.ipv4Settings?.excludedRoutes ?? []
+        for route in routes {
+            XCTAssertFalse(
+                route.destinationAddress == "172.16.0.0" && route.destinationSubnetMask == "255.240.0.0",
+                "172.16/12 exclusion shadows the tunnel's own 172.19/16 interface and must not be re-introduced",
+            )
+        }
+    }
+
+    func testMakeLeavesDNSMatchDomainsUnset() {
+        let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
+        XCTAssertNil(
+            settings.dnsSettings?.matchDomains,
+            "matchDomains must stay nil (default 'match all'); empty-string entries have been observed to drop queries",
+        )
+    }
+
     func testMakeAppliesIPv6LANExcludedRoutesInDeclaredOrder() {
+        // fc00::/7 (ULA) is intentionally absent for this iteration. The
+        // tunnel's own fdfe:dcba:9876::/126 sits inside that block, so the
+        // same shadowing risk as 172.16/12 applies. A split ULA exclusion
+        // will land in a follow-up once the v4 narrow fix is confirmed green.
         let expected: [(String, Int)] = [
-            ("fc00::", 7),
             ("fe80::", 10),
             ("::1", 128),
             ("ff00::", 8),

--- a/PacketTunnel/Sources/TunnelEngine.swift
+++ b/PacketTunnel/Sources/TunnelEngine.swift
@@ -102,12 +102,15 @@ final class TunnelEngine: @unchecked Sendable {
     // MARK: - Ingress
 
     private static func runIngressLoop(flow: NEPacketTunnelFlow, counter: ManagedAtomicCounter) async {
+        // DIAGNOSTIC: remove once tunnel ingest is verified stable in v1.0.
+        let log = Logger(subsystem: "io.github.madeye.meow.PacketTunnel", category: "engine")
         while !Task.isCancelled {
             let packets = await withCheckedContinuation { (cont: CheckedContinuation<[Data], Never>) in
                 flow.readPackets { packets, _ in
                     cont.resume(returning: packets)
                 }
             }
+            log.info("ingress batch: count=\(packets.count, privacy: .public)")
             for packet in packets {
                 packet.withUnsafeBytes { buf in
                     guard let base = buf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }

--- a/PacketTunnel/Sources/TunnelSettings.swift
+++ b/PacketTunnel/Sources/TunnelSettings.swift
@@ -9,10 +9,18 @@ enum TunnelSettings {
     ///
     /// Exposed as a computed property because `NEIPv4Route` is a non-Sendable
     /// ObjC class and Swift 6 strict concurrency rejects a `static let` of it.
+    /// The 172.16/12 block is split four ways so 172.19/16 — the tunnel's own
+    /// virtual interface (172.19.0.1/30) and DNS server (172.19.0.2) — stays
+    /// routed through the tunnel. Excluding 172.19.x made iOS hand the tunnel
+    /// DNS query to the physical interface, where it had nowhere to go.
     static var ipv4LanExcludedRoutes: [NEIPv4Route] {
         [
             route(address: "10.0.0.0", mask: "255.0.0.0"), // RFC 1918 Class A
-            route(address: "172.16.0.0", mask: "255.240.0.0"), // RFC 1918 Class B (172.16-172.31)
+            // 172.16/12 split to skip 172.19/16 (tunnel interface + DNS):
+            route(address: "172.16.0.0", mask: "255.254.0.0"), // 172.16-172.17 (/15)
+            route(address: "172.18.0.0", mask: "255.255.0.0"), // 172.18 (/16)
+            route(address: "172.20.0.0", mask: "255.252.0.0"), // 172.20-172.23 (/14)
+            route(address: "172.24.0.0", mask: "255.248.0.0"), // 172.24-172.31 (/13)
             route(address: "192.168.0.0", mask: "255.255.0.0"), // RFC 1918 Class C
             route(address: "169.254.0.0", mask: "255.255.0.0"), // Link-local (DHCP fallback)
             route(address: "127.0.0.0", mask: "255.0.0.0"), // Loopback
@@ -24,8 +32,12 @@ enum TunnelSettings {
     /// IPv6 equivalents: ULA + link-local + loopback + multicast. Computed
     /// for the same Sendable reason as `ipv4LanExcludedRoutes`.
     static var ipv6LanExcludedRoutes: [NEIPv6Route] {
+        // TODO: add split ULA (fc00::/7) exclusion back in a follow-up once
+        // the v4 narrow fix is confirmed green. Dropped here to minimise the
+        // diff for the recovery PR — tunnel uses fdfe:dcba:9876::/126, which
+        // sits inside fc00::/7, so the same interface-route shadowing risk
+        // applies until we split this the same way IPv4 is split.
         [
-            route6(address: "fc00::", prefix: 7), // Unique Local Addresses (ULA)
             route6(address: "fe80::", prefix: 10), // Link-local
             route6(address: "::1", prefix: 128), // Loopback
             route6(address: "ff00::", prefix: 8), // Multicast
@@ -46,7 +58,10 @@ enum TunnelSettings {
         settings.ipv6Settings = ipv6
 
         let dns = NEDNSSettings(servers: ["172.19.0.2"])
-        dns.matchDomains = [""]
+        // Leaving matchDomains at its default (nil) — see NEDNSSettings.h,
+        // which describes the default as "match all domains". Passing [""]
+        // was a no-op at best and risked being interpreted as an empty-suffix
+        // match that some iOS revisions drop on the floor.
         settings.dnsSettings = dns
 
         settings.mtu = 1500


### PR DESCRIPTION
## Summary

PR #53 shipped LAN-bypass with a single `172.16.0.0/255.240.0.0` (172.16/12) exclusion. The tunnel's own interface (172.19.0.1/30) and DNS server (172.19.0.2) sit inside that block — iOS chose the excluded-route decision over the on-link /30 for the DNS lookup, so the VPN reported connected but no traffic ever reached mihomo. Team-lead and I traced this together; full diagnosis in the #53 review thread.

This PR is deliberately narrow: make traffic flow again, add instrumentation to confirm, defer adjacent cleanups.

### Changes

- **IPv4 four-way split** replacing the `172.16.0.0/255.240.0.0` entry:
  - `172.16.0.0/255.254.0.0` — 172.16–172.17 (/15)
  - `172.18.0.0/255.255.0.0` — 172.18 (/16)
  - `172.20.0.0/255.252.0.0` — 172.20–172.23 (/14)
  - `172.24.0.0/255.248.0.0` — 172.24–172.31 (/13)
  - Leaves 172.19/16 routed through the tunnel. Callout from the #53 brief — "if LAN-on-172.19 networks surface weirdness, fall back to splitting and leaving 172.19 out" — is the path we're now on.
- **Drop `fc00::/7` (IPv6 ULA) for this iteration.** Tunnel's `fdfe:dcba:9876::/126` sits inside fc00::/7, same shadowing risk. TODO comment in `TunnelSettings.swift` to add a split ULA exclusion back once v4 is confirmed green. See follow-up below.
- **`dns.matchDomains = [""]` → `nil`.** `NEDNSSettings.h` documents the default as "match all domains". Passing `[""]` was a no-op at best and — on some iOS revisions — may have been interpreted as an empty-suffix match that iOS drops. Clean default is strictly safer.
- **DIAGNOSTIC ingress-batch log** in `TunnelEngine.runIngressLoop`: `log.info("ingress batch: count=\(packets.count, privacy: .public)")`. Lets the v1.0 on-device smoke confirm packets are actually arriving at `NEPacketTunnelFlow` before we chase further suspects. Marked DIAGNOSTIC in the code comment so it gets removed once tunnel ingest is verified stable.

### Tests

- `TunnelSettingsLANExclusionTests.testMakeAppliesIPv4LANExcludedRoutesInDeclaredOrder`: expected list grows 7 → 10 entries.
- `testMakeAppliesIPv6LANExcludedRoutesInDeclaredOrder`: expected list shrinks 4 → 3 (fc00::/7 dropped).
- New `testMakeDoesNotExcludeTunnelSubnet`: regression guard that fails if anyone re-introduces the exact `172.16.0.0/255.240.0.0` pattern.
- New `testMakeLeavesDNSMatchDomainsUnset`: guards the `matchDomains = nil` decision against a well-meaning revert.

### Follow-ups (not in this PR)

- **Re-add split IPv6 ULA exclusion** in a follow-up once v4 narrow is confirmed green. Commented in `ipv6LanExcludedRoutes`.
- **DoH port-0 bug.** Separate from LAN exclusion, but found during the phase 5 diagnosis: `core/rust/mihomo-ios-ffi/src/tun2socks.rs:76` calls `doh_client::init_doh_client(0)`, and `core/rust/mihomo-ios-ffi/src/doh_client.rs:29` then builds a `reqwest::Proxy::all("socks5h://127.0.0.1:0")`. Port 0 is invalid for a client; this will fail as soon as DoH is actually exercised. Will open a separate PR after this one confirms ingress is arriving.
- `NEDNSSettings.allowFailover` (new in iOS 26) is intentionally left at its default (NO) for this PR. If post-fix on-device testing still shows DNS drops, that's the next lever.

## Test plan (Path B attestation)

- [x] `swiftformat --lint .` at repo root — 0 violations.
- [x] `swiftlint` at repo root — 0 violations.
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowIntegrationTests/TunnelSettingsLANExclusionTests -only-testing:MeowTests` on iOS 26 simulator — 5/5 LAN exclusion tests pass (including 2 new assertions), MeowTests 99/99 pass.
- [x] `git diff origin/main...HEAD --stat` verified — 3 files: `PacketTunnel/Sources/TunnelSettings.swift`, `PacketTunnel/Sources/TunnelEngine.swift`, `MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift`. No accidental additions.
- [ ] Manual on-device smoke: VPN on, confirm ingress log shows non-zero packet batches and real traffic flows. (Team-lead's call after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)