### PR TITLE
chore(version): bump to 1.1.0 (build 2026042401)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026041901</string>
+	<string>2026042401</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2026041901</string>
+	<string>2026042401</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -43,8 +43,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.0.0"
-        CFBundleVersion: "2026041901"
+        CFBundleShortVersionString: "1.1.0"
+        CFBundleVersion: "2026042401"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -184,8 +184,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.0.0"
-        CFBundleVersion: "2026041901"
+        CFBundleShortVersionString: "1.1.0"
+        CFBundleVersion: "2026042401"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary
- Bumps marketing version `1.0.0` → `1.1.0` and build `2026041901` → `2026042401` across `project.yml`, `App/Info.plist`, and `PacketTunnel/Info.plist`.

## Path B attestation
Diff touches `project.yml` + Info.plists (code-path per CLAUDE.md), but is pure metadata — no Swift/Rust source changed.

- [x] `swiftlint --strict` at repo root → 0 violations
- [x] `swiftformat --lint .` at repo root → 0 violations on tracked files (pre-existing violations only in untracked `build-derived/SourcePackages/`)
- [x] `xcodegen generate` → project regenerates cleanly
- [x] `xcodebuild build -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17'` → BUILD SUCCEEDED
- [x] `xcodebuild test -only-testing:MeowTests ... iPhone 17` → 105 tests / 20 suites passed
- [x] `git diff origin/main...HEAD --stat` → only the 3 intended files

## Test plan
- [x] Local build + MeowTests green on iPhone 17 simulator (iOS 26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)