### PR TITLE
feat(home): persist + replay proxy-group selections per profile

### DIFF
--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import MeowIPC
 import MeowModels
 import Observation
+import SwiftData
 
 /// Top-level observable that wires the app's long-lived services together and
 /// performs first-launch setup (asset seeding, IPC observer registration).
@@ -38,8 +39,38 @@ final class AppModel {
         guard !didBootstrap else { return }
         didBootstrap = true
 
+        vpnManager.onConnected = { [weak self] in
+            self?.replaySelectedProxiesOnConnect()
+        }
         await AssetSeeder.seedIfNeeded()
         await vpnManager.refresh()
         ipcBridge.start()
+    }
+
+    /// Re-issues the active profile's persisted `selectedProxies` after the
+    /// engine starts. mihomo-rust drops in-memory group state on every
+    /// engine.start, so without this the UI shows the YAML defaults instead
+    /// of what the user last picked. Stale entries (group/proxy renamed or
+    /// removed since the last save) are dropped and persisted back.
+    private func replaySelectedProxiesOnConnect() {
+        let context = AppModelContainer.shared.container.mainContext
+        let descriptor = FetchDescriptor<Profile>(predicate: #Predicate { $0.isSelected })
+        guard let profile = try? context.fetch(descriptor).first else { return }
+        let selections = profile.selectedProxies
+        guard !selections.isEmpty else { return }
+        let api = mihomoAPI
+        Task { @MainActor in
+            let stale = await SelectedProxyRestorer.restore(
+                selections: selections,
+                select: { group, name in try await api.selectProxy(group: group, name: name) },
+            )
+            guard !stale.isEmpty else { return }
+            var updated = profile.selectedProxies
+            for group in stale {
+                updated.removeValue(forKey: group)
+            }
+            profile.selectedProxies = updated
+            try? context.save()
+        }
     }
 }

--- a/App/Sources/Services/SelectedProxyRestorer.swift
+++ b/App/Sources/Services/SelectedProxyRestorer.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Replays persisted proxy-group selections after the engine starts. mihomo-rust
+/// keeps proxy-group state in-memory only, so each connect re-issues every
+/// `(group, proxy)` selection the user previously made on the active profile.
+enum SelectedProxyRestorer {
+    /// Calls `select` for every `(group, proxy)` entry in `selections`.
+    /// Iteration is alphabetical by group name so callers (and tests) can
+    /// reason about ordering. Returns the names of groups whose `select`
+    /// closure threw — caller may use this list to drop stale entries from
+    /// persistence (the proxy or the group disappeared after a refresh).
+    static func restore(
+        selections: [String: String],
+        select: @Sendable (String, String) async throws -> Void,
+    ) async -> [String] {
+        var stale: [String] = []
+        for (group, proxy) in selections.sorted(by: { $0.key < $1.key }) {
+            do {
+                try await select(group, proxy)
+            } catch {
+                stale.append(group)
+            }
+        }
+        return stale
+    }
+}

--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -12,6 +12,12 @@ final class VpnManager {
     private(set) var stage: VpnStage = .idle
     private(set) var lastError: String?
 
+    /// Fires once each time `stage` transitions into `.connected`. Wired by
+    /// `AppModel` to replay persisted proxy-group selections via
+    /// `SelectedProxyRestorer` — mihomo-rust resets group state on every
+    /// engine start, so the app owns persistence.
+    var onConnected: (@MainActor () -> Void)?
+
     /// Clear the user-visible error banner. Called when the user dismisses it
     /// or when a new connect attempt starts.
     func clearError() {
@@ -94,7 +100,9 @@ final class VpnManager {
             guard let self else { return }
             let status = mgr.connection.status
             Task { @MainActor in
-                self.stage = self.map(status)
+                let previous = self.stage
+                let next = self.map(status)
+                self.stage = next
                 // When the extension aborts startup (engine.start throws) the
                 // connection transitions straight to .disconnected with no
                 // thrown NEVPNManagerError. The provider writes the Rust error
@@ -102,6 +110,12 @@ final class VpnManager {
                 // UI can show the actual reason instead of a silent toggle.
                 if status == .disconnected, let msg = SharedStore.readState()?.errorMessage, !msg.isEmpty {
                     self.lastError = msg
+                }
+                // Fire onConnected exactly once per connect transition. The
+                // observer can run repeatedly (e.g. .reasserting → .connected
+                // round trips), so guard on the actual stage edge.
+                if next == .connected, previous != .connected {
+                    self.onConnected?()
                 }
             }
         }

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -6,6 +6,7 @@ struct HomeView: View {
     @Environment(VpnManager.self) private var vpnManager
     @Environment(AppIPCBridge.self) private var ipcBridge
     @Environment(MihomoAPI.self) private var mihomoAPI
+    @Environment(\.modelContext) private var modelContext
     @Query(filter: #Predicate<Profile> { $0.isSelected }) private var selected: [Profile]
 
     @State private var groups: [ProxyGroupModel] = []
@@ -319,6 +320,10 @@ struct HomeView: View {
     private func select(group: String, proxy: String) async {
         do {
             try await mihomoAPI.selectProxy(group: group, name: proxy)
+            if let profile = selected.first {
+                profile.selectedProxies[group] = proxy
+                try? modelContext.save()
+            }
             await refreshGroupsIfConnected()
         } catch {
             groupsLoadError = String(

--- a/MeowTests/Models/ProfileTests.swift
+++ b/MeowTests/Models/ProfileTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import meow_ios
 import SwiftData
 import Testing
 
@@ -17,9 +18,24 @@ struct ProfileTests {
         // calling markSelected on profile B should deselect A
     }
 
-    @Test(.disabled("blocked on T4.1"))
-    func `selectedProxies encodes/decodes as JSON dict`() {
-        // set ["Proxy": "node-01", "Auto": "auto"], save, reload, compare
+    @Test
+    func `selectedProxies accessor round-trips through JSON`() {
+        let profile = Profile(name: "p", url: "https://example.com/a.yaml", yamlContent: "")
+        profile.selectedProxies = ["Auto": "auto", "Proxy": "node-01"]
+        let parsed = try? JSONDecoder().decode(
+            [String: String].self,
+            from: Data(profile.selectedProxiesJSON.utf8),
+        )
+        #expect(parsed == ["Auto": "auto", "Proxy": "node-01"])
+        #expect(profile.selectedProxies == ["Auto": "auto", "Proxy": "node-01"])
+    }
+
+    @Test
+    func `selectedProxies setter overwrites prior entries`() {
+        let profile = Profile(name: "p", url: "https://example.com/a.yaml", yamlContent: "")
+        profile.selectedProxies = ["Proxy": "node-01"]
+        profile.selectedProxies = ["Auto": "auto"]
+        #expect(profile.selectedProxies == ["Auto": "auto"])
     }
 }
 

--- a/MeowTests/Services/SelectedProxyRestorerTests.swift
+++ b/MeowTests/Services/SelectedProxyRestorerTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+@testable import meow_ios
+import Testing
+
+@Suite("SelectedProxyRestorer", .tags(.service))
+struct SelectedProxyRestorerTests {
+    actor Recorder {
+        var calls: [(String, String)] = []
+        var failOn: Set<String> = []
+
+        func record(_ group: String, _ proxy: String) async throws {
+            if failOn.contains(group) {
+                throw NSError(domain: "test", code: 404)
+            }
+            calls.append((group, proxy))
+        }
+
+        func fail(on groups: [String]) {
+            failOn = Set(groups)
+        }
+
+        var captured: [(String, String)] {
+            calls
+        }
+    }
+
+    @Test
+    func `restore calls select for every entry in alphabetical group order`() async {
+        let rec = Recorder()
+        let stale = await SelectedProxyRestorer.restore(
+            selections: ["Proxy": "node-a", "Auto": "auto", "Region": "hk-01"],
+            select: { group, proxy in try await rec.record(group, proxy) },
+        )
+        let calls = await rec.captured
+        #expect(stale.isEmpty)
+        #expect(calls.map(\.0) == ["Auto", "Proxy", "Region"])
+        #expect(calls.map(\.1) == ["auto", "node-a", "hk-01"])
+    }
+
+    @Test
+    func `restore on empty map issues no calls and no stale entries`() async {
+        let rec = Recorder()
+        let stale = await SelectedProxyRestorer.restore(
+            selections: [:],
+            select: { group, proxy in try await rec.record(group, proxy) },
+        )
+        #expect(stale.isEmpty)
+        let calls = await rec.captured
+        #expect(calls.isEmpty)
+    }
+
+    @Test
+    func `failed selects are reported as stale, others still apply`() async {
+        let rec = Recorder()
+        await rec.fail(on: ["Region"])
+        let stale = await SelectedProxyRestorer.restore(
+            selections: ["Proxy": "node-a", "Region": "missing"],
+            select: { group, proxy in try await rec.record(group, proxy) },
+        )
+        let calls = await rec.captured
+        #expect(stale == ["Region"])
+        #expect(calls.map(\.0) == ["Proxy"])
+    }
+}


### PR DESCRIPTION
## Summary

PRD T4.2 ("Restore saved `selectedProxies` on connect") had the storage half wired (`Profile.selectedProxiesJSON` + a `[String: String]` computed accessor) but neither end of the loop was hooked up — manual proxy-group selections vanished on every reconnect because mihomo-rust holds group state in-memory only.

This PR symmetrically wires both ends:

- **Write-on-select** (`HomeView.select(group:proxy:)`): after a successful `PUT /proxies/{group}`, write `profile.selectedProxies[group] = proxy` and save the SwiftData modelContext. Uses the existing `@Query(filter: { $0.isSelected })` — no new source of truth.
- **Replay-on-connect** (`AppModel.bootstrap` → `VpnManager.onConnected`): VpnManager exposes a callback that fires exactly once per `.connected` transition (guarded against `.reasserting → .connected` round-trips). AppModel installs a callback that fetches the active profile via `FetchDescriptor<Profile>(predicate: #Predicate { $0.isSelected })` and replays every saved selection through the new `SelectedProxyRestorer`.

`SelectedProxyRestorer` is a tiny `enum` helper with one static `restore(selections:select:)` method — takes a `[String: String]` and a `@Sendable` select closure, iterates alphabetically (stable order so tests can assert), returns the names of any groups whose select threw. AppModel uses that list to drop stale entries (proxy renamed or removed since the last save) from the persisted map.

### Edge cases handled

- **Stale entry** (proxy gone after subscription refresh): `selectProxy` returns 4xx → group name returned in stale list → cleared from `Profile.selectedProxies` and re-saved. No crash, no perpetual retry.
- **No selected profile**: `FetchDescriptor.first == nil` → callback no-ops cleanly.
- **Empty `selectedProxies`**: early-return before spawning the replay Task.
- **Race between replay and user picking simultaneously**: last write wins; `selectProxy` is idempotent.

### Out of scope (flagging for follow-ups, not implemented)

- "Clear saved selections" UI button — flag if useful, not in this brief.
- Preserving selections across `SubscriptionService.refreshAll` — separate concern; a refresh may legitimately invalidate a node, and the stale-cleanup path above handles it on the next reconnect.

## Test plan

Path B attestation:

- [x] `swiftformat --lint .` at repo root → 0/82 files require formatting.
- [x] `swiftlint` at repo root → 0 violations (HomeView trimmed back to exactly 600 lines using the `dict[key] = value` shortcut on the computed accessor).
- [x] `xcodebuild test -only-testing:MeowTests` on iPhone 17 (iOS 26 sim) → ** TEST SUCCEEDED ** (103 tests, +5 vs prior baseline of 99: 2 in ProfileTests, 3 in SelectedProxyRestorerTests).
- [x] `xcodebuild test -only-testing:MeowIntegrationTests` on iPhone 17 (iOS 26 sim) → ** TEST SUCCEEDED ** (26 tests).
- [x] `git diff origin/main...HEAD --stat` verified — 6 files, all expected (`App/Sources/AppModel.swift`, `App/Sources/Services/VpnManager.swift`, `App/Sources/Services/SelectedProxyRestorer.swift` (new), `App/Sources/Views/HomeView.swift`, `MeowTests/Models/ProfileTests.swift`, `MeowTests/Services/SelectedProxyRestorerTests.swift` (new)). No accidental additions. No Rust touched (skipped `build-rust.sh`).

## Manual verification (post-merge / install)

1. Pick a non-default proxy in any group.
2. Toggle VPN off → on.
3. Confirm the same proxy is still selected — visible via the group's "now" marker on Home, or via `GET /proxies` against `127.0.0.1:9090`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)