### PR TITLE
feat(distribution): Firebase App Distribution scripts

### DIFF
--- a/scripts/build-adhoc.sh
+++ b/scripts/build-adhoc.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Build a Release IPA signed for Ad Hoc distribution (release-testing method).
+# Output: build/export-adhoc/meow-ios.ipa
+#
+# Companion to scripts/build-release.sh. Used for Firebase App Distribution
+# delivery to manually-registered tester UDIDs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PROJECT_PATH="$ROOT/meow-ios.xcodeproj"
+SCHEME="meow-ios"
+ARCHIVE_PATH="$ROOT/build/meow-ios-adhoc.xcarchive"
+EXPORT_DIR="$ROOT/build/export-adhoc"
+EXPORT_PLIST="$ROOT/build/ExportOptions-adhoc.plist"
+
+# Ad Hoc profiles installed on this Mac (UUIDs from
+# ~/Library/MobileDevice/Provisioning Profiles/)
+APP_PROFILE="${APP_PROFILE:-1530eda1-0fae-4c05-bbae-d07cde47ac39}"
+PT_PROFILE="${PT_PROFILE:-67929e8a-de89-4046-a21a-fad19f92071b}"
+
+TEAM_ID="${DEVELOPMENT_TEAM:-SK4GFF6AHN}"
+ASC_KEY_ID="${ASC_KEY_ID:-5MC8U9Z7P9}"
+ASC_ISSUER_ID="${ASC_ISSUER_ID:-1200242f-e066-47cc-9ac8-b3affd0eee32}"
+ASC_KEY_PATH="${ASC_KEY_PATH:-$HOME/.appstoreconnect/AuthKey_5MC8U9Z7P9.p8}"
+
+SKIP_RUST_BUILD=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-rust-build) SKIP_RUST_BUILD=1; shift;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 1;;
+    esac
+done
+
+mkdir -p "$ROOT/build"
+rm -rf "$ARCHIVE_PATH" "$EXPORT_DIR"
+
+if [[ "$SKIP_RUST_BUILD" -eq 0 ]]; then
+    "$ROOT/scripts/build-rust.sh"
+fi
+"$ROOT/scripts/fetch-geo-assets.sh"
+
+cat >"$EXPORT_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>release-testing</string>
+    <key>destination</key>
+    <string>export</string>
+    <key>teamID</key>
+    <string>$TEAM_ID</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>signingCertificate</key>
+    <string>Apple Distribution</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>io.github.madeye.meow</key>
+        <string>$APP_PROFILE</string>
+        <key>io.github.madeye.meow.PacketTunnel</key>
+        <string>$PT_PROFILE</string>
+    </dict>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+echo "==> Archiving (Ad Hoc)"
+xcodebuild -allowProvisioningUpdates \
+    -xcconfig "$ROOT/Local.xcconfig" \
+    -project "$PROJECT_PATH" \
+    -scheme "$SCHEME" \
+    -configuration Release \
+    -destination 'generic/platform=iOS' \
+    -archivePath "$ARCHIVE_PATH" \
+    -derivedDataPath "$ROOT/build/DerivedData" \
+    -clonedSourcePackagesDirPath "$ROOT/build/SourcePackages" \
+    archive \
+    "DEVELOPMENT_TEAM=$TEAM_ID" \
+    -authenticationKeyID "$ASC_KEY_ID" \
+    -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
+    -authenticationKeyPath "$ASC_KEY_PATH"
+
+echo "==> Exporting (release-testing)"
+xcodebuild -exportArchive \
+    -archivePath "$ARCHIVE_PATH" \
+    -exportPath "$EXPORT_DIR" \
+    -exportOptionsPlist "$EXPORT_PLIST" \
+    -allowProvisioningUpdates \
+    -authenticationKeyID "$ASC_KEY_ID" \
+    -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
+    -authenticationKeyPath "$ASC_KEY_PATH"
+
+IPA="$EXPORT_DIR/meow-ios.ipa"
+[[ -f "$IPA" ]] || { echo "error: missing $IPA" >&2; exit 1; }
+echo "==> Ad Hoc IPA: $IPA"
+ls -la "$IPA"

--- a/scripts/sync-firebase-udids.py
+++ b/scripts/sync-firebase-udids.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Register tester UDIDs (collected by Firebase App Distribution) in App Store Connect.
+
+Workflow:
+  1. A new tester accepts the Firebase invite, visits the registration page,
+     and installs the configuration profile that captures their UDID.
+  2. UDIDs accumulate in Firebase console → Project Settings → Apple Devices.
+  3. Export the device list as CSV (button in that page).
+  4. Pass the CSV to this script:
+
+         scripts/sync-firebase-udids.py <devices.csv>
+
+     or pipe a list of UDIDs (one per line) on stdin:
+
+         pbpaste | scripts/sync-firebase-udids.py -
+
+     Each new UDID is POSTed to App Store Connect /v1/devices. Already-registered
+     UDIDs are skipped. After this runs, the next `xcodebuild -allowProvisioningUpdates`
+     will regenerate the Ad Hoc profile to include the new devices.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import jwt
+import requests
+
+API_KEY_JSON = Path("/Users/mlv/.appstoreconnect/api_key.json")
+BASE_URL = "https://api.appstoreconnect.apple.com/v1"
+UDID_RE = re.compile(r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}$|^[0-9A-Fa-f]{40}$")
+
+
+def make_token() -> str:
+    cfg = json.loads(API_KEY_JSON.read_text())
+    payload = {
+        "iss": cfg["issuer_id"],
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 20 * 60,
+        "aud": "appstoreconnect-v1",
+    }
+    return jwt.encode(
+        payload, cfg["key"], algorithm="ES256", headers={"kid": cfg["key_id"], "typ": "JWT"}
+    )
+
+
+def api(session: requests.Session, method: str, path: str, **kw) -> dict:
+    r = session.request(method, f"{BASE_URL}{path}", **kw)
+    if not r.ok:
+        print(f"ERROR {method} {path}: {r.status_code} {r.text}", file=sys.stderr)
+        r.raise_for_status()
+    return {} if not r.content else r.json()
+
+
+def parse_input(source: str) -> list[tuple[str, str]]:
+    """Return [(udid, name), ...] from a CSV, plain-text list, or stdin."""
+    if source == "-":
+        text = sys.stdin.read()
+    else:
+        text = Path(source).read_text(encoding="utf-8")
+
+    out: list[tuple[str, str]] = []
+
+    # Try CSV first
+    try:
+        reader = csv.reader(text.splitlines())
+        rows = list(reader)
+        if rows and any("device" in c.lower() or "udid" in c.lower() for c in rows[0]):
+            # Header row present — find UDID and name columns
+            header = [c.strip().lower() for c in rows[0]]
+            udid_col = next(
+                (i for i, c in enumerate(header) if "udid" in c or "device id" in c or "deviceid" in c),
+                None,
+            )
+            name_col = next((i for i, c in enumerate(header) if "name" in c), None)
+            if udid_col is not None:
+                for row in rows[1:]:
+                    if udid_col >= len(row):
+                        continue
+                    u = row[udid_col].strip()
+                    n = row[name_col].strip() if name_col is not None and name_col < len(row) else ""
+                    if u:
+                        out.append((u, n or f"Tester device ({u[:8]})"))
+                return out
+    except Exception:
+        pass
+
+    # Fallback: one UDID per line
+    for line in text.splitlines():
+        u = line.strip().split(",")[0].strip()
+        if not u or u.startswith("#"):
+            continue
+        out.append((u, f"Tester device ({u[:8]})"))
+    return out
+
+
+def get_existing_udids(session: requests.Session) -> set[str]:
+    udids: set[str] = set()
+    next_url = f"{BASE_URL}/devices?fields[devices]=udid,status&limit=200"
+    while next_url:
+        r = session.get(next_url)
+        r.raise_for_status()
+        data = r.json()
+        for item in data.get("data", []):
+            u = item["attributes"].get("udid")
+            if u:
+                udids.add(u.lower())
+        next_url = data.get("links", {}).get("next")
+    return udids
+
+
+def register_device(session: requests.Session, udid: str, name: str) -> bool:
+    body = {
+        "data": {
+            "type": "devices",
+            "attributes": {
+                "name": name[:50] or "Tester device",
+                "udid": udid,
+                "platform": "IOS",
+            },
+        }
+    }
+    r = session.post(f"{BASE_URL}/devices", json=body)
+    if r.status_code == 201:
+        return True
+    if r.status_code == 409:
+        return False  # already exists, but our pre-check should have caught it
+    print(f"  ERROR registering {udid}: {r.status_code} {r.text}", file=sys.stderr)
+    return False
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <devices.csv | - >", file=sys.stderr)
+        sys.exit(2)
+
+    entries = parse_input(sys.argv[1])
+    if not entries:
+        print("no UDIDs parsed from input", file=sys.stderr)
+        sys.exit(1)
+
+    valid = []
+    for u, n in entries:
+        if UDID_RE.match(u):
+            valid.append((u, n))
+        else:
+            print(f"  skip (not a valid UDID): {u}", file=sys.stderr)
+    if not valid:
+        print("no valid UDIDs in input", file=sys.stderr)
+        sys.exit(1)
+
+    token = make_token()
+    session = requests.Session()
+    session.headers.update({"Authorization": f"Bearer {token}", "Content-Type": "application/json"})
+
+    print(f"==> Fetching existing devices from App Store Connect")
+    existing = get_existing_udids(session)
+    print(f"    {len(existing)} already registered")
+
+    added = 0
+    skipped = 0
+    for udid, name in valid:
+        if udid.lower() in existing:
+            skipped += 1
+            continue
+        print(f"  + {udid}  ({name})")
+        if register_device(session, udid, name):
+            added += 1
+            existing.add(udid.lower())
+
+    print(
+        f"==> Done. {added} new device(s) registered, {skipped} already present, "
+        f"{len(valid)} total in input."
+    )
+    if added:
+        print(
+            "    Next: rebuild the Ad Hoc IPA — `scripts/build-adhoc.sh` will pick up the\n"
+            "    refreshed Ad Hoc provisioning profile via -allowProvisioningUpdates."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload-firebase-distribution.sh
+++ b/scripts/upload-firebase-distribution.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Upload the Ad Hoc IPA to Firebase App Distribution.
+#
+# Reads release notes from metadata/testflight/whats_new/<build>.txt to keep
+# parity with what TestFlight testers see. Distributes to a tester group named
+# "beta" by default (override with --groups).
+#
+# Prereqs: `firebase login` (one-time), `scripts/build-adhoc.sh` already ran.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FIREBASE_APP_ID="${FIREBASE_APP_ID:-1:634173336877:ios:74690155062764080b77a4}"
+IPA="${IPA:-$ROOT/build/export-adhoc/meow-ios.ipa}"
+TESTER_GROUPS="${TESTER_GROUPS:-beta}"
+RELEASE_NOTES_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ipa) IPA="$2"; shift 2;;
+        --groups) TESTER_GROUPS="$2"; shift 2;;
+        --release-notes-file) RELEASE_NOTES_FILE="$2"; shift 2;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 1;;
+    esac
+done
+
+[[ -f "$IPA" ]] || { echo "error: missing IPA at $IPA — run scripts/build-adhoc.sh first" >&2; exit 1; }
+
+if [[ -z "$RELEASE_NOTES_FILE" ]]; then
+    BUILD_NUMBER=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$ROOT/App/Info.plist")
+    RELEASE_NOTES_FILE="$ROOT/metadata/testflight/whats_new/${BUILD_NUMBER}.txt"
+fi
+
+if [[ ! -f "$RELEASE_NOTES_FILE" ]]; then
+    echo "warning: release notes file not found: $RELEASE_NOTES_FILE — uploading without notes" >&2
+    NOTES_ARGS=()
+else
+    NOTES_ARGS=(--release-notes-file "$RELEASE_NOTES_FILE")
+fi
+
+echo "==> Distributing $IPA to Firebase app $FIREBASE_APP_ID (groups: $TESTER_GROUPS)"
+firebase appdistribution:distribute "$IPA" \
+    --app "$FIREBASE_APP_ID" \
+    --groups "$TESTER_GROUPS" \
+    "${NOTES_ARGS[@]}"
+
+echo "==> Done."


### PR DESCRIPTION
## Summary

Adds an Ad Hoc + OTA distribution channel as an alternative to TestFlight, backed by Firebase App Distribution. Useful for friends-and-family-scale testing on devices that bypass TestFlight's 90-day rebuild cycle.

- **`scripts/build-adhoc.sh`** — mirrors the App Store flow but exports with `method=release-testing` and the Ad Hoc provisioning profiles (`meow iOS Ad Hoc` + `meow PacketTunnel iOS Ad Hoc`). Output: `build/export-adhoc/meow-ios.ipa`.
- **`scripts/upload-firebase-distribution.sh`** — wraps `firebase appdistribution:distribute`. Reads release notes from `metadata/testflight/whats_new/<build>.txt`. Defaults to the `beta` tester group. (Avoids the bash readonly `$GROUPS` builtin by using `$TESTER_GROUPS`.)
- **`scripts/sync-firebase-udids.py`** — reads a CSV/text list of UDIDs (exported from Firebase console → Project Settings → Apple Devices) and registers each new one in App Store Connect via the existing `AuthKey_5MC8U9Z7P9.p8`. Already-registered UDIDs are skipped. The next `xcodebuild -allowProvisioningUpdates` then refreshes the Ad Hoc profile.

Tested end-to-end against Firebase project `meow-ios-2125b` (app `1:634173336877:ios:74690155062764080b77a4`): release `1.1.4 (2026042501)` uploaded and distributed to the `beta` group successfully.

Apple's 100-UDID/year cap still applies. This channel is for ~dozens of testers, not a TestFlight replacement at scale.

## Path B attestation

Per `CLAUDE.md` → "Path B — Code PRs with local-CI-green attestation":

- [x] **(1) swiftformat**: `swiftformat --lint . --exclude build-derived` → `0/77 files require formatting`
- [x] **(2) swiftlint**: `swiftlint --strict` → `Found 0 violations, 0 serious in 68 files`
- [x] **(3) MeowTests on iOS 26 simulator**: `xcodebuild test -only-testing:MeowTests -destination 'platform=iOS Simulator,name=iPhone 17'` → `** TEST SUCCEEDED **`
- [x] **(4) diff base verified**: 3 new files only under `scripts/`. No Swift / Rust / project / Info.plist / workflow files touched.

No `.github/workflows/*.yml` touched, so Path B applies.

## Test plan
- [x] Ad Hoc IPA builds (10.7 MB)
- [x] Firebase upload reports `re-uploaded already existing release` on idempotent re-run
- [x] Distribution to `beta` group succeeds
- [ ] Once a tester registers a UDID and CSV-exports it, run `scripts/sync-firebase-udids.py <export.csv>`; rebuild Ad Hoc IPA; redistribute. Real run pending real testers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)