### PR TITLE
fix(home): guard proxy-selection replay against api-server race

### DIFF
--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -50,8 +50,13 @@ final class AppModel {
     /// Re-issues the active profile's persisted `selectedProxies` after the
     /// engine starts. mihomo-rust drops in-memory group state on every
     /// engine.start, so without this the UI shows the YAML defaults instead
-    /// of what the user last picked. Stale entries (group/proxy renamed or
-    /// removed since the last save) are dropped and persisted back.
+    /// of what the user last picked. Stale entries (HTTP 4xx — group/proxy
+    /// renamed or removed since the last save) are dropped and persisted
+    /// back. Transient errors (connection refused, timeout, 5xx) are left
+    /// alone: `meow_engine_start` returns before the in-process api_server
+    /// task binds :9090, so a replay fired on NEVPNStatus=.connected can
+    /// race it. Wiping persisted selections on that race is how #59
+    /// silently erased the user's picks after a single unlucky reconnect.
     private func replaySelectedProxiesOnConnect() {
         let context = AppModelContainer.shared.container.mainContext
         let descriptor = FetchDescriptor<Profile>(predicate: #Predicate { $0.isSelected })
@@ -60,13 +65,25 @@ final class AppModel {
         guard !selections.isEmpty else { return }
         let api = mihomoAPI
         Task { @MainActor in
-            let stale = await SelectedProxyRestorer.restore(
+            var ready = false
+            for _ in 0 ..< 10 {
+                do {
+                    _ = try await api.getProxies()
+                    ready = true
+                    break
+                } catch {
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+            }
+            guard ready else { return }
+
+            let outcome = await SelectedProxyRestorer.restore(
                 selections: selections,
                 select: { group, name in try await api.selectProxy(group: group, name: name) },
             )
-            guard !stale.isEmpty else { return }
+            guard !outcome.stale.isEmpty else { return }
             var updated = profile.selectedProxies
-            for group in stale {
+            for group in outcome.stale {
                 updated.removeValue(forKey: group)
             }
             profile.selectedProxies = updated

--- a/App/Sources/Services/SelectedProxyRestorer.swift
+++ b/App/Sources/Services/SelectedProxyRestorer.swift
@@ -6,21 +6,30 @@ import Foundation
 enum SelectedProxyRestorer {
     /// Calls `select` for every `(group, proxy)` entry in `selections`.
     /// Iteration is alphabetical by group name so callers (and tests) can
-    /// reason about ordering. Returns the names of groups whose `select`
-    /// closure threw — caller may use this list to drop stale entries from
-    /// persistence (the proxy or the group disappeared after a refresh).
+    /// reason about ordering. Returns two lists:
+    ///
+    /// - `stale`: the API responded with HTTP 4xx, meaning the group or proxy
+    ///   no longer exists server-side. Caller should drop these from the
+    ///   persisted map — a subscription refresh renamed or removed them.
+    /// - `transient`: any other error (URLError, timeout, 5xx). The server
+    ///   may not be reachable yet or may be temporarily unhappy. Caller MUST
+    ///   NOT treat these as stale; wiping persisted selections on transient
+    ///   errors is how #59 silently erased the user's picks.
     static func restore(
         selections: [String: String],
         select: @Sendable (String, String) async throws -> Void,
-    ) async -> [String] {
+    ) async -> (stale: [String], transient: [String]) {
         var stale: [String] = []
+        var transient: [String] = []
         for (group, proxy) in selections.sorted(by: { $0.key < $1.key }) {
             do {
                 try await select(group, proxy)
-            } catch {
+            } catch let MihomoAPIError.http(status) where (400 ..< 500).contains(status) {
                 stale.append(group)
+            } catch {
+                transient.append(group)
             }
         }
-        return stale
+        return (stale, transient)
     }
 }

--- a/MeowTests/Services/SelectedProxyRestorerTests.swift
+++ b/MeowTests/Services/SelectedProxyRestorerTests.swift
@@ -6,17 +6,17 @@ import Testing
 struct SelectedProxyRestorerTests {
     actor Recorder {
         var calls: [(String, String)] = []
-        var failOn: Set<String> = []
+        var failures: [String: Error] = [:]
 
         func record(_ group: String, _ proxy: String) async throws {
-            if failOn.contains(group) {
-                throw NSError(domain: "test", code: 404)
+            if let err = failures[group] {
+                throw err
             }
             calls.append((group, proxy))
         }
 
-        func fail(on groups: [String]) {
-            failOn = Set(groups)
+        func fail(on group: String, with error: Error) {
+            failures[group] = error
         }
 
         var captured: [(String, String)] {
@@ -27,38 +27,75 @@ struct SelectedProxyRestorerTests {
     @Test
     func `restore calls select for every entry in alphabetical group order`() async {
         let rec = Recorder()
-        let stale = await SelectedProxyRestorer.restore(
+        let outcome = await SelectedProxyRestorer.restore(
             selections: ["Proxy": "node-a", "Auto": "auto", "Region": "hk-01"],
             select: { group, proxy in try await rec.record(group, proxy) },
         )
         let calls = await rec.captured
-        #expect(stale.isEmpty)
+        #expect(outcome.stale.isEmpty)
+        #expect(outcome.transient.isEmpty)
         #expect(calls.map(\.0) == ["Auto", "Proxy", "Region"])
         #expect(calls.map(\.1) == ["auto", "node-a", "hk-01"])
     }
 
     @Test
-    func `restore on empty map issues no calls and no stale entries`() async {
+    func `restore on empty map issues no calls and no outcomes`() async {
         let rec = Recorder()
-        let stale = await SelectedProxyRestorer.restore(
+        let outcome = await SelectedProxyRestorer.restore(
             selections: [:],
             select: { group, proxy in try await rec.record(group, proxy) },
         )
-        #expect(stale.isEmpty)
+        #expect(outcome.stale.isEmpty)
+        #expect(outcome.transient.isEmpty)
         let calls = await rec.captured
         #expect(calls.isEmpty)
     }
 
     @Test
-    func `failed selects are reported as stale, others still apply`() async {
+    func `HTTP 404 is reported as stale, others still apply`() async {
         let rec = Recorder()
-        await rec.fail(on: ["Region"])
-        let stale = await SelectedProxyRestorer.restore(
+        await rec.fail(on: "Region", with: MihomoAPIError.http(status: 404))
+        let outcome = await SelectedProxyRestorer.restore(
             selections: ["Proxy": "node-a", "Region": "missing"],
             select: { group, proxy in try await rec.record(group, proxy) },
         )
         let calls = await rec.captured
-        #expect(stale == ["Region"])
+        #expect(outcome.stale == ["Region"])
+        #expect(outcome.transient.isEmpty)
         #expect(calls.map(\.0) == ["Proxy"])
+    }
+
+    @Test
+    func `URLError is reported as transient, not stale`() async {
+        // Regression guard for the #59 replay-race bug: the in-process
+        // api_server may not have bound :9090 by the time replay fires on
+        // NEVPNStatus=.connected. A connection-refused URLError must NOT
+        // bubble through to the caller as `stale` — doing so silently
+        // wipes the user's persisted proxy-group selections.
+        let rec = Recorder()
+        await rec.fail(on: "Proxy", with: URLError(.cannotConnectToHost))
+        await rec.fail(on: "Region", with: URLError(.timedOut))
+        let outcome = await SelectedProxyRestorer.restore(
+            selections: ["Proxy": "node-a", "Auto": "auto", "Region": "hk-01"],
+            select: { group, proxy in try await rec.record(group, proxy) },
+        )
+        let calls = await rec.captured
+        #expect(outcome.stale.isEmpty)
+        #expect(outcome.transient == ["Proxy", "Region"])
+        #expect(calls.map(\.0) == ["Auto"])
+    }
+
+    @Test
+    func `HTTP 5xx is reported as transient, not stale`() async {
+        let rec = Recorder()
+        await rec.fail(on: "Proxy", with: MihomoAPIError.http(status: 503))
+        let outcome = await SelectedProxyRestorer.restore(
+            selections: ["Proxy": "node-a", "Auto": "auto"],
+            select: { group, proxy in try await rec.record(group, proxy) },
+        )
+        let calls = await rec.captured
+        #expect(outcome.stale.isEmpty)
+        #expect(outcome.transient == ["Proxy"])
+        #expect(calls.map(\.0) == ["Auto"])
     }
 }


### PR DESCRIPTION
## Summary
- #59 replay loop had two compounding bugs that silently erased the user's persisted proxy-group selections after a single unlucky reconnect. User confirmed symptom (b): selections reverted after force-quit + relaunch.
- **Bug 1 — api-server readiness race.** `meow_engine_start` returns before the in-process `api_server` tokio task binds `127.0.0.1:9090` (see `core/rust/mihomo-ios-ffi/src/engine.rs:64-77`). A replay fired from `NEVPNStatus=.connected` can race that bind; every PUT fails with URLError (cannot connect).
- **Bug 2 — destructive stale-cleanup.** `SelectedProxyRestorer.restore` treated every throw as "stale" — URLError and HTTP 4xx both landed in the same bucket. `AppModel` then removed the "stale" groups from `profile.selectedProxies` and saved, permanently erasing the persisted map after one racy reconnect.
- **Fix:**
  - `AppModel.replaySelectedProxiesOnConnect` now runs a bounded readiness probe (10 × 100ms, 1s cap) against `GET /proxies` before the restore loop. If the probe never succeeds, bail without touching persistence.
  - `SelectedProxyRestorer.restore` returns `(stale: [String], transient: [String])`. Only HTTP 4xx responses land in `stale`; URLError / 5xx / other land in `transient`. `AppModel` only removes `stale` from the persisted map. Transient failures are silently skipped this round.

## Scope
- `App/Sources/AppModel.swift` — readiness probe + only-remove-stale
- `App/Sources/Services/SelectedProxyRestorer.swift` — new tuple return, error-type classification
- `MeowTests/Services/SelectedProxyRestorerTests.swift` — existing tests updated to new return shape; two new regression tests (URLError → transient, HTTP 5xx → transient)

Diff scope: `git diff origin/main HEAD --stat` → 3 files, +88 / -25.

## Path B attestation (code PR — CLAUDE.md admin-bypass rules)
- [x] `swiftformat --lint .` at repo root → 0 violations.
- [x] `swiftlint` at repo root → 0 violations.
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -only-testing:MeowTests` → **TEST SUCCEEDED** (105 tests in 21 suites; SelectedProxyRestorer suite = 5/5 green including both new URLError + HTTP 5xx regression tests).
- [x] `git diff origin/main HEAD --stat` reviewed — 3 files, +88/-25, no accidental additions.
- [x] No Rust / FFI changes; `--skip-rust-build` safe on rebuild. MihomoCore.xcframework stays at aa8a133.
- [x] No workflow files touched (`.github/workflows/*.yml`).

## Test plan
- [ ] Device rebuild + install after merge (PM-driven).
- [ ] User verification: pick non-default proxy in a group → disconnect → reconnect → confirm selection persists. Force-quit + relaunch → reconnect → confirm selection still persists.
- [ ] Optional: force an api-server race by selecting across multiple groups → disconnect → immediately reconnect. Expected: readiness probe gates the replay, no wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)