### PR TITLE
fix(ne): NE reliability — tracing filter, tokio workers, VPN on-demand

### DIFF
--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -54,12 +54,18 @@ final class VpnManager {
     }
 
     /// Kick off a connect. Caller should have already written the selected
-    /// profile YAML into the App Group container.
+    /// profile YAML into the App Group container. Re-enables on-demand if
+    /// `disconnect` previously turned it off.
     func connect() async {
         lastError = nil
         do {
             if manager == nil { await refresh() }
             guard let manager else { return }
+            if !manager.isOnDemandEnabled {
+                manager.isOnDemandEnabled = true
+                try await manager.saveToPreferences()
+                try await manager.loadFromPreferences()
+            }
             try manager.connection.startVPNTunnel()
         } catch {
             lastError = error.localizedDescription
@@ -67,8 +73,18 @@ final class VpnManager {
         }
     }
 
-    func disconnect() {
-        manager?.connection.stopVPNTunnel()
+    /// Disable on-demand first, then tear down the tunnel. iOS reclaims the NE
+    /// under media/CPU/network pressure and normally auto-reconnects via the
+    /// on-demand rule — so we have to actively disable it when the user
+    /// intentionally wants the VPN off.
+    func disconnect() async {
+        guard let manager else { return }
+        if manager.isOnDemandEnabled {
+            manager.isOnDemandEnabled = false
+            try? await manager.saveToPreferences()
+            try? await manager.loadFromPreferences()
+        }
+        manager.connection.stopVPNTunnel()
     }
 
     // MARK: - Private
@@ -84,9 +100,30 @@ final class VpnManager {
         proto.providerConfiguration = [
             "appGroup": AppGroup.identifier,
         ]
+        // Keep the tunnel alive across screen lock — iOS defaults to false
+        // on packet-tunnel providers but we set it explicitly because any
+        // future protocol tweak that re-uses the default would regress this.
+        proto.disconnectOnSleep = false
+        // NOTE: `includeAllNetworks = true` was trialed as an iOS reclaim
+        // mitigation. Observed on-device: kill frequency went UP (two
+        // reclaims within 40s of each other, same (1,7,9) tuple as before)
+        // AND first-reconnect latency regressed from 5.4s to 8.1s. So we
+        // explicitly do NOT set it; the on-demand rule below handles the
+        // reclaim case invisibly regardless.
         mgr.protocolConfiguration = proto
         mgr.localizedDescription = "meow"
         mgr.isEnabled = true
+        // iOS reclaims NE extensions under resource pressure (media playback
+        // resource arbiter, network-stack APN refresh, containing app entering
+        // after-life). Without on-demand, the user sees "VPN died" and has to
+        // toggle manually. With on-demand + an always-connect rule, iOS
+        // auto-reestablishes the tunnel the moment the kernel sees an outbound
+        // flow on any interface. `disconnect()` disables on-demand before
+        // stopping so the user can still turn the VPN off.
+        let rule = NEOnDemandRuleConnect()
+        rule.interfaceTypeMatch = .any
+        mgr.onDemandRules = [rule]
+        mgr.isOnDemandEnabled = true
     }
 
     private func attach(_ mgr: NETunnelProviderManager) {

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -307,7 +307,7 @@ private extension HomeView {
     func toggle() {
         if isConnected {
             ipcBridge.send(.stop)
-            vpnManager.disconnect()
+            Task { await vpnManager.disconnect() }
         } else {
             ipcBridge.send(.start, profileID: selected.first?.id)
             Task { await vpnManager.connect() }

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -63,7 +63,7 @@ struct SettingsView: View {
                     LabeledContent("Egress pkts", value: "\(ipcBridge.currentTraffic.egressPackets)")
                     Button("Install NE profile") { Task { await vpnManager.refresh() } }
                     Button("Connect (no profile required)") { Task { await vpnManager.connect() } }
-                    Button("Disconnect", role: .destructive) { vpnManager.disconnect() }
+                    Button("Disconnect", role: .destructive) { Task { await vpnManager.disconnect() } }
                     NavigationLink("Open Diagnostics") {
                         DiagnosticsPanelView()
                             .ignoresSafeArea(edges: .bottom)

--- a/core/rust/mihomo-ios-ffi/src/engine.rs
+++ b/core/rust/mihomo-ios-ffi/src/engine.rs
@@ -136,10 +136,17 @@ fn log_broadcast_tx() -> &'static broadcast::Sender<LogMessage> {
 fn install_tracing_subscriber() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
+        // INFO, not TRACE. serde emits per-`deserialize_any` / `deserialize_option`
+        // spans at TRACE; under burst load (video streaming + simultaneous
+        // `/configs` or `/providers` hits from the main app) this flooded the
+        // broadcast channel with thousands of events per second. Each event is
+        // processed synchronously on the emitting tokio worker via `on_event`,
+        // starving the 2-worker runtime until TCP flow handling stalled. The
+        // /logs WebSocket consumers never wanted serde trace spans anyway.
         let log_layer = LogBroadcastLayer {
             tx: log_broadcast_tx().clone(),
         }
-        .with_filter(LevelFilter::TRACE);
+        .with_filter(LevelFilter::INFO);
         // `try_init` returns Err if another subscriber beat us to the global
         // slot (unlikely in the FFI, but be defensive — panicking here would
         // abort the extension).

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -40,8 +40,16 @@ static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 pub(crate) fn get_runtime() -> &'static tokio::runtime::Runtime {
     RUNTIME.get_or_init(|| {
+        // 4 workers, not 2. Observed under load: during a burst of concurrent
+        // TLS dials + DoH resolutions + /configs or /providers handler work,
+        // the previous 2-worker runtime could starve — both workers busy on
+        // serde/TLS CPU work while new TCP flows queued up, eventually the
+        // tunnel stopped making progress (same PID, no death, just frozen).
+        // 4 gives the scheduler enough headroom on iPhone 17 Pro without
+        // meaningfully increasing resident memory (per-worker stack is ~2 MB
+        // of virtual address space, not committed).
         tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
+            .worker_threads(4)
             .enable_all()
             .build()
             .expect("failed to create tokio runtime")


### PR DESCRIPTION
## Summary

Two commits addressing NE reliability during heavy traffic on iPhone 17 Pro / iOS 26.4.1. Both came out of live-syslog instrumentation captured during video streaming + Threads login flows.

### Commit 1 — \`perf(ffi)\`: tracing filter + tokio workers

1. **\`LogBroadcastLayer\` filter \`TRACE → INFO\`.** At TRACE, serde's \`deserialize_any\`/\`deserialize_option\` internal spans emit per nested value. Under burst load the broadcast channel saw thousands of events/sec; each runs synchronously on the emitting tokio worker via \`on_event\`, starving the runtime. /logs WebSocket consumers never wanted serde internals.
2. **tokio \`worker_threads\` 2 → 4.** With 2, both workers could be busy on CPU-bound serde/TLS while new TCP flows queued, eventually the runtime stopped making progress (same PID, no death, just frozen — a serde trace burst followed by 24 minutes of silence was captured).

### Commit 2 — \`feat(vpn)\`: on-demand + disconnectOnSleep=false

Even with the Rust fixes, iOS *will* reclaim the NE under the right pressure — the tuple \`termination reported by launchd (1, 7, 9)\` shows up after \`FigPlayerResourceArbiter\` + CommCenter APN refresh + main app in \`com.apple.frontboard.after-life.interrupted\`. No memory kill, no crashlog, no panic. Pure iOS extension lifecycle.

Adding \`NEOnDemandRuleConnect\` with \`interfaceTypeMatch = .any\` tells iOS to re-establish the tunnel the moment the kernel sees an outbound flow. On-device the kill→new-NE-running gap is ~5.4s, iOS owns most of that. Crucially, the Settings-level VPN status toggle never shows Disconnected from the user's perspective.

\`disconnect()\` disables on-demand before \`stopVPNTunnel\` (otherwise iOS would auto-reconnect immediately and the Off toggle would appear to do nothing) and goes async to guarantee \`saveToPreferences\` completes before stop. \`HomeView\` toggle and \`SettingsView\` debug button wrap it in Task.

\`disconnectOnSleep\` pinned to false (defaults false for packet-tunnel, but a future protocolConfiguration tweak could regress).

A NOTE in \`configureIfNeeded\` documents why \`includeAllNetworks\` is NOT set — on-device testing of that flag made kill frequency go *up* and reconnect latency regressed from 5.4s to 8.1s.

## Test plan

- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 8/8 green (includes the ss-feature regression test from #67)
- [x] \`xcodebuild -scheme meow-ios build\` → BUILD SUCCEEDED
- [x] On-device: Threads login + Rednote shorts still trigger occasional iOS reclaims (that's iOS policy, not fixable from our side), but on-demand recovers invisibly and VPN status never flips to Disconnected
- [ ] Full remote CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)