### PR TITLE
chore(release): bump to 1.1.6 (build 2026043001)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.5</string>
+	<string>1.1.6</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026042906</string>
+	<string>2026043001</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.5</string>
+	<string>1.1.6</string>
 	<key>CFBundleVersion</key>
-	<string>2026042906</string>
+	<string>2026043001</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -46,8 +46,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.1.5"
-        CFBundleVersion: "2026042906"
+        CFBundleShortVersionString: "1.1.6"
+        CFBundleVersion: "2026043001"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -191,8 +191,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.1.5"
-        CFBundleVersion: "2026042906"
+        CFBundleShortVersionString: "1.1.6"
+        CFBundleVersion: "2026043001"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

- Bump `CFBundleShortVersionString` 1.1.5 → **1.1.6**.
- Bump `CFBundleVersion` 2026042906 → **2026043001** (first build of 2026-04-30).
- Updated in `project.yml`, `App/Info.plist`, `PacketTunnel/Info.plist`.

Cuts the next TestFlight release on top of the v0.6.0 mihomo-rust pin (#106 / 5131a07).

## Path B attestation (admin rebase-merge bypass)

Diff is plist metadata only — no Swift/Rust source changed. Still ran the lint gate:

- [x] `swiftformat --lint .` → **0 violations** (78 files).
- [x] `swiftlint --strict` → **0 violations** (69 files).
- [x] `git diff origin/main...HEAD --stat` → only `project.yml`, `App/Info.plist`, `PacketTunnel/Info.plist`. No accidental additions.
- [x] `MeowTests` already green earlier this session (no Swift changes since); skipped re-run as the diff is build-metadata only.
- [x] Rust build/tests N/A — no Rust touched.

## Test plan

- [x] Lint clean.
- [ ] TestFlight build cut after merge.