### PR TITLE
fix(tunnel): patch smoltcp window-underflow + log Rust panics

### DIFF
--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -2809,8 +2809,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smoltcp"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+source = "git+https://github.com/madeye/smoltcp?branch=fix%2Freject-bytes-outside-recv-win#d986300eee4bed07c033744359e192a60211b23a"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -65,6 +65,16 @@ mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", branch = "main"
 mihomo-api = { git = "https://github.com/madeye/mihomo-rust", branch = "main" }
 mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", branch = "main" }
 
+# Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
+# ("tcp: Reject bytes outside the receive window"). Without it, peers that
+# accept bytes past our advertised window edge trigger a panic in
+# smoltcp::socket::tcp::Socket::last_scaled_window via the SeqNumber
+# subtraction underflow guard, aborting the PacketTunnel process. The fix
+# is in upstream main but has not been released; netstack-smoltcp 0.2 still
+# pins smoltcp 0.12, so a 0.13 bump would also need to fork netstack-smoltcp.
+[patch.crates-io]
+smoltcp = { git = "https://github.com/madeye/smoltcp", branch = "fix/reject-bytes-outside-recv-win" }
+
 [build-dependencies]
 cbindgen = "0.28"
 

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -94,6 +94,7 @@ unsafe fn write_out(src: &[u8], out: *mut c_char, out_cap: c_int) -> c_int {
 #[no_mangle]
 pub extern "C" fn meow_core_init() {
     logging::init_os_logger();
+    logging::install_panic_hook();
     logging::bridge_log("meow_core_init: os_log initialized");
 }
 

--- a/core/rust/mihomo-ios-ffi/src/logging.rs
+++ b/core/rust/mihomo-ios-ffi/src/logging.rs
@@ -31,6 +31,40 @@ pub fn bridge_log(msg: &str) {
     info!("{}", msg);
 }
 
+/// Route Rust panics to os_log before the runtime aborts. Without this hook
+/// the panic message goes to stderr only, which NetworkExtension does not
+/// capture — the iOS crash report shows just the backtrace, not the message.
+/// Safe to call more than once.
+pub fn install_panic_hook() {
+    static INSTALLED: Once = Once::new();
+    INSTALLED.call_once(|| {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let location = info
+                .location()
+                .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+                .unwrap_or_else(|| "<unknown>".to_string());
+            let payload = info.payload();
+            let msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<non-string panic payload>".to_string()
+            };
+            let thread = std::thread::current();
+            let thread_name = thread.name().unwrap_or("<unnamed>");
+            log::error!(
+                "rust panic in thread '{}' at {}: {}",
+                thread_name,
+                location,
+                msg
+            );
+            default_hook(info);
+        }));
+    });
+}
+
 // ---------------------------------------------------------------------------
 // tracing → log bridge
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Diagnosis of the recurring PacketTunnel crashes (4 reports across two builds, all `EXC_CRASH SIGABRT` on `tokio-rt-worker`, panic site `smoltcp::socket::tcp::Socket::window_to_update + 128`):

1. **Patch smoltcp**. Pin to a fork of smoltcp 0.12.0 that backports upstream commit [f56ed8b](https://github.com/smoltcp-rs/smoltcp/commit/f56ed8b) (\"tcp: Reject bytes outside the receive window\"). Without it, peers that accept bytes past our advertised window edge make `last_scaled_window` compute `last_ack + last_win - next_ack`, where `SeqNumber - SeqNumber` panics on underflow and aborts the extension. Fix is in upstream main but unreleased; netstack-smoltcp 0.2 still pins smoltcp 0.12, so a 0.13 bump would also need a netstack-smoltcp fork.
   - Fork: [madeye/smoltcp@fix/reject-bytes-outside-recv-win](https://github.com/madeye/smoltcp/tree/fix/reject-bytes-outside-recv-win)
   - 595/595 smoltcp tests pass on the fork.

2. **Log panics to os_log.** Install `std::panic::set_hook` in `meow_core_init` that routes panic message + thread + location to `log::error!` → os_log. NetworkExtension does not capture stderr, so panic strings were lost — only the abort backtrace survived in `.ips`. Future panics will include the actual assertion message in `log show --predicate 'process == \"PacketTunnel\"'`.

## Path B attestation (admin-bypass for code PRs)

- [x] `swiftformat --lint --exclude build-derived,build .` → 0 violations (no Swift in this PR; ran for due diligence)
- [x] `swiftlint --strict` → 0 violations
- [x] `cargo test --lib` in `core/rust/mihomo-ios-ffi/` → 8 passed
- [x] `scripts/build-rust.sh` → green (XCFramework rebuilt against patched smoltcp)
- [x] `git diff origin/main...HEAD --stat` verified: 4 files (Cargo.toml, Cargo.lock, src/lib.rs, src/logging.rs) — no Swift, no workflow files, no accidental additions.

## Test plan

- [x] Cargo tests green
- [x] Rust XCFramework builds clean
- [ ] Verify next PacketTunnel crash (if any) carries the panic string in `log show`
- [ ] Smoke-test on device for at least one VPN session

🤖 Generated with [Claude Code](https://claude.com/claude-code)