### PR TITLE
fix(lint): restore swiftlint --strict green on main

### DIFF
--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -108,7 +108,11 @@ final class AppModel {
                 try await api.selectProxy(group: group, name: proxy)
             } catch {
                 replayLog.error(
-                    "selectProxy failed group=\(group, privacy: .public) proxy=\(proxy, privacy: .public) err=\(String(describing: error), privacy: .public)",
+                    """
+                    selectProxy failed group=\(group, privacy: .public) \
+                    proxy=\(proxy, privacy: .public) \
+                    err=\(String(describing: error), privacy: .public)
+                    """,
                 )
             }
         }

--- a/App/Sources/Models/ProxyGroupModel.swift
+++ b/App/Sources/Models/ProxyGroupModel.swift
@@ -1,0 +1,48 @@
+import MeowModels
+
+/// View-model shape the proxy-groups section renders. Built from a mihomo
+/// `/proxies` response via `build(from:)`, which filters to user-selectable
+/// group types and projects each child proxy's most recent delay probe.
+struct ProxyGroupModel: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let type: String
+    let now: String?
+    let children: [Child]
+
+    struct Child: Identifiable, Equatable {
+        let id: String
+        let name: String
+        let type: String
+        let delay: Int?
+    }
+
+    /// Flatten the mihomo `/proxies` response into the subset of proxy groups
+    /// the user can interact with. `GLOBAL` is hidden because it's the
+    /// top-level aggregator, not a user-facing selector; direct/reject are
+    /// leaf proxies, not groups.
+    static func build(from dict: [String: Proxy]) -> [ProxyGroupModel] {
+        let selectable: Set = ["Selector", "URLTest", "Fallback", "LoadBalance", "Relay"]
+        return dict.values
+            .filter { selectable.contains($0.type) && $0.all != nil && $0.name != "GLOBAL" }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+            .map { group in
+                let children = (group.all ?? []).compactMap { childName -> Child? in
+                    guard let p = dict[childName] else { return nil }
+                    return Child(
+                        id: childName,
+                        name: p.name,
+                        type: p.type,
+                        delay: p.history?.last?.delay,
+                    )
+                }
+                return ProxyGroupModel(
+                    id: group.name,
+                    name: group.name,
+                    type: group.type,
+                    now: group.now,
+                    children: children,
+                )
+            }
+    }
+}

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -295,10 +295,16 @@ struct HomeView: View {
         if isConnected { return false }
         return selected.first == nil
     }
+}
 
-    // MARK: - Actions
+// MARK: - Actions
 
-    private func toggle() {
+// Methods split into an extension so swiftlint's `type_body_length` counts
+// only the declarative surface (stored state + subviews) — the action layer
+// is wiring between the view and the engine and reads as a separate concern.
+
+private extension HomeView {
+    func toggle() {
         if isConnected {
             ipcBridge.send(.stop)
             vpnManager.disconnect()
@@ -308,7 +314,7 @@ struct HomeView: View {
         }
     }
 
-    private func refreshGroupsIfConnected() async {
+    func refreshGroupsIfConnected() async {
         guard vpnManager.stage == .connected else {
             groups = []
             groupsLoadError = nil
@@ -326,7 +332,7 @@ struct HomeView: View {
         }
     }
 
-    private func select(group: String, proxy: String) async {
+    func select(group: String, proxy: String) async {
         do {
             try await mihomoAPI.selectProxy(group: group, name: proxy)
             if let profile = selected.first {
@@ -342,7 +348,7 @@ struct HomeView: View {
         }
     }
 
-    private func ping(proxy: String) async {
+    func ping(proxy: String) async {
         inflightDelay.insert(proxy)
         _ = try? await mihomoAPI.testDelay(
             proxy: proxy,
@@ -350,52 +356,6 @@ struct HomeView: View {
         )
         await refreshGroupsIfConnected()
         inflightDelay.remove(proxy)
-    }
-}
-
-// MARK: - Proxy group model
-
-struct ProxyGroupModel: Identifiable, Equatable {
-    let id: String
-    let name: String
-    let type: String
-    let now: String?
-    let children: [Child]
-
-    struct Child: Identifiable, Equatable {
-        let id: String
-        let name: String
-        let type: String
-        let delay: Int?
-    }
-
-    /// Flatten the mihomo `/proxies` response into the subset of proxy groups
-    /// the user can interact with. `GLOBAL` is hidden because it's the
-    /// top-level aggregator, not a user-facing selector; direct/reject are
-    /// leaf proxies, not groups.
-    static func build(from dict: [String: Proxy]) -> [ProxyGroupModel] {
-        let selectable: Set = ["Selector", "URLTest", "Fallback", "LoadBalance", "Relay"]
-        return dict.values
-            .filter { selectable.contains($0.type) && $0.all != nil && $0.name != "GLOBAL" }
-            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
-            .map { group in
-                let children = (group.all ?? []).compactMap { childName -> Child? in
-                    guard let p = dict[childName] else { return nil }
-                    return Child(
-                        id: childName,
-                        name: p.name,
-                        type: p.type,
-                        delay: p.history?.last?.delay,
-                    )
-                }
-                return ProxyGroupModel(
-                    id: group.name,
-                    name: group.name,
-                    type: group.type,
-                    now: group.now,
-                    children: children,
-                )
-            }
     }
 }
 


### PR DESCRIPTION
## Summary

CI's `lint` job on `main` has been red since PR #63 — three pre-existing `swiftlint --strict` violations slipped through admin-bypass merges. Fix them with real extractions (no threshold bumps) so the baseline is honest and subsequent Path B attestations can hold to `swiftlint --strict → 0`.

- **AppModel.swift:111** `line_length` (158 > 120): split the `selectProxy failed …` log call across a triple-quoted string with `\` continuations. OSLog privacy annotations preserved because each interpolation still lives inside the single logical `StringInterpolation` literal.
- **HomeView.swift:5** `type_body_length` (302 > 300): move the four `// MARK: - Actions` methods (`toggle`, `refreshGroupsIfConnected`, `select`, `ping`) into a `private extension HomeView` in the same file. Declarative surface stays in the main struct; engine-wiring actions read as a separate concern.
- **HomeView.swift:609** `file_length` (609 > 600): extract `ProxyGroupModel` (value type + `build(from:)` projector) into a new file at `App/Sources/Models/ProxyGroupModel.swift`. It's already decoupled from SwiftUI — only consumes `Proxy` from `MeowModels` — so the move is pure code motion.

Thresholds in `.swiftlint.yml` stay at their prior 600/300/800/400 values.

## Local verification (Path B attestation)

- `swiftformat --lint .` → `0/81 files require formatting`
- `swiftlint --strict` → `Found 0 violations, 0 serious in 72 files` (exit 0)
- `xcodebuild test -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` → `Test run with 105 tests in 20 suites passed`
- `git diff origin/main...HEAD --stat` → 3 files: `.swiftlint.yml` (no diff vs main), `App/Sources/AppModel.swift`, `App/Sources/Views/HomeView.swift`, plus new `App/Sources/Models/ProxyGroupModel.swift`.

## Test plan

- [x] swiftformat lint green
- [x] swiftlint --strict green (0 violations, thresholds unchanged)
- [x] MeowTests green on iPhone 17 sim
- [ ] Remote CI green (this PR's whole point — no admin bypass, let CI actually run)

Not admin-bypassing: the lint job on main has been slipping through attestation-based bypasses for several PRs and this one needs remote CI to actually run and go green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)