### PR TITLE
chore(tun2socks): cap burst TCP at 512, revert mimalloc

### DIFF
--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -1506,15 +1506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "libproc"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,7 +1743,6 @@ dependencies = [
  "mihomo-dns",
  "mihomo-proxy",
  "mihomo-tunnel",
- "mimalloc",
  "netstack-smoltcp",
  "oslog",
  "parking_lot",
@@ -1871,15 +1861,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -45,18 +45,6 @@ serde_json = "1"
 libc = "0.2"
 anyhow = "1"
 
-# Global allocator. The system allocator is fine for general-purpose Rust
-# workloads but falls over on the tun2socks churn profile: thousands of
-# ~1500 B `Vec<u8>` allocations per second for IP frames, each dropped within
-# milliseconds. mimalloc's thread-local size-class freelists recycle those
-# blocks without a global-lock trip, and its page-purge policy returns
-# memory to the kernel on quiet periods so resident footprint can shrink
-# back under the NE extension's 50 MiB jetsam threshold.
-# `default-features = false` drops mimalloc's `secure` hardening mode — a
-# noticeable perf / binary-size win we don't need in a sandboxed NE process
-# that already has iOS-level mitigations.
-mimalloc = { version = "0.1", default-features = false }
-
 # Subscription parsing (v2rayN URI list → Clash YAML)
 base64 = "0.22"
 url = "2"

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -14,14 +14,6 @@
 //! short-circuited pre-stack to a plain-TCP DNS client (still routed through
 //! mihomo's proxy chain); everything else flows through netstack's UDP socket.
 
-// Tests use the system allocator: mimalloc-rust 0.1 probes the stack on every
-// allocation, and `mihomo-config`'s serde_yaml deserialization nests deep
-// enough that the combination blows past any reasonable test-thread stack.
-// Production NE threads don't hit this path cold from a sync test.
-#[cfg(not(test))]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 mod china_dns;
 mod diagnostics;
 mod dns_table;

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -70,14 +70,12 @@ pub(crate) static ACTIVE_TCP_CONNS: std::sync::atomic::AtomicI64 =
 // completes. Drops at the accept boundary; peers see RST / packet loss for a
 // few hundred ms instead of the whole tunnel dying.
 //
-// `TCP_BURST_CAP` is a hard memory backstop sitting above `TCP_SOFT_CAP`.
-// The soft cap (512) is the one users normally hit: when reached, idle flows
-// (>= TCP_IDLE_SECS without any byte movement) are evicted at accept time
-// and by a periodic sweeper, freeing both their burst-cap permits and the
-// upstream SOCKS5 connection mihomo's relay was holding open. The hard cap
-// only fires if eviction can't free enough room — a real overload.
-const TCP_BURST_CAP: usize = 1024;
-const TCP_SOFT_CAP: usize = 512;
+// `TCP_BURST_CAP` is the hard accept-time ceiling. When `try_acquire_owned`
+// returns `Err`, we run the idle sweeper once to evict flows that haven't
+// moved bytes for `TCP_IDLE_SECS` — eviction drops the held permit + closes
+// the upstream SOCKS5 connection — and retry the acquire. Genuine overload
+// (no idle flows to reclaim) drops the new flow at the listener.
+const TCP_BURST_CAP: usize = 512;
 const TCP_IDLE_SECS: u64 = 90;
 const TCP_IDLE_SWEEP_INTERVAL_SECS: u64 = 30;
 const UDP_BURST_CAP: usize = 512;
@@ -302,23 +300,25 @@ async fn run_tun2socks(
     let tcp_sem_accept = tcp_sem.clone();
     let tcp_accept_handle = tokio::spawn(async move {
         while let Some((stream, local_addr, remote_addr)) = tcp_listener.next().await {
-            // Soft cap: reaching 512 active flows triggers an idle sweep
-            // before we commit to admitting the new flow. Eviction frees
-            // burst-cap permits along with the upstream SOCKS5 connections
-            // those flows held, so the subsequent acquire usually succeeds.
-            if ACTIVE_TCP_CONNS.load(Ordering::Relaxed) >= TCP_SOFT_CAP as i64 {
+            // Burst cap: when the semaphore is exhausted, run the idle
+            // sweeper before giving up. Eviction returns held permits +
+            // closes the upstream SOCKS5 connections of stale flows, so a
+            // retry usually succeeds. If the sweep frees nothing (every
+            // flow is genuinely active), drop at the listener.
+            let permit = if let Ok(p) = tcp_sem_accept.clone().try_acquire_owned() {
+                p
+            } else {
                 sweep_idle_tcp_flows();
-            }
-
-            let permit = match tcp_sem_accept.clone().try_acquire_owned() {
-                Ok(p) => p,
-                Err(_) => {
-                    warn_capped(
-                        &TCP_CAP_LOG_LAST_MS,
-                        "tun2socks: TCP burst cap reached, dropping flow",
-                    );
-                    drop(stream);
-                    continue;
+                match tcp_sem_accept.clone().try_acquire_owned() {
+                    Ok(p) => p,
+                    Err(_) => {
+                        warn_capped(
+                            &TCP_CAP_LOG_LAST_MS,
+                            "tun2socks: TCP burst cap reached, dropping flow",
+                        );
+                        drop(stream);
+                        continue;
+                    }
                 }
             };
             logging::bridge_log(&format!("tun2socks: TCP {} -> {}", local_addr, remote_addr));


### PR DESCRIPTION
## Summary

- Revert `mimalloc` as the global allocator (#114). Back to the system allocator. `Cargo.lock` loses `libmimalloc-sys` + `mimalloc`.
- Lower `TCP_BURST_CAP` 1024 → 512 and drop `TCP_SOFT_CAP`. With both caps collapsing into one, eviction is now driven by acquire-failure rather than a separate soft threshold:

  ```rust
  let permit = if let Ok(p) = sem.try_acquire_owned() {
      p
  } else {
      sweep_idle_tcp_flows();
      match sem.try_acquire_owned() {
          Ok(p) => p,
          Err(_) => { /* drop, peer sees RST */ }
      }
  };
  ```

  The 30s periodic sweeper still runs so flows that go idle without new accepts arriving still get reclaimed.

## Test plan

- [x] `cargo check --lib`
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --lib` — 23/23
- [x] `scripts/build-rust.sh` — device + sim XCFramework rebuilt without mimalloc

🤖 Generated with [Claude Code](https://claude.com/claude-code)