### PR TITLE
fix(doh): send DoH via mihomo's mixed-port 7890, not :0

### DIFF
--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -73,7 +73,13 @@ pub fn start(ctx: *mut c_void, cb: WritePacketFn) -> Result<(), String> {
     let emitter = EgressEmitter { ctx: EmitCtx(ctx), cb };
 
     info!("tun2socks starting (direct-callback ingest)");
-    doh_client::init_doh_client(0);
+    // Must match `EffectiveConfigWriter.defaultMixedPort` on the Swift side;
+    // that's the port mihomo's in-process mixed (SOCKS+HTTP) listener binds
+    // to. DoH routes through it so queries ride the user's proxy chain
+    // instead of leaking directly. TODO(v1.1): expose the loaded mixed-port
+    // via an FFI getter so this doesn't silently drift if the Swift default
+    // changes.
+    doh_client::init_doh_client(7890);
 
     let (ingress_tx, ingress_rx) = mpsc::channel::<Vec<u8>>(256);
     *ingress_slot().lock() = Some(ingress_tx);


### PR DESCRIPTION
## Summary

The loopback-route fix in #55 unblocked ingress. Fresh `logarchive` at **2026-04-18 19:44:22** confirms packets are reaching the TUN — the tun2socks DoH interceptor now logs:

```
19:44:22  DoH: play.google.com from 172.19.0.1:52536
```

…but every DoH lookup immediately fails:

```
19:44:22  DoH request failed … error sending request for url
19:44:22  DoH: all servers failed
```

### Root cause

`tun2socks::start` called `doh_client::init_doh_client(0)`, which built a `reqwest::Proxy::all("socks5h://127.0.0.1:0")`. Port 0 isn't a valid client connect target — the SOCKS transport rejects it before it can reach mihomo's in-process mixed listener. Every DoH query therefore failed at the reqwest layer, never actually hitting the proxy chain.

### Fix

One-liner at `core/rust/mihomo-ios-ffi/src/tun2socks.rs:76`:

```rust
- doh_client::init_doh_client(0);
+ doh_client::init_doh_client(7890);
```

7890 matches `EffectiveConfigWriter.defaultMixedPort` on the Swift side — the port mihomo binds for its in-process mixed SOCKS+HTTP listener. DoH queries now ride the user's proxy chain instead of leaking outside the tunnel.

### Judgement call on the cleaner alternative

The brief offered two shapes: hardcoded 7890, or expose the loaded mixed-port via an FFI getter. Plumbing a getter is not trivial here — it crosses `mihomo-config → engine → FFI` and touches engine-init ordering — so I went with the hardcoded value and an inline `TODO(v1.1)` flagging the silent-drift risk if the Swift default ever changes. v1.0 ships with the one-line fix.

### Out of scope

- `ingress batch` Swift log not appearing in `log stream` grep — team-lead's separate investigation; not blocking DoH resolution.
- DoH retry strategy / fallback server list — unchanged.
- Removing the SOCKS hop and going direct-HTTPS — that would leak DNS outside the tunnel; explicitly rejected in the brief.

## Test plan (Path B attestation)

- [x] `cargo clippy --all-targets --manifest-path core/rust/mihomo-ios-ffi/Cargo.toml -- -D warnings` — clean.
- [x] `cargo test --lib --manifest-path core/rust/mihomo-ios-ffi/Cargo.toml` — 4/4 pass (subscription + xdg_home_dir tests).
- [x] `scripts/build-rust.sh` — xcframework rebuilt for both `aarch64-apple-ios` and `aarch64-apple-ios-sim`, output written to `MeowCore/Frameworks/MihomoCore.xcframework`.
- [x] `swiftlint` and `swiftformat --lint .` at repo root — 0 violations each (no Swift touched; CLAUDE.md requires both anyway).
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` on iOS 26 simulator — green (links against rebuilt xcframework, no regressions).
- [x] `git diff origin/main...HEAD --stat` verified — 1 file: `core/rust/mihomo-ios-ffi/src/tun2socks.rs`. No accidental additions.
- [ ] On-device smoke: rebuild, install, retry — expected `logarchive` output is a successful DoH response followed by actual HTTP traffic flowing. (Team-lead's call after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)