### PR TITLE
docs(readme): add TestFlight public-beta link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@ Native iOS port of the Android "meow" VPN/proxy client. Full mihomo proxy engine
 wrapped in a SwiftUI iOS 26 Liquid Glass UI with a NetworkExtension packet
 tunnel provider.
 
+## Install
+
+[<img src="https://img.shields.io/badge/TestFlight-Public%20Beta-0070F5?style=for-the-badge&logo=apple&logoColor=white" alt="Join the TestFlight public beta" height="60">](https://testflight.apple.com/join/nnDAn7ZH)
+
+Public beta is open on TestFlight: <https://testflight.apple.com/join/nnDAn7ZH>.
+Requires iOS 26 or later (iPhone and iPad). Bring your own Mihomo / Clash
+subscription — meow does not provide proxy servers.
+
 ## Status
 
-Bootstrapping. See [`docs/PRD.md`](docs/PRD.md) and
+Public beta. See [`docs/PRD.md`](docs/PRD.md) and
 [`docs/PROJECT_PLAN.md`](docs/PROJECT_PLAN.md) for the product spec and task
 breakdown.
 


### PR DESCRIPTION
## Summary
- Add an "Install" section to the top of `README.md` with a TestFlight badge linking to <https://testflight.apple.com/join/nnDAn7ZH>.
- Flip `Status: Bootstrapping` to `Status: Public beta`.

## Path A — non-code PR
Only `README.md` is touched. No Swift/Rust/YAML/project/workflow files. Path A applies → safe to admin rebase-merge without CI per CLAUDE.md.

## Test plan
- [x] Badge renders on GitHub's README preview
- [x] TestFlight link resolves to the public-beta join page

🤖 Generated with [Claude Code](https://claude.com/claude-code)