### PR TITLE
chore(release): bump build to 2026050101

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.6"
-        CFBundleVersion: "2026043001"
+        CFBundleVersion: "2026050101"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -192,7 +192,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.6"
-        CFBundleVersion: "2026043001"
+        CFBundleVersion: "2026050101"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

- Bumps `CFBundleVersion` from `2026043001` → `2026050101` (App + PacketTunnel targets).
- Marketing version `1.1.6` unchanged.
- This is the first build that includes the DoH → plain-TCP DNS switch and the Settings-driven DNS upstream field from #109.

## Test plan

- [ ] CI green
- [ ] After merge: `scripts/upload-testflight.sh` from main → TestFlight build 2026050101 lands without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)