### PR TITLE
feat(doh): persist answer cache in redb

### DIFF
--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -1737,6 +1737,7 @@ dependencies = [
  "netstack-smoltcp",
  "oslog",
  "parking_lot",
+ "redb",
  "rustls",
  "serde",
  "serde_json",
@@ -2364,6 +2365,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -56,6 +56,11 @@ urlencoding = "2"
 # tun2socks
 netstack-smoltcp = "0.2"
 
+# Persistent DoH answer cache (single-writer KV at $HOME_DIR/doh-cache.redb).
+# Pure-Rust, mmap-backed; survives PacketTunnel restarts so cold starts don't
+# repay the burst of fanout queries from launch flows.
+redb = "2"
+
 # Embedded mihomo-rust engine. Pinned to main; revisit once the project tags
 # releases. Each crate is a workspace member of madeye/mihomo-rust.
 mihomo-common = { git = "https://github.com/madeye/mihomo-rust", branch = "main" }

--- a/core/rust/mihomo-ios-ffi/src/doh_cache.rs
+++ b/core/rust/mihomo-ios-ffi/src/doh_cache.rs
@@ -1,0 +1,198 @@
+//! Persistent companion to the in-memory DoH answer cache in `doh_client`.
+//!
+//! Stores `(question_section → (response_bytes, expires_unix_secs))` in a
+//! single redb file under `$HOME_DIR/doh-cache.redb`. Read at
+//! `init_doh_client` to warm the in-memory map; written through on every
+//! cache insert/eviction. Expires are wall-clock (`SystemTime`) so a reboot
+//! correctly invalidates stale entries — the in-memory cache uses `Instant`
+//! and is rebuilt fresh from the persisted wall-clock TTLs at hydrate time.
+//!
+//! Single-writer: the DoH client only runs inside the PacketTunnel
+//! extension (gated by `engine::tunnel()`), so no two processes ever open
+//! this file concurrently.
+
+use parking_lot::Mutex;
+use redb::{Database, ReadableTable, TableDefinition};
+use std::path::Path;
+use std::sync::OnceLock;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{info, warn};
+
+const TABLE: TableDefinition<&[u8], (&[u8], u64)> = TableDefinition::new("doh_v1");
+
+type CacheResult<T> = Result<T, Box<redb::Error>>;
+type Entry = (Vec<u8>, Vec<u8>, u64);
+
+static DB: OnceLock<Mutex<Option<Database>>> = OnceLock::new();
+
+fn slot() -> &'static Mutex<Option<Database>> {
+    DB.get_or_init(|| Mutex::new(None))
+}
+
+/// Open (or create) the persistent cache file. Idempotent — repeated calls
+/// after a successful open are a no-op. On error (path missing, redb open
+/// failure) the in-memory cache continues to work; persistence is best-effort.
+pub fn init(home_dir: Option<&str>) {
+    let mut guard = slot().lock();
+    if guard.is_some() {
+        return;
+    }
+    let Some(home) = home_dir else {
+        info!("doh cache: no HOME_DIR, persistence disabled");
+        return;
+    };
+    let path = Path::new(home).join("doh-cache.redb");
+    match open_db(&path) {
+        Ok(db) => {
+            info!("doh cache: opened {}", path.display());
+            *guard = Some(db);
+        }
+        Err(e) => {
+            warn!("doh cache: open {} failed: {e}", path.display());
+        }
+    }
+}
+
+fn open_db(path: &Path) -> CacheResult<Database> {
+    let db = Database::create(path).map_err(boxed)?;
+    // Touch the table so a fresh file has the schema before the first read
+    // transaction tries to open it.
+    let txn = db.begin_write().map_err(boxed)?;
+    {
+        let _ = txn.open_table(TABLE).map_err(boxed)?;
+    }
+    txn.commit().map_err(boxed)?;
+    Ok(db)
+}
+
+fn boxed<E: Into<redb::Error>>(e: E) -> Box<redb::Error> {
+    Box::new(e.into())
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Convert a Unix-seconds expiry into a `Duration` from now (saturating to
+/// zero if already expired).
+pub fn expires_in(unix_secs: u64) -> Duration {
+    let now = now_unix_secs();
+    if unix_secs > now {
+        Duration::from_secs(unix_secs - now)
+    } else {
+        Duration::ZERO
+    }
+}
+
+pub fn unix_secs_in(ttl: Duration) -> u64 {
+    now_unix_secs().saturating_add(ttl.as_secs())
+}
+
+/// Load all unexpired `(key, response_bytes, expires_unix_secs)` triples.
+/// Caller is expected to call this once at startup to hydrate the in-memory
+/// map; subsequent reads hit the in-memory map directly.
+pub fn load_unexpired() -> Vec<(Vec<u8>, Vec<u8>, u64)> {
+    let guard = slot().lock();
+    let Some(db) = guard.as_ref() else {
+        return Vec::new();
+    };
+    load_unexpired_from(db).unwrap_or_else(|e| {
+        warn!("doh cache: load failed: {e}");
+        Vec::new()
+    })
+}
+
+pub fn put(key: &[u8], bytes: &[u8], expires_unix_secs: u64) {
+    let guard = slot().lock();
+    let Some(db) = guard.as_ref() else { return };
+    if let Err(e) = put_into(db, key, bytes, expires_unix_secs) {
+        warn!("doh cache: put failed: {e}");
+    }
+}
+
+pub fn remove(key: &[u8]) {
+    let guard = slot().lock();
+    let Some(db) = guard.as_ref() else { return };
+    if let Err(e) = remove_from(db, key) {
+        warn!("doh cache: remove failed: {e}");
+    }
+}
+
+fn load_unexpired_from(db: &Database) -> CacheResult<Vec<Entry>> {
+    let now = now_unix_secs();
+    let txn = db.begin_read().map_err(boxed)?;
+    let table = txn.open_table(TABLE).map_err(boxed)?;
+    let mut out = Vec::new();
+    for entry in table.iter().map_err(boxed)? {
+        let (k, v) = entry.map_err(boxed)?;
+        let (bytes, expires) = v.value();
+        if expires > now {
+            out.push((k.value().to_vec(), bytes.to_vec(), expires));
+        }
+    }
+    Ok(out)
+}
+
+fn put_into(db: &Database, key: &[u8], bytes: &[u8], expires_unix_secs: u64) -> CacheResult<()> {
+    let txn = db.begin_write().map_err(boxed)?;
+    {
+        let mut table = txn.open_table(TABLE).map_err(boxed)?;
+        table
+            .insert(key, (bytes, expires_unix_secs))
+            .map_err(boxed)?;
+    }
+    txn.commit().map_err(boxed)?;
+    Ok(())
+}
+
+fn remove_from(db: &Database, key: &[u8]) -> CacheResult<()> {
+    let txn = db.begin_write().map_err(boxed)?;
+    {
+        let mut table = txn.open_table(TABLE).map_err(boxed)?;
+        table.remove(key).map_err(boxed)?;
+    }
+    txn.commit().map_err(boxed)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn round_trip_and_expiry_filter() {
+        let dir = tempdir().unwrap();
+        let db = open_db(&dir.path().join("test.redb")).unwrap();
+        let now = now_unix_secs();
+
+        put_into(&db, b"fresh", b"resp-fresh", now + 60).unwrap();
+        put_into(&db, b"stale", b"resp-stale", now.saturating_sub(10)).unwrap();
+        put_into(&db, b"also-fresh", b"resp-also", now + 600).unwrap();
+
+        let mut loaded = load_unexpired_from(&db).unwrap();
+        loaded.sort_by(|a, b| a.0.cmp(&b.0));
+        let keys: Vec<&[u8]> = loaded.iter().map(|(k, _, _)| k.as_slice()).collect();
+        assert_eq!(keys, vec![b"also-fresh".as_slice(), b"fresh".as_slice()]);
+    }
+
+    #[test]
+    fn remove_drops_entry() {
+        let dir = tempdir().unwrap();
+        let db = open_db(&dir.path().join("test.redb")).unwrap();
+        put_into(&db, b"k", b"v", now_unix_secs() + 60).unwrap();
+        remove_from(&db, b"k").unwrap();
+        assert!(load_unexpired_from(&db).unwrap().is_empty());
+    }
+
+    #[test]
+    fn expires_in_saturates_to_zero() {
+        let now = now_unix_secs();
+        assert_eq!(expires_in(now.saturating_sub(5)), Duration::ZERO);
+        let d = expires_in(now + 30);
+        assert!(d > Duration::ZERO && d <= Duration::from_secs(31));
+    }
+}

--- a/core/rust/mihomo-ios-ffi/src/doh_client.rs
+++ b/core/rust/mihomo-ios-ffi/src/doh_client.rs
@@ -5,6 +5,7 @@
 //! sees the TLS bytes the same way it sees TUN-originated TCP.
 
 use crate::dns_table;
+use crate::doh_cache;
 use crate::engine;
 use crate::logging;
 use bytes::Bytes;
@@ -166,6 +167,15 @@ pub fn init_doh_client() {
         let doh_urls = read_doh_urls_from_config();
         info!("DoH client (in-process dispatch): urls={:?}", doh_urls);
 
+        // Open the persistent answer cache and hydrate the in-memory map from
+        // its unexpired entries. Cold-start now reuses warm DoH answers from
+        // prior PacketTunnel runs instead of re-paying the launch-burst.
+        {
+            let home_dir = crate::HOME_DIR.lock();
+            doh_cache::init(home_dir.as_deref());
+        }
+        hydrate_in_memory_from_disk();
+
         // The DoH path can traverse arbitrary upstream proxies the user
         // configured; matching the previous reqwest behavior, accept any
         // server cert. The DNS payload itself is not a secret and we trust
@@ -185,6 +195,26 @@ pub fn init_doh_client() {
     });
 }
 
+fn hydrate_in_memory_from_disk() {
+    let entries = doh_cache::load_unexpired();
+    if entries.is_empty() {
+        return;
+    }
+    let now = Instant::now();
+    let mut cache = cache().lock();
+    for (k, bytes, expires_unix_secs) in entries {
+        if cache.len() >= CACHE_MAX_ENTRIES {
+            break;
+        }
+        let ttl = doh_cache::expires_in(expires_unix_secs);
+        if ttl.is_zero() {
+            continue;
+        }
+        cache.insert(k, (bytes, now + ttl));
+    }
+    info!("doh cache: hydrated {} entries from disk", cache.len());
+}
+
 pub async fn resolve_via_doh(query: &[u8]) -> Option<Vec<u8>> {
     let client = DOH_CLIENT.get()?;
 
@@ -201,6 +231,8 @@ pub async fn resolve_via_doh(query: &[u8]) -> Option<Vec<u8>> {
                 return Some(resp);
             }
             cache.remove(k);
+            drop(cache);
+            doh_cache::remove(k);
         }
     }
 
@@ -248,20 +280,29 @@ pub async fn resolve_via_doh(query: &[u8]) -> Option<Vec<u8>> {
     // Cache successful result.
     if let (Some(k), Some(bytes)) = (key.as_ref(), result.as_ref()) {
         let ttl = cache_ttl(bytes);
-        let mut cache = cache().lock();
-        if cache.len() >= CACHE_MAX_ENTRIES {
-            // Evict the entry closest to expiry — cheap O(n) at n≤1024 and
-            // naturally biases toward dropping near-stale entries before fresh
-            // ones.
-            if let Some(oldest) = cache
-                .iter()
-                .min_by_key(|(_, (_, e))| *e)
-                .map(|(k, _)| k.clone())
-            {
-                cache.remove(&oldest);
+        let expires_unix = doh_cache::unix_secs_in(ttl);
+        let mut evicted: Option<Vec<u8>> = None;
+        {
+            let mut cache = cache().lock();
+            if cache.len() >= CACHE_MAX_ENTRIES {
+                // Evict the entry closest to expiry — cheap O(n) at n≤1024 and
+                // naturally biases toward dropping near-stale entries before fresh
+                // ones.
+                if let Some(oldest) = cache
+                    .iter()
+                    .min_by_key(|(_, (_, e))| *e)
+                    .map(|(k, _)| k.clone())
+                {
+                    cache.remove(&oldest);
+                    evicted = Some(oldest);
+                }
             }
+            cache.insert(k.clone(), (bytes.clone(), Instant::now() + ttl));
         }
-        cache.insert(k.clone(), (bytes.clone(), Instant::now() + ttl));
+        if let Some(e) = evicted {
+            doh_cache::remove(&e);
+        }
+        doh_cache::put(k, bytes, expires_unix);
     }
 
     if let Some(guard) = leader_guard {

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod diagnostics;
 mod dns_table;
+mod doh_cache;
 mod doh_client;
 mod engine;
 mod logging;


### PR DESCRIPTION
## Summary
- Add `redb = \"2\"` and a thin wrapper (`doh_cache.rs`) that opens a single table at `\$HOME_DIR/doh-cache.redb`.
- On `init_doh_client`, hydrate the in-memory `HashMap` from unexpired persisted entries; on every cache `insert` and capacity-eviction, write through to redb. Expired-on-read also clears the row.
- Expires are stored as wall-clock `SystemTime` Unix seconds so a reboot doesn't resurrect stale entries; the in-memory cache keeps `Instant` and is rebuilt fresh from the persisted wall-clock TTL on hydrate.

The in-memory cache (f851b2b) only collapses bursts within a single PacketTunnel run. iOS jetsams the extension routinely, so every reconnect re-paid the launch-burst — this fixes that.

Single-writer by construction: the DoH client is gated by `engine::tunnel()` and only runs inside PacketTunnel, never in the app process, so no cross-process redb contention.

## Path B attestation (Rust-only diff)
- [x] `cargo build --lib` — exit 0
- [x] `cargo clippy --lib --all-targets -- -D warnings` — 0 warnings, 0 errors
- [x] `cargo test --lib` in `core/rust/mihomo-ios-ffi/` — 11 passed (3 new in `doh_cache::tests`: round-trip + expiry filter, remove drops entry, `expires_in` saturation)
- [x] `scripts/build-rust.sh` — exit 0; xcframework rebuilt for ios-arm64 + ios-arm64-simulator
- [x] `git diff origin/main...HEAD --stat` reviewed — only the 4 expected Rust files + the new `doh_cache.rs`; no Swift / project / workflow changes
- [x] Smoke-tested on device (iPhone 17 Pro) via `scripts/build-adhoc.sh` + `xcrun devicectl device install`

## Test plan
- [ ] First launch on a fresh container: `info!` line `doh cache: opened …/doh-cache.redb`
- [ ] After a connect / disconnect cycle: `doh cache: hydrated N entries from disk` on the second launch with `N > 0`
- [ ] After a long pause where TTLs expire then a reconnect: hydrate count drops; expired rows are filtered out
- [ ] DoH still works when redb open fails (e.g., disk full / read-only) — `warn!` and in-memory cache continues serving

🤖 Generated with [Claude Code](https://claude.com/claude-code)