### PR TITLE
chore(release): bump to build 2026042601

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042502</string>
+	<string>2026042601</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2026042502</string>
+	<string>2026042601</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026042502"
+        CFBundleVersion: "2026042601"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -192,7 +192,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026042502"
+        CFBundleVersion: "2026042601"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary
- Bump CFBundleVersion 2026042502 → 2026042601 across project.yml + App/Info.plist + PacketTunnel/Info.plist.
- Picks up auto-reconnect-on-network-change (#92, 15314e2).

## TestFlight upload
Uploaded to App Store Connect via `xcrun altool --upload-app` (Apple Distribution, App Store profiles 1e7fc11e + 7b6ce2a5). Delivery UUID **8ec1a41e-1996-49ed-aaef-2a2fcd6f1a17**.

## Path B attestation
Diff touches only `project.yml` + 2 Info.plists (no Swift/Rust/code-path source files; no workflow files).
- [x] swiftlint --strict ✅ 0 violations.
- [x] Archive build (Release, generic/iOS) ✅ ARCHIVE SUCCEEDED.
- [x] altool --validate-app ✅ then altool --upload-app ✅ "No errors uploading archive".
- [x] `git diff origin/main...HEAD --stat` = exactly project.yml + App/Info.plist + PacketTunnel/Info.plist (3 files, +4/-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)