### PR TITLE
docs(pages): update Firebase App Distribution invite link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -195,7 +195,7 @@
           <a class="cta" href="https://testflight.apple.com/join/nnDAn7ZH"
             >Join the TestFlight public beta →</a
           >
-          <a class="cta-alt" href="https://appdistribution.firebase.dev/i/e47c2a75b1e72734"
+          <a class="cta-alt" href="https://appdistribution.firebase.dev/i/85546f1795ab613a"
             >Firebase Ad Hoc (direct install)</a
           >
           <a class="cta-secondary" href="https://github.com/madeye/meow-ios"


### PR DESCRIPTION
## Summary
- Update the Firebase Ad Hoc install link on the GitHub Pages landing site to the current invite URL.

## Merge path
- Path A (non-code, docs-only): only `docs/index.html` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)