### PR TITLE
feat(ne): auto-reconnect engine on network change

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.h
+++ b/PacketTunnel/Sources/MWTunnelEngine.h
@@ -13,6 +13,11 @@
 /// Stops engine, tun2socks, ingress loop, traffic pump.
 - (void)stop;
 
+/// Stops & restarts the engine + TUN in-process with the same config.
+/// Async; no-op if not started or a restart is already in flight (in which
+/// case `completion` fires with NO immediately).
+- (void)restartWithCompletion:(nullable void (^)(BOOL success))completion;
+
 @property (nonatomic, readonly) BOOL isEngineRunning;
 @property (nonatomic, readonly) BOOL tunStarted;
 

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -238,12 +238,9 @@ static os_log_t gLog;
 
     // Grace period: skip the soft-cap check for the first 60 ticks (30 s) to
     // let the engine and GeoIP data finish initializing before we measure.
-    if (_pumpTick > 60 && footprintMB >= 40 && !atomic_load_explicit(&_restarting, memory_order_relaxed)) {
-        atomic_store_explicit(&_restarting, YES, memory_order_relaxed);
-        os_log_error(gLog, "softcap: footprint=%ldMB >= 40MB — scheduling engine restart", (long)footprintMB);
-        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-            [self performEngineRestart];
-        });
+    if (_pumpTick > 60 && footprintMB >= 40) {
+        os_log_error(gLog, "softcap: footprint=%ldMB >= 40MB — requesting restart", (long)footprintMB);
+        [self restartWithCompletion:nil];
     }
 
     NSTimeInterval epoch = now + NSTimeIntervalSince1970;
@@ -270,10 +267,26 @@ static os_log_t gLog;
     [MWDarwinBridge post:MWNotificationTraffic];
 }
 
-// MARK: - Soft-cap engine restart
+// MARK: - Engine restart
 
-- (void)performEngineRestart {
-    os_log_info(gLog, "softcap restart: stopping tun + engine");
+- (void)restartWithCompletion:(void (^)(BOOL))completion {
+    if (!_started) {
+        if (completion) completion(NO);
+        return;
+    }
+    if (atomic_exchange(&_restarting, YES)) {
+        os_log_info(gLog, "restart: already in flight, skipping");
+        if (completion) completion(NO);
+        return;
+    }
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        BOOL ok = [self performEngineRestart];
+        if (completion) completion(ok);
+    });
+}
+
+- (BOOL)performEngineRestart {
+    os_log_info(gLog, "restart: stopping tun + engine");
 
     meow_tun_stop();
     _tunStarted = NO;
@@ -290,27 +303,26 @@ static os_log_t gLog;
     malloc_zone_pressure_relief(NULL, 0);
 
     if (!_started) {
-        // stop() was called on us during the restart window — don't come back up.
-        os_log_info(gLog, "softcap restart: engine was stopped externally, aborting");
+        os_log_info(gLog, "restart: engine was stopped externally, aborting");
         atomic_store_explicit(&_restarting, NO, memory_order_relaxed);
-        return;
+        return NO;
     }
 
     MWPreferences *prefs = [MWPreferences loadFromDefaults:[MWAppGroup defaults]];
     NSError *err = nil;
     if (![self writeEffectiveConfigWithPrefs:prefs error:&err]) {
-        os_log_error(gLog, "softcap restart: config write failed: %{public}@", err);
+        os_log_error(gLog, "restart: config write failed: %{public}@", err);
         atomic_store_explicit(&_restarting, NO, memory_order_relaxed);
-        return;
+        return NO;
     }
 
     NSString *configPath = [MWAppGroup effectiveConfigURL].path;
     int rc = meow_engine_start(configPath.UTF8String);
     if (rc != 0) {
-        os_log_error(gLog, "softcap restart: engine start failed: %{public}@",
+        os_log_error(gLog, "restart: engine start failed: %{public}@",
                      [self lastRustError]);
         atomic_store_explicit(&_restarting, NO, memory_order_relaxed);
-        return;
+        return NO;
     }
 
     MWPacketWriter *writer = [[MWPacketWriter alloc] initWithFlow:_flow];
@@ -319,19 +331,20 @@ static os_log_t gLog;
 
     rc = meow_tun_start(_writerCtx, meowPacketWriterCB);
     if (rc != 0) {
-        os_log_error(gLog, "softcap restart: tun start failed: %{public}@",
+        os_log_error(gLog, "restart: tun start failed: %{public}@",
                      [self lastRustError]);
         CFBridgingRelease(_writerCtx);
         _writerCtx = NULL;
         _writer    = nil;
         meow_engine_stop();
         atomic_store_explicit(&_restarting, NO, memory_order_relaxed);
-        return;
+        return NO;
     }
     _tunStarted = YES;
 
-    os_log_info(gLog, "softcap restart: complete");
+    os_log_info(gLog, "restart: complete");
     atomic_store_explicit(&_restarting, NO, memory_order_relaxed);
+    return YES;
 }
 
 // MARK: - Config patching

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -7,6 +7,7 @@
 #import "MWDiagnosticsRunner.h"
 #import <os/log.h>
 #import <mach/mach.h>
+@import Network;
 
 static const uint8_t kDiagTagCanned = 0x01;
 static const uint8_t kDiagTagUser   = 0x02;
@@ -15,8 +16,14 @@ static const uint8_t kDiagTagMemory = 0x03;
 static os_log_t gLog;
 
 @implementation PacketTunnelProvider {
-    MWTunnelEngine  *_engine;
-    MWIPCListener   *_ipcListener;
+    MWTunnelEngine     *_engine;
+    MWIPCListener      *_ipcListener;
+    nw_path_monitor_t   _pathMonitor;
+    dispatch_queue_t    _pathQueue;
+    dispatch_source_t   _pathDebounceTimer;
+    BOOL                _havePath;
+    BOOL                _lastSatisfied;
+    nw_interface_type_t _lastInterfaceType;
 }
 
 + (void)initialize {
@@ -64,6 +71,8 @@ static os_log_t gLog;
             [listener start];
             self->_ipcListener = listener;
 
+            [self startPathMonitor];
+
             [self writeState:@"connected" profileID:profileID errorMessage:nil];
             completionHandler(nil);
         });
@@ -73,6 +82,7 @@ static os_log_t gLog;
 - (void)stopTunnelWithReason:(NEProviderStopReason)reason
            completionHandler:(void (^)(void))completionHandler {
     os_log_info(gLog, "stopTunnel reason=%ld", (long)reason);
+    [self stopPathMonitor];
     [_engine stop];
     _engine = nil;
     [_ipcListener stop];
@@ -181,6 +191,126 @@ static os_log_t gLog;
         return;
     }
     [MWDarwinBridge post:MWNotificationState];
+}
+
+// MARK: - Network path monitoring
+
+- (void)startPathMonitor {
+    _pathQueue = dispatch_queue_create("io.github.madeye.meow.PacketTunnel.path",
+                                       DISPATCH_QUEUE_SERIAL);
+    _havePath = NO;
+    _lastSatisfied = NO;
+    _lastInterfaceType = nw_interface_type_other;
+
+    nw_path_monitor_t monitor = nw_path_monitor_create();
+    nw_path_monitor_set_queue(monitor, _pathQueue);
+
+    __weak __typeof__(self) weak = self;
+    nw_path_monitor_set_update_handler(monitor, ^(nw_path_t _Nonnull path) {
+        __strong __typeof__(weak) self = weak;
+        if (!self) return;
+        [self handlePathUpdate:path];
+    });
+    nw_path_monitor_start(monitor);
+    _pathMonitor = monitor;
+}
+
+- (void)stopPathMonitor {
+    if (_pathDebounceTimer) {
+        dispatch_source_cancel(_pathDebounceTimer);
+        _pathDebounceTimer = nil;
+    }
+    if (_pathMonitor) {
+        nw_path_monitor_cancel(_pathMonitor);
+        _pathMonitor = nil;
+    }
+    _pathQueue = nil;
+}
+
+// Caller queue: _pathQueue (serial). All ivar access here is single-threaded.
+- (void)handlePathUpdate:(nw_path_t)path {
+    nw_path_status_t status = nw_path_get_status(path);
+    BOOL satisfied = (status == nw_path_status_satisfied);
+
+    nw_interface_type_t iface = nw_interface_type_other;
+    if (satisfied) {
+        if (nw_path_uses_interface_type(path, nw_interface_type_wifi)) {
+            iface = nw_interface_type_wifi;
+        } else if (nw_path_uses_interface_type(path, nw_interface_type_cellular)) {
+            iface = nw_interface_type_cellular;
+        } else if (nw_path_uses_interface_type(path, nw_interface_type_wired)) {
+            iface = nw_interface_type_wired;
+        }
+    }
+
+    if (!_havePath) {
+        _havePath = YES;
+        _lastSatisfied = satisfied;
+        _lastInterfaceType = iface;
+        os_log_info(gLog, "path: initial satisfied=%d iface=%d", satisfied, iface);
+        return;
+    }
+
+    BOOL meaningful = NO;
+    if (satisfied && !_lastSatisfied) {
+        os_log_info(gLog, "path: connectivity regained");
+        meaningful = YES;
+    } else if (satisfied && iface != _lastInterfaceType) {
+        os_log_info(gLog, "path: interface changed %d -> %d", _lastInterfaceType, iface);
+        meaningful = YES;
+    }
+
+    _lastSatisfied = satisfied;
+    _lastInterfaceType = iface;
+
+    if (meaningful) {
+        [self scheduleReconnect];
+    }
+}
+
+// Caller queue: _pathQueue. Coalesces a burst of path updates into one restart.
+- (void)scheduleReconnect {
+    if (_pathDebounceTimer) return;
+
+    dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER,
+                                                     0, 0, _pathQueue);
+    dispatch_source_set_timer(timer,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)),
+        DISPATCH_TIME_FOREVER,
+        100 * NSEC_PER_MSEC);
+
+    __weak __typeof__(self) weak = self;
+    dispatch_source_set_event_handler(timer, ^{
+        __strong __typeof__(weak) self = weak;
+        if (!self) return;
+        if (self->_pathDebounceTimer) {
+            dispatch_source_cancel(self->_pathDebounceTimer);
+            self->_pathDebounceTimer = nil;
+        }
+        [self triggerReconnect];
+    });
+    _pathDebounceTimer = timer;
+    dispatch_resume(timer);
+}
+
+- (void)triggerReconnect {
+    MWTunnelEngine *engine = _engine;
+    if (!engine) return;
+
+    os_log_info(gLog, "path: triggering engine restart");
+    self.reasserting = YES;
+
+    __weak __typeof__(self) weak = self;
+    [engine restartWithCompletion:^(BOOL success) {
+        __strong __typeof__(weak) self = weak;
+        if (!self) return;
+        self.reasserting = NO;
+        os_log_info(gLog, "path: restart finished success=%d", success);
+        if (!success) {
+            [self writeState:@"error" profileID:nil
+                errorMessage:@"reconnect after network change failed"];
+        }
+    }];
 }
 
 @end


### PR DESCRIPTION
## Summary
- Add `nw_path_monitor` to `PacketTunnelProvider` that watches the default path while the tunnel is up. On a meaningful change (unsatisfied → satisfied, or active interface type changed between wifi/cellular/wired), debounce 1.5 s and trigger an in-process engine restart with `self.reasserting = YES` so iOS surfaces "Connecting…" during the swap.
- Factor the existing soft-cap restart into a public `MWTunnelEngine -restartWithCompletion:` with atomic-exchange gating, so soft-cap and network-change reconnects share one code path and can't race.
- Initial path snapshot is suppressed (no spurious restart on connect). Only the leading edge of a debounce window fires; bursts of path updates collapse into one restart.

## Test plan
- [x] **swiftlint --strict** at repo root → 0 violations.
- [x] **xcodebuild build** scheme `meow-ios`, destination `platform=iOS Simulator,name=iPhone 17` → BUILD SUCCEEDED.
- [x] **xcodebuild test** -only-testing:MeowTests, same destination → TEST SUCCEEDED.
- [x] **Ad Hoc IPA built + installed** on iPhone 17 Pro via `scripts/build-adhoc.sh` + `xcrun devicectl device install app` (`io.github.madeye.meow`).
- [x] **swiftformat --lint .** — only failures are in vendored `build-derived/SourcePackages/checkouts/Yams/Tests/...` (third-party SwiftPM checkout artifacts, not present on a fresh CI checkout, not in this diff).
- [x] **Diff verified** — `git diff origin/main...HEAD --stat` is exactly `PacketTunnel/Sources/{MWTunnelEngine.h,MWTunnelEngine.m,PacketTunnelProvider.m}` (3 files, +169/-21).
- [ ] **On-device manual:** connect VPN, toggle Wi-Fi off (forces cellular), confirm tunnel reasserts and stays up. Filter Console for `subsystem:io.github.madeye.meow.PacketTunnel category:provider` for `path:` lines.

## Path B attestation
Diff touches only ObjC sources under `PacketTunnel/Sources/`. No Rust/FFI, project.yml, or workflow changes. Eligible for admin rebase-merge once on-device manual passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)