### PR TITLE
chore(release): bump to build 2026042701

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042601</string>
+	<string>2026042701</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2026042601</string>
+	<string>2026042701</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026042601"
+        CFBundleVersion: "2026042701"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -192,7 +192,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026042601"
+        CFBundleVersion: "2026042701"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

Bump CFBundleVersion to 2026042701. Picks up:

- perf(ffi): tokio worker threads 1 → 2 (#94)
- fix(tunnel): smoltcp window-underflow patch + Rust panic hook (#95)
- fix(ne): remove soft-cap engine restart at 40 MB footprint (#96)

## Path B attestation (admin-bypass for code PRs)

- [x] `swiftformat --lint --exclude build-derived,build .` → 0 violations
- [x] `swiftlint --strict` → 0 violations
- [x] `xcodebuild test … -only-testing:MeowTests` on iPhone 17 / iOS 26 → **TEST SUCCEEDED**
- [x] `git diff origin/main...HEAD --stat` verified: 3 files (App/Info.plist, PacketTunnel/Info.plist, project.yml), version-string only, no Swift, no Rust, no workflow files.
- [x] No Rust changes — `scripts/build-rust.sh` not relevant.

## Test plan

- [x] Lint + tests green
- [ ] Archive + upload to App Store Connect for TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)