### PR TITLE
perf(ffi): bump tokio worker threads from 1 to 2

### DIFF
--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -40,14 +40,12 @@ static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 pub(crate) fn get_runtime() -> &'static tokio::runtime::Runtime {
     RUNTIME.get_or_init(|| {
-        // Single worker thread to minimize RSS under jetsam's 50 MB cap.
-        // Tasks still interleave at every .await point (cooperative concurrency),
-        // but only one OS thread is ever created. Stack capped at 512 KB (default
-        // is 2 MB) — sufficient for async leaf tasks that don't recurse deeply.
-        // Trade-off: CPU-bound bursts (TLS handshake + DoH + serde simultaneously)
-        // cannot overlap; measure if throughput regresses under load.
+        // Two worker threads to allow CPU-bound bursts (TLS handshake + DoH +
+        // serde) to overlap while keeping RSS in check under jetsam's 50 MB cap.
+        // Stack capped at 512 KB (default is 2 MB) — sufficient for async leaf
+        // tasks that don't recurse deeply.
         tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
+            .worker_threads(2)
             .thread_stack_size(512 * 1024)
             .enable_all()
             .build()


### PR DESCRIPTION
## Summary
- Bump tokio runtime from 1 → 2 worker threads in `core/rust/mihomo-ios-ffi/src/lib.rs` so CPU-bound bursts (TLS handshake + DoH + serde) can overlap.
- Stack size still capped at 512 KB; RSS stays in check under jetsam's 50 MB cap.

## Path B attestation (admin-bypass for code PRs)
- [x] `swiftformat --lint --exclude build-derived .` → 0 violations (the local `build-derived/` is from xcodebuild's custom DerivedData and isn't present in CI; the in-repo `.swiftformat` already excludes the standard `build/` and `.build/`)
- [x] `swiftlint --strict` → 0 violations
- [x] `scripts/build-rust.sh` → green (ran via `scripts/build-adhoc.sh`)
- [x] `cd core/rust/mihomo-ios-ffi && cargo test --lib` → 8 passed
- [x] `git diff origin/main...HEAD --stat` verified: single-file Rust change, no accidental additions
- [x] Installed Ad Hoc IPA on physical device (iPhone 17 Pro) for smoke verification

## Test plan
- [x] Build green
- [x] Unit tests green
- [x] Installs and launches on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)