### PR TITLE
chore(release): bump to build 2026042901

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042701</string>
+	<string>2026042901</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2026042701</string>
+	<string>2026042901</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026042701"
+        CFBundleVersion: "2026042901"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -192,7 +192,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026042701"
+        CFBundleVersion: "2026042901"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

Bump to build 2026042901 for TestFlight upload.

Picks up:
- fix(doh): single-flight + h2 pool + reconnect on failure (#100)

## Path B local-CI attestation

Diff is metadata-only (CFBundleVersion strings in two Info.plist files and project.yml — version literals, not behavior). No Swift / Rust / workflow files touched.

- [x] `swiftformat --lint .` at repo root → 0 violations (`build-derived/` stashed)
- [x] `swiftlint --strict` at repo root → 0 violations (68 files)
- [x] `git diff origin/main...HEAD --stat` verified — 3 files (`App/Info.plist`, `PacketTunnel/Info.plist`, `project.yml`), 4 lines total. No accidental additions.
- [x] cargo / xcodebuild test suites N/A — no source code changed since the green attestation in #100.

## Test plan

- [ ] Build app-store IPA, validate with `xcrun altool --validate-app`
- [ ] Upload to TestFlight, confirm processing succeeds
- [ ] Submit for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)