### PR TITLE
feat(dns): skip CN-IP records, disable mihomo SNI sniffer

### DIFF
--- a/core/rust/mihomo-ios-ffi/src/china_dns.rs
+++ b/core/rust/mihomo-ios-ffi/src/china_dns.rs
@@ -407,6 +407,19 @@ pub(crate) fn response_has_cn_ip(response: &[u8]) -> bool {
     false
 }
 
+/// True iff `ip` is in the pre-built CN ipset. Returns `false` when the
+/// ipset is missing or empty (GeoIP unavailable) so callers degrade to a
+/// pass-through and don't accidentally treat every IP as non-CN-special.
+pub(crate) fn is_cn_ip(ip: IpAddr) -> bool {
+    let Some(ipset) = CN_IPSET.get() else {
+        return false;
+    };
+    if ipset.is_empty() {
+        return false;
+    }
+    ipset.contains(ip)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/rust/mihomo-ios-ffi/src/engine.rs
+++ b/core/rust/mihomo-ios-ffi/src/engine.rs
@@ -70,6 +70,13 @@ fn strip_listener_fields(yaml: &str) -> Result<String> {
             "mixed-port",
             "tproxy-port",
             "listeners",
+            // Drop the entire `sniffer:` block. iOS routes TCP via the SOCKS5
+            // loopback and relies on the reverse DNS table for hostname
+            // recovery, so SNI/ALPN sniffing inside mihomo is redundant — and
+            // when enabled it rewrites the destination based on the sniffed
+            // hostname, which fights the dns_table mapping. Strip at the FFI
+            // boundary so user subscriptions can't re-enable it.
+            "sniffer",
         ] {
             m.remove(serde_yaml::Value::String(key.to_string()));
         }
@@ -293,6 +300,11 @@ listeners:
   - name: mixed
     type: mixed
     port: 7890
+sniffer:
+  enable: true
+  sniff:
+    TLS:
+      ports: [443]
 mode: rule
 log-level: info
 "#;
@@ -305,6 +317,7 @@ log-level: info
             "mixed-port",
             "tproxy-port",
             "listeners",
+            "sniffer",
         ] {
             assert!(
                 !m.contains_key(serde_yaml::Value::String(k.into())),

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -802,6 +802,13 @@ async fn handle_dns_query(
 
     if let Some(response) = crate::china_dns::resolve(&query).await {
         for (ip, hostname, ttl) in dns_table::parse_dns_response_records(&response) {
+            // Skip CN-IP records: traffic to them takes the direct path and
+            // never hits the SOCKS5 loopback, so the reverse-lookup table
+            // entry would never be consulted — caching it just bloats the
+            // map and risks shadowing a later non-CN answer for the same IP.
+            if crate::china_dns::is_cn_ip(ip) {
+                continue;
+            }
             dns_table::dns_table_insert(ip, hostname, ttl);
         }
         let _ = reply_tx.try_send(build_udp_packet(

--- a/core/rust/mihomo-ios-ffi/tests/fixtures/subscription_ss_like.yaml
+++ b/core/rust/mihomo-ios-ffi/tests/fixtures/subscription_ss_like.yaml
@@ -42,7 +42,7 @@ dns:
   - 1.1.1.1
   nameserver:
   - https://1.1.1.1/dns-query
-  - https://dns.google/dns-query
+  - https://8.8.8.8/dns-query
   fake-ip-range: 198.18.0.1/15
   fake-ip-filter:
   - '*.lan'


### PR DESCRIPTION
## Summary

- **`tun2socks` DNS table:** `handle_dns_query` now skips inserting (IP, hostname) pairs when the resolved IP is in the CN ipset. CN-IP traffic takes the direct path and never traverses the SOCKS5 loopback, so the reverse map entry would never be consulted; caching it just bloats the table and risks shadowing later non-CN answers for the same IP.
- **mihomo SNI sniffer:** `strip_listener_fields` now also drops the entire `sniffer:` block. mihomo's TLS/HTTP sniffer rewrites the destination from the sniffed hostname, which fights the dns_table mapping iOS relies on for hostname recovery. Stripping at the FFI boundary makes this enforceable regardless of what the user's subscription YAML says.
- **Unblock ss-feature regression test:** Replaced `https://dns.google/dns-query` with `https://8.8.8.8/dns-query` in the test fixture. mihomo-config v0.6.0's `parse_dns` synchronously bootstraps every encrypted upstream that uses a hostname; in sandboxed CI the plain-UDP bootstrap to `223.5.5.5` etc. times out (~36s). IP-literal DoH URLs short-circuit the bootstrap.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 23 passed (was 22 + 1 timeout; fixture fix turns it green offline)
- [x] Verified `git diff origin/main...HEAD --stat` — only the 4 intended files
- [x] Built Ad Hoc IPA (`scripts/build-adhoc.sh`) and installed on iPhone 17 Pro via `devicectl` for smoke testing
- [ ] CI green on this branch before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)