### PR TITLE
chore(rust): bump mihomo-rust to 7a5a4634 — /logs WS + async config

### DIFF
--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -332,6 +332,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -448,6 +450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +485,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -629,6 +647,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dynosaur"
@@ -1000,21 +1024,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
+ "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "h2",
+ "http",
  "idna",
  "ipnet",
  "once_cell",
  "rand 0.9.4",
  "ring",
+ "rustls",
  "serde",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "url",
 ]
@@ -1034,9 +1063,11 @@ dependencies = [
  "parking_lot",
  "rand 0.9.4",
  "resolv-conf",
+ "rustls",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tracing",
 ]
 
@@ -1345,7 +1376,7 @@ dependencies = [
  "socket2 0.6.3",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1394,6 +1425,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1567,39 +1608,51 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "mihomo-api"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 dependencies = [
+ "arc-swap",
  "axum",
+ "base64",
  "dashmap 6.1.0",
  "futures",
+ "libc",
  "mihomo-common",
  "mihomo-config",
  "mihomo-dns",
  "mihomo-proxy",
+ "mihomo-rules",
  "mihomo-tunnel",
  "parking_lot",
+ "prometheus-client",
  "serde",
  "serde_json",
  "serde_yaml",
  "subtle",
+ "sysinfo",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "mihomo-common"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 dependencies = [
  "async-trait",
  "bytes",
+ "httparse",
+ "ipnet",
  "libc",
  "libproc",
+ "parking_lot",
  "serde",
  "serde_json",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1609,11 +1662,12 @@ dependencies = [
 [[package]]
 name = "mihomo-config"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "ipnet",
  "maxminddb",
  "mihomo-common",
  "mihomo-dns",
@@ -1621,10 +1675,13 @@ dependencies = [
  "mihomo-rules",
  "mihomo-transport",
  "mihomo-trie",
+ "parking_lot",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1633,16 +1690,18 @@ dependencies = [
 [[package]]
 name = "mihomo-dns"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 dependencies = [
  "anyhow",
  "async-trait",
  "dashmap 6.1.0",
+ "futures",
  "hickory-proto",
  "hickory-resolver",
  "hickory-server",
  "ipnet",
  "lru",
+ "maxminddb",
  "mihomo-common",
  "mihomo-trie",
  "parking_lot",
@@ -1660,6 +1719,7 @@ dependencies = [
  "base64",
  "bytes",
  "cbindgen",
+ "dashmap 6.1.0",
  "futures",
  "http-body-util",
  "hyper",
@@ -1692,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "mihomo-proxy"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1709,6 +1769,7 @@ dependencies = [
  "mihomo-transport",
  "parking_lot",
  "rand 0.9.4",
+ "regex",
  "reqwest",
  "rustls",
  "serde",
@@ -1727,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "mihomo-rules"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 dependencies = [
  "ipnet",
  "maxminddb",
@@ -1737,12 +1798,13 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
 name = "mihomo-transport"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1766,12 +1828,12 @@ dependencies = [
 [[package]]
 name = "mihomo-trie"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 
 [[package]]
 name = "mihomo-tunnel"
 version = "0.4.0"
-source = "git+https://github.com/madeye/mihomo-rust?branch=main#6b9af50b695d05451a03dcef854823b0bb8ff2bf"
+source = "git+https://github.com/madeye/mihomo-rust?branch=main#7a5a4634b62a3ffb79a8bed4b5f0a42a0cd278a1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1780,6 +1842,7 @@ dependencies = [
  "mihomo-dns",
  "mihomo-proxy",
  "mihomo-rules",
+ "mihomo-trie",
  "parking_lot",
  "serde",
  "serde_json",
@@ -1881,6 +1944,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2006,6 +2078,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2185,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2242,6 +2343,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2798,6 +2919,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,10 +3007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2883,6 +3020,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -3133,6 +3280,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,12 +3299,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3478,12 +3638,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3499,8 +3725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3888,3 +4123,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -19,6 +19,10 @@ needless_return = "allow"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "macros", "time", "signal"] }
 parking_lot = "0.12"
 futures = "0.3"
+# Explicit pin — transitive through mihomo-tunnel, but engine.rs builds
+# `DashMap<String, Arc<ProxyProvider>>` for ApiServer::new and tun2socks.rs
+# uses the same NAT-key concrete type as mihomo-tunnel. Match upstream's 6.x.
+dashmap = "6"
 
 # Logging
 tracing = "0.1"

--- a/core/rust/mihomo-ios-ffi/src/engine.rs
+++ b/core/rust/mihomo-ios-ffi/src/engine.rs
@@ -10,14 +10,22 @@
 //! releases the ports synchronously, so a fast `start → stop → start` cycle
 //! doesn't race the previous bind (`EADDRINUSE`).
 use anyhow::Result;
+use dashmap::DashMap;
+use mihomo_api::log_stream::{LogBroadcastLayer, LogMessage};
 use mihomo_api::ApiServer;
 use mihomo_config::{load_config, load_config_from_str};
 use mihomo_dns::DnsServer;
 use mihomo_tunnel::{Statistics, Tunnel};
 use parking_lot::{Mutex, RwLock};
-use std::sync::{Arc, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Once, OnceLock};
+use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::prelude::*;
+
+use crate::logging::LogForwardLayer;
 
 struct EngineState {
     stats: Arc<Statistics>,
@@ -35,14 +43,48 @@ fn install_tls_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
+/// Process-wide log broadcast channel. Registered into the tracing subscriber
+/// on first `start()` and handed to every subsequent `ApiServer::new` —
+/// tracing's global default can only be set once, so the channel (and the
+/// registry that feeds it) outlive individual engine lifetimes.
+fn log_broadcast_tx() -> &'static broadcast::Sender<LogMessage> {
+    static TX: OnceLock<broadcast::Sender<LogMessage>> = OnceLock::new();
+    TX.get_or_init(|| {
+        let (tx, _rx) = broadcast::channel(128);
+        tx
+    })
+}
+
+/// Install the tracing subscriber once per process. Subsequent calls are
+/// no-ops — re-invoking `set_global_default` after start/stop/start would
+/// panic with `SetGlobalDefaultError`.
+fn install_tracing_subscriber() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let log_layer = LogBroadcastLayer { tx: log_broadcast_tx().clone() }
+            .with_filter(LevelFilter::TRACE);
+        // `try_init` returns Err if another subscriber beat us to the global
+        // slot (unlikely in the FFI, but be defensive — panicking here would
+        // abort the extension).
+        let _ = tracing_subscriber::registry()
+            .with(LogForwardLayer)
+            .with(log_layer)
+            .try_init();
+    });
+}
+
 pub fn start(config_path: &str) -> Result<()> {
     if slot().lock().is_some() {
         return Ok(());
     }
 
     install_tls_provider();
+    install_tracing_subscriber();
 
-    let cfg = load_config(config_path)?;
+    // `load_config` is async as of the 2026-04-19 mihomo-rust bump
+    // (rule-provider cache is fetched eagerly during config build). Bridge to
+    // our shared runtime rather than spawning a single-use one.
+    let cfg = crate::get_runtime().block_on(load_config(config_path))?;
     let raw_config = Arc::new(RwLock::new(cfg.raw.clone()));
 
     let tunnel = Tunnel::new(cfg.dns.resolver.clone());
@@ -50,6 +92,19 @@ pub fn start(config_path: &str) -> Result<()> {
     tunnel.update_rules(cfg.rules);
     tunnel.update_proxies(cfg.proxies);
     let stats = tunnel.statistics().clone();
+
+    // `ApiServer::new` grew from 5 to 9 parameters to serve the new
+    // `/providers/*`, `/rules`, `/listeners`, and `/logs` routes. Build the
+    // required shapes from the loaded Config.
+    let proxy_providers = {
+        let map: DashMap<_, _> = cfg.proxy_providers.into_iter().collect();
+        Arc::new(map)
+    };
+    let rule_providers = Arc::new(RwLock::new(
+        cfg.rule_providers.into_iter().collect::<HashMap<_, _>>(),
+    ));
+    let listeners = cfg.listeners.named.clone();
+    let log_tx = log_broadcast_tx().clone();
 
     let dns_task = cfg.dns.listen_addr.map(|addr| {
         let resolver = cfg.dns.resolver.clone();
@@ -68,6 +123,10 @@ pub fn start(config_path: &str) -> Result<()> {
             cfg.api.secret.clone(),
             config_path.to_string(),
             raw_config,
+            log_tx,
+            proxy_providers,
+            rule_providers,
+            listeners,
         );
         crate::get_runtime().spawn(async move {
             if let Err(e) = api_server.run().await {
@@ -123,6 +182,6 @@ pub fn tunnel() -> Option<Tunnel> {
 
 pub fn validate(yaml: &str) -> Result<()> {
     install_tls_provider();
-    let _ = load_config_from_str(yaml)?;
+    let _ = crate::get_runtime().block_on(load_config_from_str(yaml))?;
     Ok(())
 }

--- a/core/rust/mihomo-ios-ffi/src/logging.rs
+++ b/core/rust/mihomo-ios-ffi/src/logging.rs
@@ -1,4 +1,11 @@
 //! os_log-backed logger. Replaces the Android `android_logger` crate.
+//!
+//! mihomo-rust uses `tracing` throughout; our oslog bridge sits on `log`.
+//! `LogForwardLayer` is a `tracing_subscriber::Layer` that forwards every
+//! tracing event to `log::log!` so engine output reaches the Apple unified
+//! log through the same pipe as our own `logging::bridge_log` calls. Installed
+//! from `engine::start` alongside `mihomo_api::log_stream::LogBroadcastLayer`
+//! (the latter powers the REST `/logs` WebSocket).
 
 use log::info;
 use std::sync::Once;
@@ -22,4 +29,54 @@ pub fn init_os_logger() {
 
 pub fn bridge_log(msg: &str) {
     info!("{}", msg);
+}
+
+// ---------------------------------------------------------------------------
+// tracing → log bridge
+// ---------------------------------------------------------------------------
+
+/// Forwards every tracing event to `log::log!` so mihomo-rust's
+/// `tracing::{info,warn,error,debug,trace}!` calls reach the oslog bridge.
+/// Field-recording matches `LogBroadcastLayer::MessageVisitor` — only the
+/// `message` field becomes the log line; structured fields are dropped
+/// (oslog doesn't render them anyway).
+pub struct LogForwardLayer;
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for LogForwardLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let level = match *event.metadata().level() {
+            tracing::Level::TRACE => log::Level::Trace,
+            tracing::Level::DEBUG => log::Level::Debug,
+            tracing::Level::INFO => log::Level::Info,
+            tracing::Level::WARN => log::Level::Warn,
+            tracing::Level::ERROR => log::Level::Error,
+        };
+        let target = event.metadata().target();
+        if !log::log_enabled!(target: target, level) {
+            return;
+        }
+        let mut visitor = MessageVisitor(String::new());
+        event.record(&mut visitor);
+        log::log!(target: target, level, "{}", visitor.0);
+    }
+}
+
+struct MessageVisitor(String);
+
+impl tracing::field::Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0 = format!("{:?}", value);
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.0 = value.to_string();
+        }
+    }
 }

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -146,7 +146,11 @@ async fn run_tun2socks(
     let (mut udp_read, udp_write) = udp_socket.split();
 
     let (udp_reply_tx, mut udp_reply_rx) = mpsc::unbounded_channel::<UdpMsg>();
-    let reply_readers: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+    // NAT key mirrors mihomo-tunnel's `NatTable = DashMap<(SocketAddr, SocketAddr), Arc<UdpSession>>`
+    // post-ADR-0008 Direction-A refactor. We must key reader spawns on the
+    // same tuple mihomo-tunnel uses, or dedupe breaks and we leak readers.
+    let reply_readers: Arc<Mutex<HashSet<(SocketAddr, SocketAddr)>>> =
+        Arc::new(Mutex::new(HashSet::new()));
 
     let (stack_ingress_tx, mut stack_ingress_rx) = mpsc::channel::<AnyIpPktFrame>(256);
     let (egress_tx, mut egress_rx) = mpsc::unbounded_channel::<Vec<u8>>();
@@ -352,7 +356,7 @@ async fn dispatch_udp(
     src: SocketAddr,
     dst: SocketAddr,
     reply_tx: mpsc::UnboundedSender<UdpMsg>,
-    reply_readers: Arc<Mutex<HashSet<String>>>,
+    reply_readers: Arc<Mutex<HashSet<(SocketAddr, SocketAddr)>>>,
 ) {
     let Some(tunnel) = crate::engine::tunnel() else {
         logging::bridge_log("tun2socks: engine not running, dropping UDP datagram");
@@ -364,7 +368,7 @@ async fn dispatch_udp(
         None => (String::new(), Some(dst.ip())),
     };
 
-    let metadata = Metadata {
+    let mut metadata = Metadata {
         network: Network::Udp,
         conn_type: ConnType::Inner,
         src_ip: Some(src.ip()),
@@ -375,14 +379,22 @@ async fn dispatch_udp(
         ..Default::default()
     };
 
-    // Matches mihomo_tunnel::udp::handle_udp's NAT key shape. `remote_address`
-    // prefers host over dst_ip, which is stable across the internal
-    // pre_resolve call.
-    let key = format!("{}:{}", src, metadata.remote_address());
+    // ADR-0008 post-Direction-A NAT key: (src SocketAddr, resolved dst
+    // SocketAddr). mihomo-tunnel calls `pre_resolve` internally before
+    // inserting into `nat_table`; we must match its output exactly or the
+    // subsequent `nat_table.get(&key)` misses. Calling `pre_resolve` here
+    // (same method handle_udp would call) guarantees parity for fake-ip /
+    // host-mode flows — it's idempotent once `dst_ip` is populated.
+    tunnel.inner().pre_resolve(&mut metadata).await;
+    let Some(resolved_ip) = metadata.dst_ip else {
+        // Resolution failed — handle_udp will also bail, nothing to dispatch.
+        return;
+    };
+    let key = (src, SocketAddr::new(resolved_ip, metadata.dst_port));
 
     mihomo_tunnel::udp::handle_udp(tunnel.inner(), &payload, src, metadata).await;
 
-    if !reply_readers.lock().insert(key.clone()) {
+    if !reply_readers.lock().insert(key) {
         return;
     }
 
@@ -397,12 +409,12 @@ async fn dispatch_udp(
 }
 
 fn spawn_udp_reply_reader(
-    key: String,
+    key: (SocketAddr, SocketAddr),
     session: Arc<UdpSession>,
     app_src: SocketAddr,
     app_dst: SocketAddr,
     reply_tx: mpsc::UnboundedSender<UdpMsg>,
-    reply_readers: Arc<Mutex<HashSet<String>>>,
+    reply_readers: Arc<Mutex<HashSet<(SocketAddr, SocketAddr)>>>,
     tunnel_inner: Arc<TunnelInner>,
 ) {
     tokio::spawn(async move {
@@ -420,7 +432,7 @@ fn spawn_udp_reply_reader(
                     }
                 }
                 Err(e) => {
-                    info!("UDP reply reader closing for {}: {}", key, e);
+                    info!("UDP reply reader closing for {:?}: {}", key, e);
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
Bumps the `mihomo-rust` pin from `6b9af50` to `7a5a4634` (2026-04-19) and adapts the iOS FFI crate to the new upstream API surface. Single commit on top of `main` (4ae25e0).

Behaviour gains on the client side:
- `/logs` WebSocket now streams tracing events (upstream landed the route + 15 WS integration tests on 2026-04-19).
- mihomo-rust's `tracing::info!/warn!/error!` calls reach oslog via a new `LogForwardLayer`, so engine-side diagnostics no longer vanish between the Rust side and Console.app.
- NAT key now tuple-based end-to-end, matching mihomo-tunnel's post-ADR-0008 Direction-A refactor — prevents fake-ip / host-mode UDP `nat_table.get(&key)` misses.

## API surface changes
- `ApiServer::new` grew 5 → 9 args (`log_tx`, `proxy_providers`, `rule_providers`, `listeners`); engine.rs builds the required `Arc<DashMap<...>>`, `Arc<RwLock<HashMap<...>>>`, `Vec<NamedListener>` shapes from the loaded `Config`.
- `load_config` / `load_config_from_str` are now async — bridged through `get_runtime().block_on(...)` so the C-ABI entry points stay sync.
- `pre_resolve(&mut metadata).await` in `dispatch_udp` before building the NAT key, so we key on the same resolved tuple mihomo-tunnel inserts.
- Global tracing subscriber installed once per process via `Once::call_once` (tracing's `set_default` is install-once). `log_broadcast_tx()` uses a static `OnceLock<broadcast::Sender>` so the /logs channel outlives individual engine lifetimes.
- Explicit `dashmap = "6"` in `Cargo.toml` (was transitive) — engine.rs constructs `DashMap<String, Arc<ProxyProvider>>` directly for `ApiServer::new`.

## Path B attestation (no admin bypass requested; let remote CI run)

Rebased onto `main` at 4ae25e0 (the lint-fix PR #64 that went in just before this). Ran locally at the repo root:

- `swiftformat --lint .` → `0/81 files require formatting`
- `swiftlint --strict` → `0 violations, 0 serious in 72 files`
- `cargo test --lib` in `core/rust/mihomo-ios-ffi/` → `4 passed`
- `scripts/build-rust.sh` → xcframework written to `MeowCore/Frameworks/MihomoCore.xcframework` (device + simulator slices, release profile, both stripped)
- `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` on iPhone 17 (iOS 26.4 sim) → `** TEST SUCCEEDED **`; MeowIntegrationTests: `Test run with 26 tests in 4 suites passed`.

First xcodebuild attempt hit the known `Application failed preflight checks / Busy` simulator flake; the retry ran to completion. All other checks passed on first try.

`git diff origin/main...HEAD --stat` was verified — the file list matches `core/rust/mihomo-ios-ffi/{Cargo.toml,src/engine.rs,src/tun2socks.rs,src/logging.rs}` plus the pinned `mihomo-rust` submodule bump. No accidental additions.

## Test plan
- [x] `cargo test --lib` in `core/rust/mihomo-ios-ffi/`
- [x] `scripts/build-rust.sh` (size budget ≤ 8 MB stripped — unchanged from main)
- [x] `xcodebuild test -only-testing:MeowTests -only-testing:MeowIntegrationTests` on iPhone 17 sim (iOS 26.4)
- [x] `swiftlint --strict` + `swiftformat --lint .` at repo root
- [ ] Remote CI green (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)