### PR TITLE
fix(ne): remove soft-cap engine restart at 40 MB footprint

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -236,13 +236,6 @@ static os_log_t gLog;
         malloc_zone_pressure_relief(NULL, 0);
     }
 
-    // Grace period: skip the soft-cap check for the first 60 ticks (30 s) to
-    // let the engine and GeoIP data finish initializing before we measure.
-    if (_pumpTick > 60 && footprintMB >= 40) {
-        os_log_error(gLog, "softcap: footprint=%ldMB >= 40MB — requesting restart", (long)footprintMB);
-        [self restartWithCompletion:nil];
-    }
-
     NSTimeInterval epoch = now + NSTimeIntervalSince1970;
     NSDictionary *snapshot = @{
         @"uploadBytes":    @(up),


### PR DESCRIPTION
## Summary

Drop the `phys_footprint >= 40 MB` soft-cap that called `restartWithCompletion:` from `emitTrafficSnapshot` after the 30 s grace period. Two regressions it was driving:

1. **Negative network speed in the main UI.** `_lastUp`/`_lastDown` ivars on `MWTunnelEngine` persist across an in-process engine restart, but the Rust counters return to 0. The next `emitTrafficSnapshot` then computes `(0 - prevTotal) / dt` and writes a large negative `uploadRate`/`downloadRate` to the shared store; HomeView reads it directly.
2. **Avoidable smoltcp churn.** Tearing down all active flows whenever footprint crosses 40 MB increases the chance of hitting the smoltcp window-math panic landed in #95.

`restartWithCompletion:` itself stays — it's still the entry point for `PacketTunnelProvider.triggerReconnect` (network-change auto-reconnect, 15314e2).

## Path B attestation (admin-bypass for code PRs)

- [x] `swiftformat --lint --exclude build-derived,build .` → 0 violations
- [x] `swiftlint --strict` → 0 violations
- [x] `xcodebuild test … -only-testing:MeowIntegrationTests` on iPhone 17 / iOS 26 → **TEST SUCCEEDED**
- [x] `git diff origin/main...HEAD --stat` verified: 1 file (`PacketTunnel/Sources/MWTunnelEngine.m`), 7 deletions, no Swift, no workflow files, no accidental additions.
- [x] No Rust changes — `scripts/build-rust.sh` not relevant.

## Test plan

- [x] Integration tests green
- [ ] Confirm on device that the speed UI no longer shows negative numbers under sustained traffic
- [ ] Watch for any regression where the extension legitimately needs a footprint-driven restart (none expected — jetsam will still kill at 50 MB if memory genuinely runs away)

🤖 Generated with [Claude Code](https://claude.com/claude-code)