### PR TITLE
chore(release): sync Info.plist to build 2026050101

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026043001</string>
+	<string>2026050101</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.6</string>
 	<key>CFBundleVersion</key>
-	<string>2026043001</string>
+	<string>2026050101</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
## Summary

Catches up the two `Info.plist` files to `CFBundleVersion = 2026050101`. xcodegen writes these from `project.yml`, but PR #110 only landed the `project.yml` half — local xcodegen runs were silently filling the gap. This commit just pins the on-disk values so the App Store archive picks up the correct build number without relying on a local `scripts/generate-xcodeproj.sh` pass.

Strictly mechanical — no logic changes.

## Path B attestation (per CLAUDE.md)

- [x] `swiftformat --lint .` → 0 violations
- [x] `swiftlint --strict` → 0 violations
- [x] `xcodebuild test … MeowTests` → 105/105 (run on PR #109 — Info.plist content does not affect Swift compilation)
- [x] `git diff origin/main...HEAD --stat` → only `App/Info.plist` and `PacketTunnel/Info.plist`, 2 lines each, just the build-number string

🤖 Generated with [Claude Code](https://claude.com/claude-code)