### PR TITLE
chore(release): bump to 1.1.2 (build 2026042403)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>1.1.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042402</string>
+	<string>2026042403</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>1.1.2</string>
 	<key>CFBundleVersion</key>
-	<string>2026042402</string>
+	<string>2026042403</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/docs/source.json
+++ b/docs/source.json
@@ -19,18 +19,27 @@
       "tintColor": "#5BC0EB",
       "category": "utilities",
       "screenshotURLs": [],
-      "version": "1.1.1",
+      "version": "1.1.2",
       "versionDate": "2026-04-24T00:00:00Z",
-      "versionDescription": "- Fix instant crash on AltStore / SideStore sideload: app-group identifier is now resolved from the embedded provisioning profile at runtime, so team-prefix rewrites by re-signers no longer hit a hard-coded lookup.\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
-      "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.1/meow-ios-1.1.1-b2026042402-adhoc.ipa",
-      "size": 9267134,
+      "versionDescription": "- Actually fix the AltStore / SideStore sideload crash. 1.1.1 tried to resolve the app-group identifier from the embedded provisioning profile, but decoded the CMS-wrapped payload as ASCII — any byte ≥ 0x80 returned nil and the code silently fell back to the hard-coded identifier, so re-signed builds still crashed. 1.1.2 decodes as ISO Latin-1 (lossless over 0x00–0xFF) and correctly recovers the team-prefixed group.\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
+      "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.2/meow-ios-1.1.2-b2026042403-adhoc.ipa",
+      "size": 9267136,
       "minOSVersion": "17.0",
       "versions": [
+        {
+          "version": "1.1.2",
+          "buildVersion": "2026042403",
+          "date": "2026-04-24T00:00:00Z",
+          "localizedDescription": "- Actually fix the AltStore / SideStore sideload crash. 1.1.1 tried to resolve the app-group identifier from the embedded provisioning profile, but decoded the CMS-wrapped payload as ASCII — any byte ≥ 0x80 returned nil and the code silently fell back to the hard-coded identifier, so re-signed builds still crashed. 1.1.2 decodes as ISO Latin-1 (lossless over 0x00–0xFF) and correctly recovers the team-prefixed group.\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
+          "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.2/meow-ios-1.1.2-b2026042403-adhoc.ipa",
+          "size": 9267136,
+          "minOSVersion": "17.0"
+        },
         {
           "version": "1.1.1",
           "buildVersion": "2026042402",
           "date": "2026-04-24T00:00:00Z",
-          "localizedDescription": "- Fix instant crash on AltStore / SideStore sideload: app-group identifier is now resolved from the embedded provisioning profile at runtime, so team-prefix rewrites by re-signers no longer hit a hard-coded lookup.\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
+          "localizedDescription": "- Attempted to fix the AltStore / SideStore sideload crash by resolving the app-group identifier from the embedded provisioning profile, but the ASCII decoder choked on CMS/PKCS7 bytes and the fix was a no-op in practice. Install 1.1.2 or later.",
           "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.1/meow-ios-1.1.1-b2026042402-adhoc.ipa",
           "size": 9267134,
           "minOSVersion": "17.0"

--- a/project.yml
+++ b/project.yml
@@ -43,8 +43,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.1.1"
-        CFBundleVersion: "2026042402"
+        CFBundleShortVersionString: "1.1.2"
+        CFBundleVersion: "2026042403"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -184,8 +184,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.1.1"
-        CFBundleVersion: "2026042402"
+        CFBundleShortVersionString: "1.1.2"
+        CFBundleVersion: "2026042403"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary
- Bumps version to 1.1.2 / build 2026042403 (App + PacketTunnel Info.plist + project.yml).
- Updates `docs/source.json`: promotes 1.1.2 as the featured AltStore version; annotates 1.1.1 as broken so clients skip it.

## Why 1.1.2 follows 1.1.1 so quickly
1.1.1 attempted to fix the AltStore / SideStore sideload crash by resolving the app-group identifier from the embedded provisioning profile. That fix decoded the CMS/PKCS7-wrapped mobileprovision as ASCII — any byte ≥ 0x80 made `String(data:encoding:.ascii)` return nil and the code silently fell back to the hard-coded `authoredIdentifier`, so re-signed builds still crashed at launch. 1.1.2 ships the already-merged `fix(appgroup): decode embedded.mobileprovision as Latin-1` (d73bfbf) as a tagged release.

## Release
Tag `v1.1.2` and GitHub release already pushed with the ad-hoc IPA:
https://github.com/madeye/meow-ios/releases/tag/v1.1.2

## Diff scope
Only version strings + docs/source.json; no Swift or Rust logic changed. `git diff origin/main...HEAD --stat` verified — 4 files, all version/docs.

## Path B local-CI attestation (admin-bypass)

1. `swiftformat --lint --exclude build-derived .` at repo root → **0 violations** (27 files skipped per .swiftformat, 77 scanned). `build-derived/` is a local xcodebuild artifact absent on CI checkout; stock `swiftformat --lint .` also passes on CI for that reason.
2. `swiftlint --strict --quiet` at repo root → **0 violations** (exit 0).
3. `xcodebuild test` **not run**: diff contains no Swift or Rust source changes — only plist/project.yml version strings and `docs/source.json`. The underlying code fix (`AppGroup.swift` Latin-1 decode) is already at `origin/main` tip and its CI run was green (run 24883868701).
4. `git diff origin/main...HEAD --stat` verified — only `App/Info.plist`, `PacketTunnel/Info.plist`, `project.yml`, `docs/source.json`.

Also: on this PR, CI `lint` already reported **pass** before admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)