### PR TITLE
fix(home): refresh proxy groups after replay completes

### DIFF
--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -17,6 +17,14 @@ final class AppModel {
     let subscriptionService: SubscriptionService
     let ipcBridge: AppIPCBridge
 
+    /// Monotonically bumped each time `replaySelectedProxies()` finishes a pass
+    /// (successful replay, probe-timeout giveup, or no-active-profile no-op).
+    /// HomeView keys a `.task(id:)` on this so the proxy-groups UI re-fetches
+    /// `/proxies` AFTER replay has had its chance to mutate engine state —
+    /// otherwise the view-mount fetch on the `.connected` edge races the
+    /// replay PUTs and caches pre-replay defaults.
+    private(set) var replayGeneration: Int = 0
+
     private var didBootstrap = false
 
     init() {
@@ -65,6 +73,7 @@ final class AppModel {
     /// #59 silently erased the user's picks on a single unlucky reconnect.
     /// User can re-pick if they want; stale entries are otherwise harmless.
     private func replaySelectedProxies() async {
+        defer { replayGeneration &+= 1 }
         let api = mihomoAPI
         // Cold-connect readiness probe. `meow_engine_start` returns before
         // the spawned api_server task binds :9090, so a replay fired on the

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -3,6 +3,7 @@ import SwiftData
 import SwiftUI
 
 struct HomeView: View {
+    @Environment(AppModel.self) private var appModel
     @Environment(VpnManager.self) private var vpnManager
     @Environment(AppIPCBridge.self) private var ipcBridge
     @Environment(MihomoAPI.self) private var mihomoAPI
@@ -30,6 +31,14 @@ struct HomeView: View {
         .scrollContentBackground(.hidden)
         .navigationTitle("home.nav.title")
         .task(id: vpnManager.stage) {
+            await refreshGroupsIfConnected()
+        }
+        // The stage-keyed task above fires on the `.connected` edge and races
+        // `AppModel.replaySelectedProxies`; the pre-replay fetch caches YAML
+        // defaults and the UI never re-reads post-replay engine state. Keying
+        // a second task on `replayGeneration` guarantees a re-fetch AFTER the
+        // replay pass finishes (success, probe timeout, or no-op alike).
+        .task(id: appModel.replayGeneration) {
             await refreshGroupsIfConnected()
         }
         .refreshable { await refreshGroupsIfConnected() }


### PR DESCRIPTION
Refresh proxy groups in HomeView when VPN transitions to `.connected` so UI reflects post-replay engine state.

## Summary

- #62 merged with working persistence + replay (device log confirmed engine selects the user's saved pick on relaunch).
- User still saw wrong proxy nodes in the UI → **UI-refresh bug, not a persistence bug.**
- Root cause: HomeView's `.task(id: vpnManager.stage)` fires on the synthetic attach-time `.connected` edge (from #61) and fetches `/proxies` concurrently with `AppModel.replaySelectedProxies()`. Pre-replay fetch wins → UI caches YAML-default selections → never re-reads after replay PUTs.
- Fix: `AppModel.replayGeneration` counter, bumped via `defer` at every terminal path of `replaySelectedProxies()`. HomeView adds a second `.task(id: appModel.replayGeneration)` that re-fetches after replay finishes, regardless of outcome (success, probe timeout, no-op). Idempotent under duplicate `.connected` edges.

## Path B attestation

- [x] `swiftformat --lint .` → 0 violations (80 files)
- [x] `swiftlint` → 3 warnings, **0 serious** (AppModel.swift:111 line_length 158 chars pre-existing under 200-char error threshold; HomeView file_length/type_body_length warnings pre-existing and near-threshold)
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` → **105 tests passed** on iOS 26 simulator
- [x] `git diff origin/main...HEAD --stat` verified: only `App/Sources/AppModel.swift` and `App/Sources/Views/HomeView.swift` touched, +18 lines total, no accidental additions

## Commands run

```
swiftformat --lint .
swiftlint
xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests
```