### PR TITLE
chore(release): build 2026042906 — uploaded to TestFlight

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042905</string>
+	<string>2026042906</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.5</string>
 	<key>CFBundleVersion</key>
-	<string>2026042905</string>
+	<string>2026042906</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/metadata/testflight/whats_new/2026042906.txt
+++ b/metadata/testflight/whats_new/2026042906.txt
@@ -1,0 +1,47 @@
+Build 2026042906 (1.1.5)
+
+WHAT'S NEW
+• Trust-China-DNS split-horizon resolver. For A / AAAA queries the
+  tunnel now races a Chinese plain-UDP resolver (DNSPod 119.29.29.29 +
+  AliDNS 223.5.5.5 by default, configurable via dns.china_nameserver in
+  config.yaml) against the existing trusted DoH path. If any A / AAAA
+  record in the China response falls in the bundled Country.mmdb's CN
+  ranges, the China answer wins; otherwise the trusted DoH answer is
+  used. Result: CN-hosted CDNs return geographically-near IPs again
+  (Weibo, Bilibili, Taobao, etc.) without leaking unrelated lookups.
+• Memory-conscious GeoIP. The full Country.mmdb (~8 MB) is parsed once
+  at PacketTunnel start, the CN ranges are extracted into a compact
+  iprange::IpRange<IpNet>, and the mmdb buffer is released. Resident
+  memory drops by ~5 MB versus keeping the whole DB mmap'd, easing
+  pressure on the 50 MB extension jetsam cap.
+
+WHAT TO TEST
+1. CN-hosted hostnames resolve to CN IPs
+   • Connect the tunnel.
+   • In Settings → About → Diagnostics (or any browser), open
+     https://www.weibo.com or https://www.bilibili.com.
+   • Confirm pages load reasonably fast (no Hong-Kong / Singapore
+     CDN routing artefacts that the previous DoH-only path produced).
+
+2. Non-CN hostnames stay routed via trusted DoH
+   • Open https://www.google.com, https://www.youtube.com.
+   • Confirm normal proxy routing (depends on your proxy rules) and
+     no regression in connectivity vs build 2026042901.
+
+3. Cold-start of PacketTunnel
+   • Toggle the VPN OFF then ON.
+   • Confirm the tunnel comes up within the usual 1-2 s; nothing
+     appears stuck during the initial GeoIP scan.
+
+4. Connect / disconnect cycles, proxy group switching, subscription
+   refresh, settings YAML editor — no new crashes or UI hangs.
+
+KNOWN LIMITATIONS
+• Non-DNS UDP traffic is not yet forwarded by the tunnel. WireGuard
+  outbounds will not pass traffic. QUIC / HTTP3 falls back to TCP
+  HTTP/2 (usually transparent).
+• The China-side path is plain UDP (no DoT / DoH on the CN upstreams
+  by design — matches trust-china-dns upstream).
+
+Please send TestFlight feedback or open an issue at:
+https://github.com/madeye/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026042906.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026042906.txt
@@ -1,0 +1,41 @@
+Build 2026042906 (1.1.5)
+
+新特性
+• Trust-China-DNS 分流解析。对 A / AAAA 查询,隧道现在会同时向中国
+  本地 UDP 解析器(默认 DNSPod 119.29.29.29 + AliDNS 223.5.5.5,可
+  通过 config.yaml 中的 dns.china_nameserver 配置)和原有的可信 DoH
+  上游发起请求,二者并行。如果中国侧响应中存在任意 A / AAAA 记录
+  落在内置 Country.mmdb 的 CN 段内,则采用中国侧答案;否则使用 DoH
+  答案。结果:微博、Bilibili、淘宝等 CN-CDN 域名重新解析到地理上
+  最近的 IP,同时其他域名的查询保持 DoH 隐私性。
+• GeoIP 内存优化。完整的 Country.mmdb(约 8 MB)在 PacketTunnel
+  启动时仅扫描一次,提取 CN 范围到紧凑的 iprange::IpRange<IpNet>,
+  随后释放原始缓冲区。常驻内存比保留整个 mmap 减少约 5 MB,缓解
+  扩展进程的 50 MB jetsam 上限压力。
+
+测试要点
+1. CN 域名解析到 CN IP
+   • 连接隧道。
+   • 浏览器打开 https://www.weibo.com 或 https://www.bilibili.com 。
+   • 确认页面加载速度合理,没有之前 DoH-only 路径产生的香港/新加坡
+     CDN 路由问题。
+
+2. 非 CN 域名仍走可信 DoH
+   • 打开 https://www.google.com 、https://www.youtube.com 。
+   • 确认按代理规则正常路由,与 build 2026042901 相比无连接性回归。
+
+3. PacketTunnel 冷启动
+   • 关闭再开启 VPN 开关。
+   • 确认隧道在通常的 1-2 秒内启动,GeoIP 扫描期间无明显卡顿。
+
+4. 连接 / 断开循环、代理组切换、订阅刷新、设置 YAML 编辑器 ——
+   无新增崩溃或界面卡顿。
+
+已知限制
+• 隧道暂未转发非 DNS 的 UDP 流量。WireGuard 出站不工作。QUIC /
+  HTTP3 会回落到 TCP HTTP/2(通常透明)。
+• 中国侧链路是明文 UDP(按 trust-china-dns 上游设计,不使用 DoT /
+  DoH)。
+
+请通过 TestFlight 反馈或在以下地址提 issue:
+https://github.com/madeye/meow-ios/issues

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.5"
-        CFBundleVersion: "2026042905"
+        CFBundleVersion: "2026042906"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -192,7 +192,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.5"
-        CFBundleVersion: "2026042905"
+        CFBundleVersion: "2026042906"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

- Bumps `CFBundleVersion` to `2026042906` (still `CFBundleShortVersionString = 1.1.5`).
- Adds en-US + zh-Hans "What to Test" notes for the trust-china-dns split-horizon resolver shipped in PR #104.
- IPA already archived from this branch and uploaded to App Store Connect via `xcodebuild -exportArchive` with `destination=upload` against the `app-store-connect` plist; processing on TF should be visible shortly. After this PR merges I'll run `scripts/upload-testflight-metadata.py` to push the `whatsNew` text once Apple has the build past the "Processing" gate.

## Path A bypass eligibility

This PR's diff touches only the `Info.plist` files, `project.yml`, and the two `metadata/testflight/whats_new/` text files — all non-code paths per CLAUDE.md's "non-code PR" definition. No Swift, Rust, workflow files, or build infrastructure changed. Eligible for `--rebase --admin --delete-branch` per the project guide's Path A.

## Test plan

- [ ] `App Store Connect → TestFlight` shows build `2026042906 (1.1.5)` reach `Ready to Test` (no missing-compliance / processing-stuck states).
- [ ] After processing, `scripts/upload-testflight-metadata.py` syncs en-US + zh-Hans "What to Test" without API errors.
- [ ] External tester installs `2026042906` and the trust-china-dns smoke test in PR #104's plan still passes (Weibo → CN IP, Google → trusted DoH IP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)