### PR TITLE
perf(ffi): set mimalloc as the global allocator

### DIFF
--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -1506,6 +1506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libproc"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1752,7 @@ dependencies = [
  "mihomo-dns",
  "mihomo-proxy",
  "mihomo-tunnel",
+ "mimalloc",
  "netstack-smoltcp",
  "oslog",
  "parking_lot",
@@ -1861,6 +1871,15 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -45,6 +45,18 @@ serde_json = "1"
 libc = "0.2"
 anyhow = "1"
 
+# Global allocator. The system allocator is fine for general-purpose Rust
+# workloads but falls over on the tun2socks churn profile: thousands of
+# ~1500 B `Vec<u8>` allocations per second for IP frames, each dropped within
+# milliseconds. mimalloc's thread-local size-class freelists recycle those
+# blocks without a global-lock trip, and its page-purge policy returns
+# memory to the kernel on quiet periods so resident footprint can shrink
+# back under the NE extension's 50 MiB jetsam threshold.
+# `default-features = false` drops mimalloc's `secure` hardening mode — a
+# noticeable perf / binary-size win we don't need in a sandboxed NE process
+# that already has iOS-level mitigations.
+mimalloc = { version = "0.1", default-features = false }
+
 # Subscription parsing (v2rayN URI list → Clash YAML)
 base64 = "0.22"
 url = "2"

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -11,8 +11,16 @@
 //!
 //! No SOCKS5 loopback sits between tun2socks and the engine; the staticlib
 //! owns a single tokio runtime that both halves share. UDP DNS is
-//! short-circuited pre-stack to DoH; everything else flows through netstack's
-//! UDP socket.
+//! short-circuited pre-stack to a plain-TCP DNS client (still routed through
+//! mihomo's proxy chain); everything else flows through netstack's UDP socket.
+
+// Tests use the system allocator: mimalloc-rust 0.1 probes the stack on every
+// allocation, and `mihomo-config`'s serde_yaml deserialization nests deep
+// enough that the combination blows past any reasonable test-thread stack.
+// Production NE threads don't hit this path cold from a sync test.
+#[cfg(not(test))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 mod china_dns;
 mod diagnostics;


### PR DESCRIPTION
## Summary

Restores `mimalloc` as the global allocator for the FFI staticlib (PacketTunnel + main app). Drops `secure` hardening via `default-features = false` for a perf / binary-size win — fine in a sandboxed NE process. Tests stay on the system allocator (`#[cfg(not(test))]`) because mimalloc-rust 0.1's stack probe interacts badly with serde_yaml's deep recursion in `mihomo-config`.

## Why

The tun2socks churn profile allocates ~1500 B IP-frame `Vec<u8>` thousands of times per second, each freed within ms. mimalloc's thread-local freelists recycle those without a global-lock trip; its page-purge policy returns memory to the kernel between bursts, helping RSS contract back below the NE extension's 50 MiB jetsam ceiling.

This pairs naturally with the just-landed TCP idle-eviction layer (#113) — eviction returns connection memory to the heap on a 30s cadence, mimalloc's purge returns it to the kernel.

## Diff

3 files / 41 lines:
- `Cargo.toml` — `mimalloc = { version = "0.1", default-features = false }`
- `Cargo.lock` — adds `mimalloc 0.1.50` + `libmimalloc-sys 0.1.47`
- `src/lib.rs` — `#[cfg(not(test))] #[global_allocator] static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;`

No `libmimalloc-sys` direct dep, no `extended` feature — current main has no `mi_collect` call sites. If we want explicit periodic purge later (e.g. tied to the new idle-sweep tick), it's a one-line addition.

## Test plan

- [x] `cargo check --lib`
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --lib` — 23/23 (system allocator path)
- [x] `scripts/build-rust.sh` — device + sim XCFramework rebuilt with mimalloc linked
- [ ] Smoke test on device: confirm `phys_footprint` from `MWTunnelEngine` traffic pump shows shorter low-water troughs after bursts compared to system allocator baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)