### PR TITLE
fix(altstore): drop empty patreonURL from source.json

### DIFF
--- a/docs/source.json
+++ b/docs/source.json
@@ -6,7 +6,6 @@
   "iconURL": "https://madeye.github.io/meow-ios/icon.png",
   "headerURL": "https://madeye.github.io/meow-ios/icon.png",
   "website": "https://github.com/madeye/meow-ios",
-  "patreonURL": "",
   "tintColor": "#5BC0EB",
   "featuredApps": ["io.github.madeye.meow"],
   "apps": [


### PR DESCRIPTION
## Summary
- AltStore validates \`patreonURL\` as a URL string. An empty string \`\"\"\` fails with \"invalid URL string\" and prevents users from adding the source.
- Omits the key entirely; AltStore treats absent as \"no Patreon\" and accepts the source.

## Path A (non-code)
\`docs/source.json\` only.

## Test plan
- [x] \`python3 -m json.tool docs/source.json\` — parses
- [ ] Post-merge: verify https://madeye.github.io/meow-ios/source.json loads in AltStore / SideStore without the invalid-URL error