### PR TITLE
feat(vpn): auto-reconnect on network-state change

### DIFF
--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MeowIPC
 import MeowModels
+import Network
 import NetworkExtension
 import Observation
 
@@ -11,6 +12,12 @@ import Observation
 final class VpnManager {
     private(set) var stage: VpnStage = .idle
     private(set) var lastError: String?
+
+    /// True between a user-initiated `connect()` and the next `disconnect()`.
+    /// The network-path observer only retriggers `connect()` while this is
+    /// true — otherwise a wifi/cellular handoff after the user explicitly
+    /// turned the VPN off would silently bring it back up.
+    private(set) var wantsConnection = false
 
     /// Fires each time `stage` transitions into `.connected`, including the
     /// synthetic attach-time edge when the tunnel is already connected on
@@ -31,7 +38,18 @@ final class VpnManager {
     // thread-safe, so a torn read here is harmless.
     private nonisolated(unsafe) var statusObserver: NSObjectProtocol?
 
+    // NWPathMonitor.cancel() is documented thread-safe; the let-bound monitor
+    // can be reached from the nonisolated deinit without isolation gymnastics.
+    private let pathMonitor = NWPathMonitor()
+    private let pathMonitorQueue = DispatchQueue(label: "io.github.madeye.meow.app.vpn-path-monitor")
+    private var pathMonitorStarted = false
+    // Initial value matches the assumption "device probably has a network at
+    // launch". If the device is offline at attach time we'll observe the
+    // satisfied-edge later when it comes back.
+    private var lastPathSatisfied = true
+
     deinit {
+        pathMonitor.cancel()
         if let statusObserver {
             NotificationCenter.default.removeObserver(statusObserver)
         }
@@ -58,6 +76,7 @@ final class VpnManager {
     /// `disconnect` previously turned it off.
     func connect() async {
         lastError = nil
+        wantsConnection = true
         do {
             if manager == nil { await refresh() }
             guard let manager else { return }
@@ -73,6 +92,7 @@ final class VpnManager {
     /// on-demand rule — so we have to actively disable it when the user
     /// intentionally wants the VPN off.
     func disconnect() async {
+        wantsConnection = false
         guard let manager else { return }
         manager.connection.stopVPNTunnel()
     }
@@ -109,6 +129,7 @@ final class VpnManager {
 
     private func attach(_ mgr: NETunnelProviderManager) {
         manager = mgr
+        startPathMonitorIfNeeded()
         // Reading the initial connection.status is NOT an observed
         // .NEVPNStatusDidChange edge, so on app relaunch into an
         // already-connected tunnel (force-quit while VPN up), the observer
@@ -148,6 +169,63 @@ final class VpnManager {
         if next == .connected, previous != .connected {
             onConnected?()
         }
+    }
+
+    private func startPathMonitorIfNeeded() {
+        guard !pathMonitorStarted else { return }
+        pathMonitorStarted = true
+        // Seed from the current path so the first delivered update doesn't
+        // look like an unsatisfied → satisfied transition on a device that
+        // was already online at attach time.
+        lastPathSatisfied = pathMonitor.currentPath.status == .satisfied
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            let satisfied = path.status == .satisfied
+            Task { @MainActor in
+                self?.handleNetworkPathChange(satisfied: satisfied)
+            }
+        }
+        pathMonitor.start(queue: pathMonitorQueue)
+    }
+
+    /// Reducer for network-path edges. Only the unsatisfied → satisfied
+    /// transition triggers a reconnect — firing on every interface delta
+    /// (e.g. wifi/cellular handoffs while the tunnel is healthy) would race
+    /// iOS's own `.reasserting` recovery and double-start the NE. Exposed at
+    /// `internal` so unit tests can drive the edge without spinning up a real
+    /// `NWPathMonitor`.
+    func handleNetworkPathChange(satisfied: Bool) {
+        let previous = lastPathSatisfied
+        lastPathSatisfied = satisfied
+        let trigger = Self.shouldReconnect(
+            previousSatisfied: previous,
+            currentSatisfied: satisfied,
+            wantsConnection: wantsConnection,
+            stage: stage,
+        )
+        guard trigger else { return }
+        Task { @MainActor in
+            await self.connect()
+        }
+    }
+
+    /// Pure gating predicate for `handleNetworkPathChange`. Returns true when
+    /// (1) the network just transitioned unsatisfied → satisfied, (2) the user
+    /// last asked for the tunnel up, and (3) the tunnel is in a stage where
+    /// kicking off a fresh `connect()` is well-defined (i.e. not already
+    /// connecting / connected / disconnecting). Static + nonisolated so tests
+    /// can exercise every cell of the truth table cheaply.
+    nonisolated static func shouldReconnect(
+        previousSatisfied: Bool,
+        currentSatisfied: Bool,
+        wantsConnection: Bool,
+        stage: VpnStage,
+    ) -> Bool {
+        guard currentSatisfied, !previousSatisfied else { return false }
+        guard wantsConnection else { return false }
+        // .connecting / .connected / .stopping: leave the existing transition
+        // alone. .stopped / .idle / .error: the tunnel is down with the user
+        // still wanting it up, and we just got a working network — reconnect.
+        return stage == .stopped || stage == .idle || stage == .error
     }
 
     private nonisolated func map(_ status: NEVPNStatus) -> VpnStage {

--- a/MeowTests/Services/VpnManagerTests.swift
+++ b/MeowTests/Services/VpnManagerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import meow_ios
+import MeowModels
 import NetworkExtension
 import Testing
 
@@ -91,5 +92,123 @@ struct VpnManagerTests {
         mgr.applyConnectionStatus(.disconnecting)
         mgr.applyConnectionStatus(.invalid)
         #expect(fired == 0)
+    }
+
+    // MARK: - Network-change auto-reconnect
+
+    /// Canonical "wifi came back" edge: user wanted the tunnel up, NE fell to
+    /// `.disconnected` while offline, NWPathMonitor delivers
+    /// unsatisfied → satisfied. We must reconnect.
+    @Test
+    func `shouldReconnect fires on unsatisfied to satisfied edge while user wants connection and tunnel is stopped`() {
+        #expect(VpnManager.shouldReconnect(
+            previousSatisfied: false,
+            currentSatisfied: true,
+            wantsConnection: true,
+            stage: .stopped,
+        ))
+    }
+
+    /// Same edge but in `.error` (e.g. extension aborted startup). Still the
+    /// user's intent is "be connected" so a recovered network should retry.
+    @Test
+    func `shouldReconnect fires from error stage`() {
+        #expect(VpnManager.shouldReconnect(
+            previousSatisfied: false,
+            currentSatisfied: true,
+            wantsConnection: true,
+            stage: .error,
+        ))
+    }
+
+    /// `.idle` is the pre-attach default; if the path satisfied edge happens
+    /// before refresh() lands the manager (e.g. cold launch offline → online),
+    /// we still want to reconnect rather than wait for the next path change.
+    @Test
+    func `shouldReconnect fires from idle stage`() {
+        #expect(VpnManager.shouldReconnect(
+            previousSatisfied: false,
+            currentSatisfied: true,
+            wantsConnection: true,
+            stage: .idle,
+        ))
+    }
+
+    /// User explicitly disconnected — a wifi handoff after that must NOT
+    /// silently bring the tunnel back up.
+    @Test
+    func `shouldReconnect does not fire when user does not want connection`() {
+        #expect(!VpnManager.shouldReconnect(
+            previousSatisfied: false,
+            currentSatisfied: true,
+            wantsConnection: false,
+            stage: .stopped,
+        ))
+    }
+
+    /// Steady-state path delivery on an already-online device: previous and
+    /// current both satisfied. Without the !previous guard we'd reconnect on
+    /// every benign path callback (interface metric tweaks, DNS changes).
+    @Test
+    func `shouldReconnect does not fire when path was already satisfied`() {
+        #expect(!VpnManager.shouldReconnect(
+            previousSatisfied: true,
+            currentSatisfied: true,
+            wantsConnection: true,
+            stage: .stopped,
+        ))
+    }
+
+    /// Network just dropped (satisfied → unsatisfied). Reconnect attempts
+    /// while offline are doomed and would just churn `.connecting` → `.error`.
+    @Test
+    func `shouldReconnect does not fire on satisfied to unsatisfied edge`() {
+        #expect(!VpnManager.shouldReconnect(
+            previousSatisfied: true,
+            currentSatisfied: false,
+            wantsConnection: true,
+            stage: .stopped,
+        ))
+    }
+
+    /// Tunnel is already up; a transient unsatisfied → satisfied flap
+    /// (briefly losing all interfaces during a handoff) must not double-start
+    /// the NE — iOS's own `.reasserting` machinery owns recovery here.
+    @Test
+    func `shouldReconnect does not fire while already connected`() {
+        #expect(!VpnManager.shouldReconnect(
+            previousSatisfied: false,
+            currentSatisfied: true,
+            wantsConnection: true,
+            stage: .connected,
+        ))
+    }
+
+    /// Same protection during the connecting / disconnecting in-between
+    /// stages: kicking off a second startVPNTunnel mid-transition is racy and
+    /// produces undefined NEVPNStatus sequences.
+    @Test
+    func `shouldReconnect does not fire while a transition is in flight`() {
+        for stage in [VpnStage.connecting, .stopping] {
+            #expect(!VpnManager.shouldReconnect(
+                previousSatisfied: false,
+                currentSatisfied: true,
+                wantsConnection: true,
+                stage: stage,
+            ))
+        }
+    }
+
+    /// On a fresh `VpnManager` the user has not yet asked to connect, so any
+    /// network-path callback (cold launch, locale change, etc.) must be a
+    /// silent no-op — no stage churn, no spurious lastError.
+    @Test
+    func `handleNetworkPathChange is a no-op when user has not asked to connect`() {
+        let mgr = VpnManager()
+        mgr.handleNetworkPathChange(satisfied: false)
+        mgr.handleNetworkPathChange(satisfied: true)
+        #expect(mgr.stage == .idle)
+        #expect(mgr.lastError == nil)
+        #expect(mgr.wantsConnection == false)
     }
 }


### PR DESCRIPTION
Wires an NWPathMonitor into VpnManager so the tunnel comes back up
when the device's network recovers (e.g. wifi drops then cellular
takes over) instead of stranding the user in `.stopped`/`.error`
until they manually toggle the switch.

- Track wantsConnection across connect()/disconnect() so a reconnect
  only fires when the user still intends the tunnel to be up. A
  wifi/cellular handoff after an explicit disconnect must NOT
  silently bring the VPN back.
- Fire reconnect only on the unsatisfied → satisfied path edge.
  Triggering on every interface delta would race iOS's own
  `.reasserting` recovery and double-start the NE.
- Gate by current stage: only `.stopped` / `.idle` / `.error`
  qualify; mid-transition stages (`.connecting`, `.connected`,
  `.stopping`) are owned by iOS's existing state machine.
- Extract the gating logic into a pure static `shouldReconnect`
  predicate so unit tests can exhaust the truth table without
  spinning up a real NETunnelProviderManager.

Note: lint/test (`swiftlint`, `swiftformat --lint .`, `xcodebuild test`)
were not runnable in this environment (Linux, no macOS toolchain).
CI will gate the merge.