### PR TITLE
chore(release): build 2026042502 (Firebase Analytics)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042501</string>
+	<string>2026042502</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2026042501</string>
+	<string>2026042502</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/metadata/testflight/whats_new/2026042502.txt
+++ b/metadata/testflight/whats_new/2026042502.txt
@@ -1,0 +1,32 @@
+Build 2026042502 (1.1.4)
+
+WHAT'S NEW
+• Firebase Analytics is now linked for anonymous, aggregate usage metrics
+  (sessions, app/iOS version, screen views). Advertising identifiers
+  (IDFA / AdID) are explicitly disabled, so no App Tracking Transparency
+  prompt is shown. Subscription URLs, proxy credentials, configuration
+  contents, and tunneled traffic are NOT sent to analytics. See the
+  privacy policy linked in the App Store / TestFlight description.
+
+WHAT TO TEST
+1. First launch on a fresh install
+   • Confirm NO ATT ("Allow App to Track") prompt appears.
+   • Confirm the app launches normally — no crashes related to Firebase
+     initialization.
+
+2. Existing functionality from build 2026042501 (please re-verify)
+   • Subscriptions list (Settings tab): pencil icon next to refresh
+     opens the built-in YAML editor as a sheet. Editing, saving, and
+     reflecting in routing on the next connection.
+   • Settings → About → Memory: shows live PacketTunnel memory usage
+     while the tunnel is connected.
+   • Connect, disconnect, switch proxy groups, refresh subscriptions —
+     no new crashes or UI hangs.
+
+KNOWN LIMITATIONS
+• Non-DNS UDP traffic is not yet forwarded by the tunnel. WireGuard
+  outbounds will not pass traffic. QUIC / HTTP3 falls back to TCP
+  HTTP/2 (usually transparent).
+
+Please send TestFlight feedback or open an issue at:
+https://github.com/madeye/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026042502.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026042502.txt
@@ -1,0 +1,27 @@
+版本 2026042502（1.1.4）
+
+更新内容
+• 集成了 Firebase Analytics，用于收集匿名的聚合使用统计（会话、应用 /
+  iOS 版本、页面浏览）。广告标识符（IDFA / AdID）已明确关闭，因此不会
+  弹出 App Tracking Transparency 弹窗。订阅地址、代理凭证、配置内容与
+  隧道转发的流量均不会上报至分析服务。详情请参阅 App Store / TestFlight
+  描述中的隐私政策链接。
+
+测试要点
+1. 全新安装首次启动
+   • 确认 没有 出现 ATT（"允许 App 跟踪"）弹窗。
+   • 确认应用正常启动——没有与 Firebase 初始化相关的崩溃。
+
+2. 上一版本（2026042501）功能回归测试
+   • 订阅列表（设置 Tab）：点击刷新按钮旁的铅笔图标，可将内置 YAML
+     编辑器以 sheet 方式打开。编辑、保存，并确认下次连接时路由按新
+     配置生效。
+   • 设置 → 关于 → 内存：连接隧道后应显示 PacketTunnel 实时内存占用。
+   • 连接、断开、切换代理组、刷新订阅——确认没有新的崩溃或界面卡顿。
+
+已知限制
+• 尚未转发非 DNS 的 UDP 流量。WireGuard 出站无法通过，QUIC / HTTP3
+  会回退到 TCP HTTP/2（通常对用户透明）。
+
+请通过 TestFlight 反馈，或在此处提交 Issue：
+https://github.com/madeye/meow-ios/issues

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026042501"
+        CFBundleVersion: "2026042502"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -192,7 +192,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026042501"
+        CFBundleVersion: "2026042502"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

Successor to build 2026042501. Picks up the Firebase Analytics integration (#88) so the analytics disclosure already pushed to TestFlight matches what's actually in the build users install.

- `CFBundleVersion`: 2026042501 → 2026042502 (1.1.4 stays)
- `metadata/testflight/{.,zh-Hans}/whats_new/2026042502.txt` — per-locale "What to Test" describing the Firebase Analytics addition, IDFA-off (no ATT prompt), and a regression checklist for the features in 2026042501

Uploaded to App Store Connect (delivery UUID `b3ce520c-4663-4cfa-9cf6-c012aa79d800`).

## Path B attestation
- [x] **swiftformat**: `swiftformat --lint . --exclude build-derived` → `0/77 files require formatting`
- [x] **swiftlint**: `swiftlint --strict` → `Found 0 violations, 0 serious in 68 files`
- [x] **MeowTests on iOS 26 (iPhone 17)**: `** TEST SUCCEEDED **`
- [x] **Diff verified**: 5 files, +63/-4. No Swift/Rust/workflow files touched.

## Test plan
- [x] App Store Connect → build 2026042502 appears in Processing → VALID
- [ ] On a tester device, confirm analytics events flow into Firebase console (DebugView). Real-device verification, post-merge.
- [ ] Confirm no ATT prompt at first launch (IDFA off — already verified by code path; confirm in practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)