### PR TITLE
fix(ne): resolve PacketTunnel bundle id at runtime for sideloads

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042403</string>
+	<string>2026042404</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -79,9 +79,45 @@ final class VpnManager {
 
     // MARK: - Private
 
+    /// Authored PacketTunnel bundle id as declared in project.yml. Apple-signed
+    /// builds preserve this verbatim. Sideloaders (AltStore / SideStore) often
+    /// rewrite the extension bundle id to prepend their team prefix or swap
+    /// the whole identifier, so a hard-coded value leaves `startVPNTunnel()`
+    /// pointed at a provider bundle id that no longer exists — it resolves to
+    /// no matching appex, the extension never starts, and the UI sees the
+    /// connection go straight back to `.disconnected`.
+    private static let authoredTunnelProviderBundleIdentifier = "io.github.madeye.meow.PacketTunnel"
+
+    /// Resolve the packet-tunnel extension's actual bundle id at runtime by
+    /// enumerating `PlugIns/*.appex` and picking the one whose
+    /// `NSExtensionPointIdentifier` is `com.apple.networkextension.packet-tunnel`.
+    /// That way re-signers can rewrite the id freely without breaking the
+    /// NE wiring.
+    private static func resolveTunnelProviderBundleIdentifier() -> String {
+        guard let pluginsURL = Bundle.main.builtInPlugInsURL,
+              let contents = try? FileManager.default.contentsOfDirectory(
+                  at: pluginsURL,
+                  includingPropertiesForKeys: nil,
+              )
+        else {
+            return authoredTunnelProviderBundleIdentifier
+        }
+        for url in contents where url.pathExtension == "appex" {
+            guard let bundle = Bundle(url: url),
+                  let info = bundle.infoDictionary,
+                  let ext = info["NSExtension"] as? [String: Any],
+                  let point = ext["NSExtensionPointIdentifier"] as? String,
+                  point == "com.apple.networkextension.packet-tunnel",
+                  let bundleID = bundle.bundleIdentifier
+            else { continue }
+            return bundleID
+        }
+        return authoredTunnelProviderBundleIdentifier
+    }
+
     private func configureIfNeeded(_ mgr: NETunnelProviderManager) {
         let proto = (mgr.protocolConfiguration as? NETunnelProviderProtocol) ?? NETunnelProviderProtocol()
-        proto.providerBundleIdentifier = "io.github.madeye.meow.PacketTunnel"
+        proto.providerBundleIdentifier = Self.resolveTunnelProviderBundleIdentifier()
         // RFC 5737 TEST-NET-1 placeholder — iOS 26 rejects non-RFC strings
         // (e.g. "meow") at NEPacketTunnelNetworkSettings construction with
         // "invalid tunnel remote address". The real proxy endpoint lives in

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>2026042403</string>
+	<string>2026042404</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/docs/source.json
+++ b/docs/source.json
@@ -19,18 +19,27 @@
       "tintColor": "#5BC0EB",
       "category": "utilities",
       "screenshotURLs": [],
-      "version": "1.1.2",
+      "version": "1.1.3",
       "versionDate": "2026-04-24T00:00:00Z",
-      "versionDescription": "- Actually fix the AltStore / SideStore sideload crash. 1.1.1 tried to resolve the app-group identifier from the embedded provisioning profile, but decoded the CMS-wrapped payload as ASCII — any byte ≥ 0x80 returned nil and the code silently fell back to the hard-coded identifier, so re-signed builds still crashed. 1.1.2 decodes as ISO Latin-1 (lossless over 0x00–0xFF) and correctly recovers the team-prefixed group.\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
-      "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.2/meow-ios-1.1.2-b2026042403-adhoc.ipa",
-      "size": 9267136,
+      "versionDescription": "- Fix Network Extension not starting on AltStore / SideStore sideloads. VpnManager was hard-coded to `providerBundleIdentifier = io.github.madeye.meow.PacketTunnel`, but re-signers rewrite the extension's bundle id (team-prefix or outright swap) — iOS then had no matching appex to launch and `startVPNTunnel()` silently snapped back to .disconnected. The app now discovers the real PacketTunnel bundle id at runtime by scanning `PlugIns/*.appex` for the one whose `NSExtensionPointIdentifier` is `com.apple.networkextension.packet-tunnel`.\n- Previous 1.1.2 change: app-group identifier resolution (Latin-1 decode of the embedded provisioning profile).\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
+      "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.3/meow-ios-1.1.3-b2026042404-adhoc.ipa",
+      "size": 9268070,
       "minOSVersion": "17.0",
       "versions": [
+        {
+          "version": "1.1.3",
+          "buildVersion": "2026042404",
+          "date": "2026-04-24T00:00:00Z",
+          "localizedDescription": "- Fix Network Extension not starting on AltStore / SideStore sideloads. VpnManager was hard-coded to `providerBundleIdentifier = io.github.madeye.meow.PacketTunnel`, but re-signers rewrite the extension's bundle id (team-prefix or outright swap) — iOS then had no matching appex to launch and `startVPNTunnel()` silently snapped back to .disconnected. The app now discovers the real PacketTunnel bundle id at runtime by scanning `PlugIns/*.appex` for the one whose `NSExtensionPointIdentifier` is `com.apple.networkextension.packet-tunnel`.\n- Previous 1.1.2 change: app-group identifier resolution (Latin-1 decode of the embedded provisioning profile).\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
+          "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.3/meow-ios-1.1.3-b2026042404-adhoc.ipa",
+          "size": 9268070,
+          "minOSVersion": "17.0"
+        },
         {
           "version": "1.1.2",
           "buildVersion": "2026042403",
           "date": "2026-04-24T00:00:00Z",
-          "localizedDescription": "- Actually fix the AltStore / SideStore sideload crash. 1.1.1 tried to resolve the app-group identifier from the embedded provisioning profile, but decoded the CMS-wrapped payload as ASCII — any byte ≥ 0x80 returned nil and the code silently fell back to the hard-coded identifier, so re-signed builds still crashed. 1.1.2 decodes as ISO Latin-1 (lossless over 0x00–0xFF) and correctly recovers the team-prefixed group.\n- Previous 1.1.0 changes: Jetsam / memory-growth fix in PacketTunnel (Rust→ObjC rewrite, single tokio worker); on-demand VPN enabled with disconnectOnSleep=false.",
+          "localizedDescription": "- Fix app-group identifier resolution for AltStore / SideStore sideloads (Latin-1 decode of the embedded provisioning profile). The NE bundle-id lookup was still hard-coded in this build, so startVPNTunnel() did not actually start the tunnel — install 1.1.3 or later.",
           "downloadURL": "https://github.com/madeye/meow-ios/releases/download/v1.1.2/meow-ios-1.1.2-b2026042403-adhoc.ipa",
           "size": 9267136,
           "minOSVersion": "17.0"

--- a/project.yml
+++ b/project.yml
@@ -43,8 +43,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.1.2"
-        CFBundleVersion: "2026042403"
+        CFBundleShortVersionString: "1.1.3"
+        CFBundleVersion: "2026042404"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -184,8 +184,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.1.2"
-        CFBundleVersion: "2026042403"
+        CFBundleShortVersionString: "1.1.3"
+        CFBundleVersion: "2026042404"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary
\`VpnManager.configureIfNeeded\` hard-coded \`proto.providerBundleIdentifier = "io.github.madeye.meow.PacketTunnel"\`. AltStore / SideStore re-signers rewrite the extension's bundle id (prepend the installer's team prefix, or swap the whole id depending on the re-signer), so the stored NE configuration pointed at an appex that no longer existed on disk. \`startVPNTunnel()\` then had nothing to launch and the connection snapped right back to \`.disconnected\` — same failure shape as the 1.1.1 / 1.1.2 app-group bug, one layer further down the NE stack.

Fix: resolve the real bundle id at runtime by scanning \`Bundle.main.builtInPlugInsURL\` for \`*.appex\` entries whose \`NSExtensionPointIdentifier\` is \`com.apple.networkextension.packet-tunnel\` (\`App/Sources/Services/VpnManager.swift:84-119\`). App Store builds still fall through to the authored constant — their extension bundle ids are preserved verbatim under Apple signing.

## Version
Bumps to 1.1.3 / build 2026042404 (\`App/Info.plist\`, \`PacketTunnel/Info.plist\`, \`project.yml\`). \`docs/source.json\` promotes 1.1.3; 1.1.2 is demoted with a note that its NE wiring was still broken.

## Path B local-CI attestation (admin-bypass eligible)

1. \`swiftformat --lint --exclude build-derived .\` → **0 violations** (27 skipped, 77 scanned).
2. \`swiftlint --strict --quiet\` → **0 violations** (exit 0).
3. \`xcodebuild test -only-testing:MeowTests -destination 'platform=iOS Simulator,name=iPhone 17'\` → **TEST SUCCEEDED**.
4. \`git diff origin/main...HEAD --stat\` verified — 5 files: \`App/Info.plist\`, \`App/Sources/Services/VpnManager.swift\`, \`PacketTunnel/Info.plist\`, \`docs/source.json\`, \`project.yml\`.

## Test plan
- [x] Local MeowTests green on iPhone 17 simulator.
- [ ] On-device: install the 1.1.3 IPA via AltStore, tap Connect, confirm the tunnel actually transitions to \`.connected\` (not the silent snap-back observed on 1.1.2).
- [ ] App Store path unaffected: TestFlight/ASC build continues to use the authored \`io.github.madeye.meow.PacketTunnel\` since the plug-in bundle id is preserved under Apple signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)