### PR TITLE
fix(appgroup): resolve identifier from embedded.mobileprovision

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042401</string>
+	<string>2026042402</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/MeowShared/Sources/MeowModels/AppGroup.swift
+++ b/MeowShared/Sources/MeowModels/AppGroup.swift
@@ -2,7 +2,42 @@ import Foundation
 
 /// Shared App Group identifier used by the app and the packet-tunnel extension.
 public enum AppGroup {
-    public static let identifier = "group.io.github.madeye.meow"
+    /// Authored identifier as declared in the .entitlements files. Apple-signed
+    /// builds (TestFlight / App Store) preserve this verbatim — the embedded
+    /// provisioning profile is absent on App Store builds, so `identifier`
+    /// resolves to this constant. Sideloaders (AltStore / SideStore) rewrite
+    /// the app-group entitlement to append the installer's team prefix.
+    public static let authoredIdentifier = "group.io.github.madeye.meow"
+
+    /// Live app-group identifier. For Ad Hoc / Development / Enterprise builds
+    /// we read the first `com.apple.security.application-groups` entry out of
+    /// the bundle's `embedded.mobileprovision`, which is where AltStore's
+    /// team-prefix rewrite lands. App Store builds strip that file, so we fall
+    /// back to `authoredIdentifier` — fine because Apple signs with the
+    /// authoring team and the identifier is preserved verbatim.
+    public static let identifier: String = resolveIdentifier()
+
+    private static func resolveIdentifier() -> String {
+        guard let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"),
+              let data = try? Data(contentsOf: url),
+              let ascii = String(data: data, encoding: .ascii),
+              let start = ascii.range(of: "<plist"),
+              let end = ascii.range(of: "</plist>", range: start.upperBound ..< ascii.endIndex)
+        else {
+            return authoredIdentifier
+        }
+        let plistSlice = Data(ascii[start.lowerBound ..< end.upperBound].utf8)
+        guard
+            let parsed = try? PropertyListSerialization.propertyList(from: plistSlice, format: nil),
+            let plist = parsed as? [String: Any],
+            let entitlements = plist["Entitlements"] as? [String: Any],
+            let groups = entitlements["com.apple.security.application-groups"] as? [String],
+            let first = groups.first
+        else {
+            return authoredIdentifier
+        }
+        return first
+    }
 
     /// Root of the shared container visible to both processes.
     public static var containerURL: URL {

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>2026042401</string>
+	<string>2026042402</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/PacketTunnel/Sources/MWAppGroup.h
+++ b/PacketTunnel/Sources/MWAppGroup.h
@@ -4,6 +4,7 @@
 extern NSString *const MWAppGroupIdentifier;
 
 @interface MWAppGroup : NSObject
+@property (class, nonatomic, readonly) NSString *identifier;
 @property (class, nonatomic, readonly) NSURL *containerURL;
 @property (class, nonatomic, readonly) NSURL *configURL;
 @property (class, nonatomic, readonly) NSURL *effectiveConfigURL;

--- a/PacketTunnel/Sources/MWAppGroup.m
+++ b/PacketTunnel/Sources/MWAppGroup.m
@@ -1,13 +1,55 @@
 #import "MWAppGroup.h"
 
+// Authored identifier as declared in PacketTunnel.entitlements. App Store
+// builds strip the embedded provisioning profile, so `+identifier` returns
+// this constant — fine because Apple signs with the authoring team and the
+// entitlement is preserved verbatim. Sideloaders (AltStore / SideStore) keep
+// the embedded.mobileprovision and rewrite the app-group entitlement to
+// append the installer's team prefix; `+identifier` reads that at runtime.
+static NSString *const MWAppGroupAuthoredIdentifier = @"group.io.github.madeye.meow";
+
 NSString *const MWAppGroupIdentifier = @"group.io.github.madeye.meow";
 
 @implementation MWAppGroup
 
++ (NSString *)identifier {
+    static NSString *resolved;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        resolved = MWAppGroupAuthoredIdentifier;
+        NSURL *url = [[NSBundle mainBundle] URLForResource:@"embedded" withExtension:@"mobileprovision"];
+        if (url == nil) { return; }
+        NSData *data = [NSData dataWithContentsOfURL:url];
+        if (data == nil) { return; }
+        NSString *ascii = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
+        if (ascii == nil) { return; }
+        NSRange start = [ascii rangeOfString:@"<plist"];
+        if (start.location == NSNotFound) { return; }
+        NSRange end = [ascii rangeOfString:@"</plist>" options:0
+                                    range:NSMakeRange(NSMaxRange(start), ascii.length - NSMaxRange(start))];
+        if (end.location == NSNotFound) { return; }
+        NSString *slice = [ascii substringWithRange:NSMakeRange(start.location, NSMaxRange(end) - start.location)];
+        NSData *plistData = [slice dataUsingEncoding:NSUTF8StringEncoding];
+        NSError *error = nil;
+        id parsed = [NSPropertyListSerialization propertyListWithData:plistData options:0 format:NULL error:&error];
+        if (![parsed isKindOfClass:[NSDictionary class]]) { return; }
+        NSDictionary *entitlements = parsed[@"Entitlements"];
+        if (![entitlements isKindOfClass:[NSDictionary class]]) { return; }
+        NSArray *groups = entitlements[@"com.apple.security.application-groups"];
+        if (![groups isKindOfClass:[NSArray class]] || groups.count == 0) { return; }
+        id first = groups.firstObject;
+        if ([first isKindOfClass:[NSString class]]) {
+            resolved = [first copy];
+        }
+    });
+    return resolved;
+}
+
 + (NSURL *)containerURL {
+    NSString *identifier = [self identifier];
     NSURL *url = [[NSFileManager defaultManager]
-        containerURLForSecurityApplicationGroupIdentifier:MWAppGroupIdentifier];
-    NSAssert(url, @"App Group container unavailable — entitlement missing '%@'", MWAppGroupIdentifier);
+        containerURLForSecurityApplicationGroupIdentifier:identifier];
+    NSAssert(url, @"App Group container unavailable — entitlement missing '%@'", identifier);
     return url;
 }
 
@@ -28,8 +70,9 @@ NSString *const MWAppGroupIdentifier = @"group.io.github.madeye.meow";
 }
 
 + (NSUserDefaults *)defaults {
-    NSUserDefaults *d = [[NSUserDefaults alloc] initWithSuiteName:MWAppGroupIdentifier];
-    NSAssert(d, @"Shared UserDefaults unavailable for suite '%@'", MWAppGroupIdentifier);
+    NSString *identifier = [self identifier];
+    NSUserDefaults *d = [[NSUserDefaults alloc] initWithSuiteName:identifier];
+    NSAssert(d, @"Shared UserDefaults unavailable for suite '%@'", identifier);
     return d;
 }
 

--- a/docs/source.json
+++ b/docs/source.json
@@ -21,10 +21,19 @@
       "screenshotURLs": [],
       "versions": [
         {
+          "version": "1.1.1",
+          "buildVersion": "2026042402",
+          "date": "2026-04-24T00:00:00Z",
+          "localizedDescription": "- Fix instant crash on AltStore / SideStore sideload: app-group identifier is now resolved from the embedded provisioning profile at runtime, so team-prefix rewrites by re-signers no longer hit a hard-coded lookup.\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
+          "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.1/meow-ios-1.1.1-b2026042402-adhoc.ipa",
+          "size": 9267134,
+          "minOSVersion": "17.0"
+        },
+        {
           "version": "1.1.0",
           "buildVersion": "2026042401",
           "date": "2026-04-24T00:00:00Z",
-          "localizedDescription": "- Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker)\n- On-demand VPN enabled, disconnectOnSleep=false\n- Build tooling & logging improvements",
+          "localizedDescription": "- Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker)\n- On-demand VPN enabled, disconnectOnSleep=false\n- Build tooling & logging improvements\n\nNote: this build has a hard-coded app-group identifier and crashes on launch when sideloaded via AltStore / SideStore. Install 1.1.1 or later.",
           "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.0/meow-ios-1.1.0-b2026042401-adhoc.ipa",
           "size": 9261201,
           "minOSVersion": "17.0"

--- a/project.yml
+++ b/project.yml
@@ -43,8 +43,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.1.0"
-        CFBundleVersion: "2026042401"
+        CFBundleShortVersionString: "1.1.1"
+        CFBundleVersion: "2026042402"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -184,8 +184,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.1.0"
-        CFBundleVersion: "2026042401"
+        CFBundleShortVersionString: "1.1.1"
+        CFBundleVersion: "2026042402"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary
Fixes an instant crash at launch when the app is sideloaded via AltStore / SideStore under a team other than \`SK4GFF6AHN\`.

## Root cause
\`AppGroup.identifier\` (\`MeowShared/...AppGroup.swift\`) and \`MWAppGroupIdentifier\` (\`PacketTunnel/...MWAppGroup.m\`) were hard-coded to \`group.io.github.madeye.meow\`. AltStore / SideStore re-sign sideloaded apps under the installer's team and rewrite the app-group entitlement to append their team prefix (observed: \`group.io.github.madeye.meow.V78XPFY5B7\`). The hard-coded lookup then returns nil from \`FileManager.containerURL(forSecurityApplicationGroupIdentifier:)\`, and the \`fatalError\` at \`AppGroup.swift:10\` / \`NSAssert\` in \`MWAppGroup.m\` fires during \`AppModel.init()\` — before the first SwiftUI frame renders.

Symbolicated crash from the user's device (\`meow-ios-2026-04-24-170405.ips\`):
\`\`\`
EXC_BREAKPOINT (SIGTRAP) at libswiftCore._assertionFailure
  → AppGroup.containerURL.getter (AppGroup.swift:10)
  → AppModel.init() (AppModel.swift:37)
  → App.init conformance MeowApp
codeSigningTeamID: V78XPFY5B7 (vs. authored SK4GFF6AHN)
codeSigningID:     io.github.madeye.meow.V78XPFY5B7
\`\`\`

## Fix
Resolve the identifier at runtime by parsing the first \`com.apple.security.application-groups\` entry out of \`Bundle.main/embedded.mobileprovision\`:
- Sideloaded builds (AltStore / SideStore / Ad Hoc) ship the profile — the rewritten identifier is read and used.
- App Store builds strip the profile — fall back to the authored constant, which is fine because Apple signs with the authoring team and the entitlement is preserved verbatim.

No C shim needed; \`SecTaskCopyValueForEntitlement\` is unavailable in the iOS SDK's public \`Security/Security.h\` umbrella, so plist-parsing the mobileprovision is the cleanest Foundation-only path.

## Files
- \`MeowShared/Sources/MeowModels/AppGroup.swift\` — dynamic identifier lookup.
- \`PacketTunnel/Sources/MWAppGroup.m\` + \`.h\` — matching ObjC implementation, new \`+identifier\` class method.
- \`project.yml\` + \`App/Info.plist\` + \`PacketTunnel/Info.plist\` — bump to 1.1.1 (build 2026042402).
- \`docs/source.json\` — pin the AltStore source to 1.1.1; keep 1.1.0 entry with a crash warning.

## Path B attestation
- [x] \`swiftlint --strict\` — 0 violations
- [x] \`swiftformat --lint .\` — 0 violations on tracked files
- [x] \`xcodegen generate\` — project parses
- [x] \`xcodebuild test -only-testing:MeowTests ... iPhone 17\` — 105 tests / 20 suites passed
- [x] \`xcodebuild archive\` + \`-exportArchive\` (Ad Hoc) — both succeeded; IPA 9,267,134 bytes at \`build/ExportAdHoc/meow-ios-1.1.1-b2026042402-adhoc.ipa\`
- [x] \`git diff origin/main...HEAD --stat\` — expected files only

## Post-merge (out of PR scope)
1. Cut \`v1.1.1\` GitHub Release and attach the new IPA.
2. (Optional) Upload 1.1.1 archive to TestFlight.
3. Verify install via AltStore: re-add source, install 1.1.1, launch — should reach the first screen instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)