### PR TITLE
fix(vpn): drop loopback routes rejected by iOS NE validator

### DIFF
--- a/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
+++ b/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
@@ -26,7 +26,6 @@ final class TunnelSettingsLANExclusionTests: XCTestCase {
             ("172.24.0.0", "255.248.0.0"),
             ("192.168.0.0", "255.255.0.0"),
             ("169.254.0.0", "255.255.0.0"),
-            ("127.0.0.0", "255.0.0.0"),
             ("224.0.0.0", "240.0.0.0"),
             ("255.255.255.255", "255.255.255.255"),
         ]
@@ -57,6 +56,35 @@ final class TunnelSettingsLANExclusionTests: XCTestCase {
         }
     }
 
+    /// Regression guard: iOS's `NEIPv4Route`/`NEIPv6Route` validator rejects
+    /// any loopback destination and discards the ENTIRE excludedRoutes payload
+    /// when it finds one. A single 127/8 or ::1 entry in #53/#54 killed every
+    /// other exclusion silently — ingress log showed zero packets. If anyone
+    /// re-introduces a loopback exclusion, this test fails before it ships.
+    func testMakeExcludesNoLoopbackDestinations() {
+        let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
+
+        let ipv4Routes = settings.ipv4Settings?.excludedRoutes ?? []
+        for route in ipv4Routes {
+            XCTAssertFalse(
+                route.destinationAddress.hasPrefix("127."),
+                "IPv4 excludedRoute \(route.destinationAddress) is loopback — iOS rejects the whole payload",
+            )
+        }
+
+        let ipv6Routes = settings.ipv6Settings?.excludedRoutes ?? []
+        for route in ipv6Routes {
+            // Anchor the match so we reject "::1" exactly but not something
+            // coincidentally like "::1abc" (which is not a real route but
+            // keeps the guard robust against future additions).
+            let addr = route.destinationAddress
+            XCTAssertFalse(
+                addr == "::1" || addr == "0:0:0:0:0:0:0:1",
+                "IPv6 excludedRoute \(addr) is loopback — iOS rejects the whole payload",
+            )
+        }
+    }
+
     func testMakeLeavesDNSMatchDomainsUnset() {
         let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
         XCTAssertNil(
@@ -72,7 +100,6 @@ final class TunnelSettingsLANExclusionTests: XCTestCase {
         // will land in a follow-up once the v4 narrow fix is confirmed green.
         let expected: [(String, Int)] = [
             ("fe80::", 10),
-            ("::1", 128),
             ("ff00::", 8),
         ]
 

--- a/PacketTunnel/Sources/TunnelSettings.swift
+++ b/PacketTunnel/Sources/TunnelSettings.swift
@@ -23,7 +23,10 @@ enum TunnelSettings {
             route(address: "172.24.0.0", mask: "255.248.0.0"), // 172.24-172.31 (/13)
             route(address: "192.168.0.0", mask: "255.255.0.0"), // RFC 1918 Class C
             route(address: "169.254.0.0", mask: "255.255.0.0"), // Link-local (DHCP fallback)
-            route(address: "127.0.0.0", mask: "255.0.0.0"), // Loopback
+            // Loopback (127/8) intentionally omitted: iOS's NEIPv4Route validator rejects
+            // any loopback destination and throws out the ENTIRE excludedRoutes payload, so
+            // including it silently broke all other exclusions. The kernel handles 127/8
+            // host-locally without needing a TUN exclusion anyway.
             route(address: "224.0.0.0", mask: "240.0.0.0"), // Multicast (mDNS, Bonjour, AirPlay)
             route(address: "255.255.255.255", mask: "255.255.255.255"), // Limited broadcast
         ]
@@ -37,9 +40,12 @@ enum TunnelSettings {
         // diff for the recovery PR — tunnel uses fdfe:dcba:9876::/126, which
         // sits inside fc00::/7, so the same interface-route shadowing risk
         // applies until we split this the same way IPv4 is split.
+        // Loopback (::1/128) intentionally omitted: NEIPv6Route validator
+        // rejects loopback destinations and drops the entire settings payload
+        // when present — same failure mode as IPv4 127/8. Kernel handles
+        // loopback host-locally without a TUN exclusion.
         [
             route6(address: "fe80::", prefix: 10), // Link-local
-            route6(address: "::1", prefix: 128), // Loopback
             route6(address: "ff00::", prefix: 8), // Multicast
         ]
     }


### PR DESCRIPTION
## Summary

Device `logarchive` captured during the post-#54 install shows the smoking gun on every `startTunnel` since the first LAN-exclusion shipment:

```
2026-04-18 19:28:43 (post-#54 install) — and every prior attempt in the archive:
IPv4 routes are invalid: ("IPv4Route Destination address is loopback")
IPv6 routes are invalid: ("IPv6Route Destination address in loopback")
```

iOS's `NEIPv4Route`/`NEIPv6Route` validator rejects any loopback-range destination and **discards the entire `excludedRoutes` payload** on the first offender. This is why the tunnel reported `meow_tun_start` success but the `ingress batch` diagnostic log (added in #54) fired **zero times** across four connection attempts: the settings never made it through validation, so the default included route had nothing attracting packets into the TUN.

### Changes

- **Remove `127.0.0.0/255.0.0.0` from `ipv4LanExcludedRoutes`.** Inline comment explains the validator behaviour and notes that the kernel handles 127/8 host-locally without needing a TUN exclusion anyway.
- **Remove `::1/128` from `ipv6LanExcludedRoutes`.** Same rationale, same comment.
- **Keep the `TunnelEngine.runIngressLoop` ingress-batch log.** Still DIAGNOSTIC-tagged; we want to see `ingress batch: count=N` fire on the next rebuild to confirm iOS is finally delivering packets. It gets removed in a follow-up once we've verified ingest is stable.

### Tests

- IPv4 expected count: 10 → 9 (loopback dropped).
- IPv6 expected count: 3 → 2 (loopback dropped).
- New `testMakeExcludesNoLoopbackDestinations`: iterates excludedRoutes and asserts no IPv4 address starts with `"127."` and no IPv6 address equals `"::1"` or its expanded form `"0:0:0:0:0:0:0:1"`. Anchored so future non-loopback entries aren't accidentally rejected.

### Out of scope for this PR

- **Re-add split IPv6 ULA exclusion** (fc00::/7 split) — still pending, comment in-code from #54. Will land once we've confirmed ingest actually fires.
- **DoH port-0 bug** at `core/rust/mihomo-ios-ffi/src/tun2socks.rs:76` → `doh_client.rs:29` — blocked on this PR landing and ingest being confirmed. We need packets arriving before we can validate any DoH-layer change.

## Test plan (Path B attestation)

- [x] `swiftformat --lint .` at repo root — 0 violations.
- [x] `swiftlint` at repo root — 0 violations.
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowIntegrationTests -only-testing:MeowTests` on iOS 26 simulator — all green. 6/6 `TunnelSettingsLANExclusionTests` (incl. new `testMakeExcludesNoLoopbackDestinations`), MeowTests suite clean.
- [x] `git diff origin/main...HEAD --stat` verified — 2 files: `PacketTunnel/Sources/TunnelSettings.swift`, `MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift`. No accidental additions.
- [ ] Manual on-device smoke: rebuild, start VPN, grep the NEW `logarchive` for `"IPv4Route Destination address is loopback"` — should be gone. Then grep for `ingress batch: count=` — should fire with non-zero counts. (Team-lead's call after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)