### PR TITLE
fix(appgroup): decode embedded.mobileprovision as Latin-1

### DIFF
--- a/MeowShared/Sources/MeowModels/AppGroup.swift
+++ b/MeowShared/Sources/MeowModels/AppGroup.swift
@@ -18,9 +18,13 @@ public enum AppGroup {
     public static let identifier: String = resolveIdentifier()
 
     private static func resolveIdentifier() -> String {
+        // mobileprovision is a CMS/PKCS7 envelope: DER signature blocks (bytes
+        // ≥ 0x80) wrapping an XML plist. `.ascii` decode fails on those high
+        // bytes; `.isoLatin1` is lossless 1:1 over 0x00–0xFF, and the plist
+        // payload itself is pure ASCII so the substring round-trip is safe.
         guard let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"),
               let data = try? Data(contentsOf: url),
-              let ascii = String(data: data, encoding: .ascii),
+              let ascii = String(data: data, encoding: .isoLatin1),
               let start = ascii.range(of: "<plist"),
               let end = ascii.range(of: "</plist>", range: start.upperBound ..< ascii.endIndex)
         else {


### PR DESCRIPTION
## Summary

- `embedded.mobileprovision` is a CMS/PKCS7-signed envelope: DER blocks (bytes ≥ 0x80) wrapping an XML plist. `String(data:encoding:.ascii)` returns `nil` on those bytes, so `AppGroup.resolveIdentifier()` always fell back to `authoredIdentifier`.
- AltStore/SideStore resign apps under their own team and rewrite the app-group entitlement with a team prefix. Falling back to the authored identifier meant `containerURL(forSecurityApplicationGroupIdentifier:)` returned `nil` and the app crashed at launch with `"App Group container unavailable"`.
- Switch to `.isoLatin1`, which is lossless 1:1 over 0x00–0xFF. The plist payload itself is pure ASCII, so the substring → UTF-8 round-trip is safe. The previous sideload fix (#previous) ships unchanged otherwise.

Verified by reproducing the crash on a sideloaded build (Max Lv's iPhone, AltStore 1.1.1) — `MeowModels/AppGroup.swift:45: Fatal error: App Group container unavailable — entitlements missing 'group.io.github.madeye.meow'`.

## Test plan

Path B attestation (CLAUDE.md):
- [x] `swiftformat --lint .` → 0 violations on tracked sources (only `build-derived/` vendored SPM noise, untracked + gitignored).
- [x] `swiftlint --strict` → `Done linting! Found 0 violations, 0 serious in 68 files.`
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath build-derived` → `** TEST SUCCEEDED **`. All three bundles (`MeowTests`, `MeowUITests`, `MeowIntegrationTests`) loaded and passed.
- [x] `git diff origin/main...HEAD --stat` → `MeowShared/Sources/MeowModels/AppGroup.swift | 6 +++++-`. Single intended file.
- [ ] Sideloaded device confirmation: re-sign the new IPA via AltStore and verify the app launches without the fatalError. (Manual, post-merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)