### PR TITLE
fix(altstore): add legacy flat-version fields to source.json

### DIFF
--- a/docs/source.json
+++ b/docs/source.json
@@ -19,6 +19,12 @@
       "tintColor": "#5BC0EB",
       "category": "utilities",
       "screenshotURLs": [],
+      "version": "1.1.1",
+      "versionDate": "2026-04-24T00:00:00Z",
+      "versionDescription": "- Fix instant crash on AltStore / SideStore sideload: app-group identifier is now resolved from the embedded provisioning profile at runtime, so team-prefix rewrites by re-signers no longer hit a hard-coded lookup.\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
+      "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.1/meow-ios-1.1.1-b2026042402-adhoc.ipa",
+      "size": 9267134,
+      "minOSVersion": "17.0",
       "versions": [
         {
           "version": "1.1.1",


### PR DESCRIPTION
## Summary
Classic AltStore (not AltStore PAL) reads version metadata from flat app-level fields — \`version\`, \`versionDate\`, \`versionDescription\`, \`downloadURL\`, \`size\`, \`minOSVersion\` — not the newer \`versions: [...]\` array. Without those fields, the client cannot surface 1.1.1 even though it's the first entry in the array.

Adds the flat fields duplicating the latest (1.1.1) entry. Keeps the \`versions\` array for SideStore / AltStore PAL clients that use the v2 schema.

## Path A (non-code)
\`docs/source.json\` only.

## Test plan
- [x] \`python3 -m json.tool docs/source.json\`
- [ ] Post-merge: remove + re-add source in AltStore, confirm 1.1.1 appears as the installable version