### PR TITLE
fix(vpn): fire onConnected on attach-time connected edge

### DIFF
--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -90,7 +90,13 @@ final class VpnManager {
 
     private func attach(_ mgr: NETunnelProviderManager) {
         manager = mgr
-        stage = map(mgr.connection.status)
+        // Reading the initial connection.status is NOT an observed
+        // .NEVPNStatusDidChange edge, so on app relaunch into an
+        // already-connected tunnel (force-quit while VPN up), the observer
+        // alone never fires and the replay-on-connect callback never runs.
+        // #60 fixed the cold-connect readiness race; this fires the
+        // callback for the relaunch-into-connected edge too.
+        applyConnectionStatus(mgr.connection.status)
         if let statusObserver { NotificationCenter.default.removeObserver(statusObserver) }
         statusObserver = NotificationCenter.default.addObserver(
             forName: .NEVPNStatusDidChange,
@@ -100,9 +106,6 @@ final class VpnManager {
             guard let self else { return }
             let status = mgr.connection.status
             Task { @MainActor in
-                let previous = self.stage
-                let next = self.map(status)
-                self.stage = next
                 // When the extension aborts startup (engine.start throws) the
                 // connection transitions straight to .disconnected with no
                 // thrown NEVPNManagerError. The provider writes the Rust error
@@ -111,13 +114,20 @@ final class VpnManager {
                 if status == .disconnected, let msg = SharedStore.readState()?.errorMessage, !msg.isEmpty {
                     self.lastError = msg
                 }
-                // Fire onConnected exactly once per connect transition. The
-                // observer can run repeatedly (e.g. .reasserting → .connected
-                // round trips), so guard on the actual stage edge.
-                if next == .connected, previous != .connected {
-                    self.onConnected?()
-                }
+                self.applyConnectionStatus(status)
             }
+        }
+    }
+
+    /// Update `stage` and fire `onConnected` on the non-connected → connected
+    /// edge. Exposed at `internal` so `@testable` consumers can exercise the
+    /// edge semantics directly without a real `NETunnelProviderManager`.
+    func applyConnectionStatus(_ status: NEVPNStatus) {
+        let previous = stage
+        let next = map(status)
+        stage = next
+        if next == .connected, previous != .connected {
+            onConnected?()
         }
     }
 

--- a/MeowTests/Services/VpnManagerTests.swift
+++ b/MeowTests/Services/VpnManagerTests.swift
@@ -1,10 +1,13 @@
 import Foundation
+@testable import meow_ios
+import NetworkExtension
 import Testing
 
 /// Lightweight unit tests for `VpnManager` that do NOT require a real
 /// NetworkExtension — those live in `MeowIntegrationTests/VPNLifecycle/`.
 /// These cover the state reducer, status mapping, and command serialization.
 @Suite("VpnManager state mapping", .tags(.service))
+@MainActor
 struct VpnManagerTests {
     @Test(.disabled("blocked on T4.2"))
     func `NEVPNStatus maps to VpnStage`() {
@@ -25,5 +28,68 @@ struct VpnManagerTests {
     func `error stage populates errorMessage`() {
         // extension writes state with stage=.error, message="dial timeout"
         // VpnManager publishes state with same message
+    }
+
+    /// Regression guard for #59/#60 relaunch-into-connected trap: when the app
+    /// cold-launches while the NE extension is already `.connected` (user
+    /// force-quit the containing app while the tunnel was up), reading the
+    /// initial status inside `attach(_:)` is not an observed
+    /// `.NEVPNStatusDidChange` edge. Without firing `onConnected` on that
+    /// synthetic edge, `SelectedProxyRestorer` never replays and the UI shows
+    /// mihomo's YAML defaults instead of the user's persisted picks.
+    @Test
+    func `applyConnectionStatus fires onConnected on idle to connected edge`() {
+        let mgr = VpnManager()
+        var fired = 0
+        mgr.onConnected = { fired += 1 }
+        mgr.applyConnectionStatus(.connected)
+        #expect(fired == 1)
+        #expect(mgr.stage == .connected)
+    }
+
+    @Test
+    func `applyConnectionStatus does not refire while staying connected`() {
+        let mgr = VpnManager()
+        var fired = 0
+        mgr.onConnected = { fired += 1 }
+        mgr.applyConnectionStatus(.connected)
+        mgr.applyConnectionStatus(.connected)
+        #expect(fired == 1)
+    }
+
+    @Test
+    func `applyConnectionStatus refires on reconnect after disconnect`() {
+        let mgr = VpnManager()
+        var fired = 0
+        mgr.onConnected = { fired += 1 }
+        mgr.applyConnectionStatus(.connected)
+        mgr.applyConnectionStatus(.disconnected)
+        mgr.applyConnectionStatus(.connected)
+        #expect(fired == 2)
+    }
+
+    @Test
+    func `reasserting round trip does not refire onConnected`() {
+        // .reasserting maps to .connecting, so the next .connected IS a fresh
+        // edge and must refire — otherwise IP-changes wouldn't trigger replay.
+        let mgr = VpnManager()
+        var fired = 0
+        mgr.onConnected = { fired += 1 }
+        mgr.applyConnectionStatus(.connected)
+        mgr.applyConnectionStatus(.reasserting)
+        mgr.applyConnectionStatus(.connected)
+        #expect(fired == 2)
+    }
+
+    @Test
+    func `onConnected is not invoked for non-connected status`() {
+        let mgr = VpnManager()
+        var fired = 0
+        mgr.onConnected = { fired += 1 }
+        mgr.applyConnectionStatus(.disconnected)
+        mgr.applyConnectionStatus(.connecting)
+        mgr.applyConnectionStatus(.disconnecting)
+        mgr.applyConnectionStatus(.invalid)
+        #expect(fired == 0)
     }
 }


### PR DESCRIPTION
## Summary

Fixes the force-quit + relaunch persistence regression surfaced after #60.

**The edge-trigger trap**: `VpnManager.attach(_:)` reads `mgr.connection.status` for the initial stage, but reading is NOT an observed `.NEVPNStatusDidChange` edge. The observer only catches future transitions, so if the NE extension survived a force-quit and is already `.connected` when the containing app relaunches, `onConnected` never fires — `SelectedProxyRestorer` never replays the persisted `(group → proxy)` selections — and the UI shows mihomo's YAML defaults instead of the user's picks. #60 fixed the cold-connect `api_server` readiness race (real, but orthogonal); this is the upstream trigger bug.

- Extract stage-update + onConnected-edge logic into `applyConnectionStatus(_:)`, called from both `attach(_:)` (initial status read) and the status-change observer. Mirrors the observer's existing `previous != .connected && next == .connected` guard exactly, so a steady-state `.connected` read on re-`attach` doesn't fire twice.
- 5 regression tests in `VpnManagerTests` covering: idle→connected edge fires once; staying connected does not refire; reconnect after disconnect refires; reasserting round-trip refires (IP-change case); non-connected statuses don't fire.

## Path B attestation

- [x] `swiftformat --lint .` — 0 violations (82 files, 17 skipped)
- [x] `swiftlint` — 0 violations (73 files)
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` — 110 tests, all passed; 5 new regression tests under `VpnManager state mapping` pass cleanly
- [x] `git diff origin/main...HEAD --stat` — only `App/Sources/Services/VpnManager.swift` and `MeowTests/Services/VpnManagerTests.swift` changed

## Test plan

- [ ] After merge: rebuild on iPhone 17 Pro device (UDID EF832BFC-FCD3-5BBD-BB69-4BDFDC04F1D0), open app, pick a non-default proxy in a group, confirm it takes effect.
- [ ] Force-quit the containing app while the tunnel remains `.connected`.
- [ ] Relaunch the app; confirm the previously picked proxy is still selected in the UI (replay fired on the attach-time connected edge).
- [ ] Toggle off VPN → on; confirm the observer path still fires exactly once per reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)