### PR TITLE
feat(proxy-control): in-process selector via NE app-message

### DIFF
--- a/App/Sources/Services/MihomoAPI.swift
+++ b/App/Sources/Services/MihomoAPI.swift
@@ -1,4 +1,6 @@
 import Foundation
+import MeowIPC
+import NetworkExtension
 import os
 
 /// REST client for the mihomo external-controller that runs inside the
@@ -30,8 +32,73 @@ final class MihomoAPI: @unchecked Sendable {
         try await get("/proxies")
     }
 
+    /// Switch the active member of a `type: select` proxy group.
+    ///
+    /// Prefers the in-process IPC path (`ProxyControlIPC` over
+    /// `sendProviderMessage`), which calls `meow_proxy_select` directly
+    /// against the `SelectorGroup` inside the PacketTunnel extension.
+    /// That path is byte-exact: the `group` and `name` strings are
+    /// matched against the parsed proxy registry without URL
+    /// percent-encoding or Unicode normalization, which is what the
+    /// previous loopback-HTTP path tripped on for emoji-named groups
+    /// (`🚀 节点选择`) and CJK + space proxy names.
+    ///
+    /// Falls back to the loopback `PUT /proxies/{group}` if no provider
+    /// session is available — typically when the tunnel isn't running
+    /// (and the IPC would have failed anyway, but the HTTP path returns
+    /// a clearer error). Set `MihomoIPCDisabled = YES` in UserDefaults
+    /// to force the HTTP path for debugging.
     func selectProxy(group: String, name: String) async throws {
+        let ipcDisabled = UserDefaults.standard.bool(forKey: "MihomoIPCDisabled")
+        if !ipcDisabled, let session = await Self.tunnelSession() {
+            try await selectProxyViaIPC(session: session, group: group, name: name)
+            return
+        }
         try await put("/proxies/\(group.urlEscaped)", body: ["name": name])
+    }
+
+    /// Single-shot request/response over `NETunnelProviderSession`.
+    /// Errors here surface as `MihomoAPIError.proxyControl` so the UI can
+    /// distinguish "engine not running" / "name not in selector" from a
+    /// transport failure.
+    private func selectProxyViaIPC(
+        session: NETunnelProviderSession,
+        group: String,
+        name: String,
+    ) async throws {
+        let payload = try ProxyControlIPC.encodeRequest(.select(group: group, name: name))
+        log.info("IPC proxy_select group=\(group, privacy: .public) name=\(name, privacy: .public)")
+        let response: ProxyControlResponse = try await withCheckedThrowingContinuation { cont in
+            do {
+                try session.sendProviderMessage(payload) { data in
+                    guard let data else {
+                        cont.resume(throwing: MihomoAPIError.proxyControl(reason: "no response from extension"))
+                        return
+                    }
+                    do {
+                        let decoded = try ProxyControlIPC.decodeResponse(data)
+                        cont.resume(returning: decoded)
+                    } catch {
+                        cont.resume(throwing: error)
+                    }
+                }
+            } catch {
+                cont.resume(throwing: error)
+            }
+        }
+        guard response.success else {
+            throw MihomoAPIError.proxyControl(reason: response.errorReason ?? "unknown (code \(response.code ?? -99))")
+        }
+    }
+
+    /// Resolves the running PacketTunnel session, if any. Returns nil
+    /// when no manager is loaded or the tunnel isn't connected — the
+    /// caller falls back to the loopback path in that case.
+    private static func tunnelSession() async -> NETunnelProviderSession? {
+        guard let managers = try? await NETunnelProviderManager.loadAllFromPreferences() else {
+            return nil
+        }
+        return managers.first?.connection as? NETunnelProviderSession
     }
 
     func testDelay(proxy: String, url: String, timeout: Int = 5000) async throws -> Int {
@@ -209,6 +276,7 @@ final class MihomoAPI: @unchecked Sendable {
 enum MihomoAPIError: Error {
     case http(status: Int)
     case malformed
+    case proxyControl(reason: String)
 }
 
 private extension String {

--- a/App/Sources/Services/MihomoAPI.swift
+++ b/App/Sources/Services/MihomoAPI.swift
@@ -79,7 +79,17 @@ final class MihomoAPI: @unchecked Sendable {
                         let decoded = try ProxyControlIPC.decodeResponse(data)
                         cont.resume(returning: decoded)
                     } catch {
-                        cont.resume(throwing: error)
+                        // Bubble up enough to identify what the extension
+                        // actually returned: bytes-length and a UTF-8
+                        // preview (truncated). The most common shapes are
+                        // empty Data (old extension binary still running
+                        // post-update — disconnect/reconnect to reload),
+                        // or a non-JSON status line.
+                        let bytes = data.count
+                        let preview = String(data: data.prefix(120), encoding: .utf8) ?? "<non-utf8>"
+                        cont.resume(throwing: MihomoAPIError.proxyControl(
+                            reason: "IPC reply not decodable (\(bytes) B): \(preview)",
+                        ))
                     }
                 }
             } catch {

--- a/App/Sources/Views/ProxyGroupsView.swift
+++ b/App/Sources/Views/ProxyGroupsView.swift
@@ -102,11 +102,33 @@ private extension ProxyGroupsView {
             }
             await refresh()
         } catch {
-            loadError = String(
+            // Surface the underlying reason — `MihomoAPIError.proxyControl`
+            // carries the sanitized message from `meow_core_last_error`
+            // (e.g. "engine not running", "'<name>' is not a member of
+            // '<group>'", "'<group>' is not a select-type group"), and
+            // HTTP-fallback failures carry a status code. Hiding it
+            // behind a generic localized string makes "select failed"
+            // un-debuggable from the device UI alone.
+            let prefix = String(
                 localized: "home.error.selectFailed",
                 comment: "Inline error shown in Proxy Groups header when selecting a proxy fails",
             )
+            loadError = "\(prefix): \(Self.describe(error))"
         }
+    }
+
+    /// Compact, user-facing description of the API error. The reasons
+    /// are already sanitized at the FFI boundary, so they're safe to
+    /// show verbatim.
+    private static func describe(_ error: any Error) -> String {
+        if let api = error as? MihomoAPIError {
+            switch api {
+            case let .proxyControl(reason): return reason
+            case let .http(status): return "HTTP \(status)"
+            case .malformed: return "malformed response"
+            }
+        }
+        return error.localizedDescription
     }
 
     func ping(proxy: String) async {

--- a/MeowCore/include/mihomo_core.h
+++ b/MeowCore/include/mihomo_core.h
@@ -129,6 +129,31 @@ int meow_engine_test_proxy_http(const char *url, int timeout_ms, int *out_status
 int meow_engine_test_dns(const char *host, int timeout_ms, char *out, int out_cap);
 
 /**
+ * Select a member proxy inside a `type: select` group, in-process —
+ * the same mutation that `PUT /proxies/{group}` performs against the
+ * REST API, but without the loopback hop. `group` and `name` are
+ * matched against the upstream `SelectorGroup` byte-for-byte: no
+ * Unicode normalization, no percent-decoding, no whitespace folding.
+ * Emoji + CJK + space names therefore round-trip verbatim from YAML
+ * to selector lookup, eliminating a class of bugs the URL-encoded
+ * path is sensitive to.
+ *
+ * Return codes:
+ * * `0`  — selection applied.
+ * * `-1` — argument is null or not valid UTF-8.
+ * * `-2` — engine is not running.
+ * * `-3` — group not found, or the named proxy is not a select group.
+ * * `-4` — `name` is not a member of the selector.
+ *
+ * On non-zero returns, `meow_core_last_error` carries a sanitized
+ * reason suitable for surfacing in the UI.
+ *
+ * # Safety
+ * `group` and `name` must each be a NUL-terminated UTF-8 C string.
+ */
+int meow_proxy_select(const char *group, const char *name);
+
+/**
  * Configure the trusted plain-TCP DNS upstream pool from the iOS Settings
  * view. `csv` is a comma-/whitespace-separated list of `host` or
  * `host:port` entries (port defaults to 53); empty / NULL / parse-failed

--- a/MeowShared/Sources/MeowIPC/ProxyControlIPC.swift
+++ b/MeowShared/Sources/MeowIPC/ProxyControlIPC.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Payload used between the app and the PacketTunnel extension's
+/// `handleAppMessage` for proxy-control mutations that today round-trip
+/// through `PUT http://127.0.0.1:9090/proxies/{group}`. Routing the call
+/// through `sendProviderMessage` lets the extension invoke the
+/// `meow_proxy_select` FFI directly against mihomo-rust's `SelectorGroup`
+/// in-process, which:
+///
+///   1. eliminates the loopback HTTP hop and the URL percent-encoding /
+///      Unicode-normalization step that breaks emoji-named groups (e.g.
+///      `🚀 节点选择`),
+///   2. removes the need to expose mihomo's `external-controller` on
+///      `127.0.0.1:9090` solely for the picker, and
+///   3. drops the apiSecret as the only thing standing between any
+///      process on-device and a privileged mutation.
+///
+/// Tag dispatch matches the `DiagnosticsIPC` convention — the extension
+/// has a single `handleAppMessage` entry point, so the first byte routes
+/// the request. Streaming endpoints (logs / connections / traffic) stay
+/// on HTTP because `sendProviderMessage` is single-shot request/response.
+public enum ProxyControlIPC {
+    /// First byte of every proxy-control request. Picked to extend
+    /// `DiagnosticsIPC`'s 0x01-0x03 range without collision.
+    public static let tag: UInt8 = 0x04
+
+    public static func encodeRequest(_ request: ProxyControlRequest) throws -> Data {
+        let body = try JSONEncoder().encode(request)
+        var data = Data([tag])
+        data.append(body)
+        return data
+    }
+
+    public static func isRequest(_ data: Data) -> Bool {
+        data.count >= 2 && data[0] == tag
+    }
+
+    public static func decodeRequest(_ data: Data) throws -> ProxyControlRequest {
+        guard isRequest(data) else {
+            throw ProxyControlIPCError.tagMismatch
+        }
+        let body = data.subdata(in: 1 ..< data.count)
+        return try JSONDecoder().decode(ProxyControlRequest.self, from: body)
+    }
+
+    public static func encodeResponse(_ response: ProxyControlResponse) throws -> Data {
+        try JSONEncoder().encode(response)
+    }
+
+    public static func decodeResponse(_ data: Data) throws -> ProxyControlResponse {
+        try JSONDecoder().decode(ProxyControlResponse.self, from: data)
+    }
+}
+
+/// Request shape. Only `select` is wired today — `delay` and
+/// `groupHealthcheck` will follow in a separate change once the select
+/// path is proven against the emoji-group fixture.
+public enum ProxyControlRequest: Codable, Sendable {
+    case select(group: String, name: String)
+}
+
+/// Response shape. `success` mirrors the FFI's `0` return; on failure,
+/// `errorReason` carries the sanitized message from
+/// `meow_core_last_error` and `code` carries the FFI's negative return
+/// code so the UI can distinguish "engine not running" from "name not in
+/// selector" without string-matching.
+public struct ProxyControlResponse: Codable, Sendable, Equatable {
+    public var success: Bool
+    public var errorReason: String?
+    public var code: Int32?
+
+    public init(success: Bool, errorReason: String? = nil, code: Int32? = nil) {
+        self.success = success
+        self.errorReason = errorReason
+        self.code = code
+    }
+
+    public static let success = ProxyControlResponse(success: true)
+
+    public static func failure(code: Int32, reason: String) -> ProxyControlResponse {
+        ProxyControlResponse(success: false, errorReason: reason, code: code)
+    }
+}
+
+public enum ProxyControlIPCError: Error, Sendable {
+    case tagMismatch
+}

--- a/MeowTests/Fixtures/yaml/clash_emoji_groups_realworld.yaml
+++ b/MeowTests/Fixtures/yaml/clash_emoji_groups_realworld.yaml
@@ -1,0 +1,373 @@
+
+#---------------------------------------------------#
+## 上次更新于：2026-05-08 04:18:06
+#---------------------------------------------------#
+
+mixed-port: 7890
+allow-lan: true
+bind-address: "*"
+mode: rule
+log-level: info
+external-controller: "127.0.0.1:9090"
+dns:
+  enable: true
+  ipv6: false
+  proxy-server-nameserver: [https://doh.pub/dns-query, https://dns.alidns.com/dns-query, tls://223.5.5.5]
+  default-nameserver: [223.5.5.5, 119.29.29.29]
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.1/16
+  use-hosts: true
+  nameserver: 
+    [
+      "https://doh.pub/dns-query",
+      "https://dns.alidns.com/dns-query",
+      "223.5.5.5",
+      "119.29.29.29",
+    ]
+  fake-ip-filter: ['*.lan', '*.localdomain', '*.example', '*.invalid', '*.localhost', '*.test', '*.local', '*.home.arpa', 'time.*.com', 'time.*.gov', 'time.*.edu.cn', 'time.*.apple.com', 'time1.*.com', 'time2.*.com', 'time3.*.com', 'time4.*.com', 'time5.*.com', 'time6.*.com', 'time7.*.com', 'ntp.*.com', 'ntp1.*.com', 'ntp2.*.com', 'ntp3.*.com', 'ntp4.*.com', 'ntp5.*.com', 'ntp6.*.com', 'ntp7.*.com', '*.time.edu.cn', '*.ntp.org.cn', +.pool.ntp.org, time1.cloud.tencent.com, music.163.com, '*.music.163.com', '*.126.net', musicapi.taihe.com, music.taihe.com, songsearch.kugou.com, trackercdn.kugou.com, '*.kuwo.cn', api-jooxtt.sanook.com, api.joox.com, joox.com, y.qq.com, '*.y.qq.com', streamoc.music.tc.qq.com, mobileoc.music.tc.qq.com, isure.stream.qqmusic.qq.com, dl.stream.qqmusic.qq.com, aqqmusic.tc.qq.com, amobile.music.tc.qq.com, '*.xiami.com', '*.music.migu.cn', music.migu.cn, +.msftconnecttest.com, +.msftncsi.com, msftconnecttest.com, msftncsi.com, localhost.ptlogin2.qq.com, localhost.sec.qq.com, +.srv.nintendo.net, +.stun.playstation.net, 'xbox.*.microsoft.com', xnotify.xboxlive.com, +.ipv6.microsoft.com, +.battlenet.com.cn, +.wotgame.cn, +.wggames.cn, +.wowsgame.cn, +.wargaming.net, proxy.golang.org, 'stun.*.*', 'stun.*.*.*', '+.stun.*.*', '+.stun.*.*.*', '+.stun.*.*.*.*', heartbeat.belkin.com, '*.linksys.com', '*.linksyssmartwifi.com', '*.router.asus.com', mesu.apple.com, swscan.apple.com, swquery.apple.com, swdownload.apple.com, swcdn.apple.com, swdist.apple.com, lens.l.google.com, stun.l.google.com, '*.square-enix.com', '*.finalfantasyxiv.com', '*.ffxiv.com', '*.ff14.sdo.com', ff.dorado.sdo.com, '*.mcdn.bilivideo.cn', +.media.dssott.com, +.pvp.net]
+proxies:
+  -
+    name: '🇭🇰 套餐到期日期：2027-01-06'
+    type: trojan
+    server: 192.0.2.10
+    port: 4005
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇭🇰 套餐重置日期：2026-05-12'
+    type: trojan
+    server: 192.0.2.10
+    port: 4005
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇭🇰 订阅获取时间：2026-05-08 16:18'
+    type: trojan
+    server: 192.0.2.10
+    port: 4005
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇭🇰 香港 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4005
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇭🇰 香港 02'
+    type: trojan
+    server: 192.0.2.10
+    port: 4006
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇭🇰 香港 03'
+    type: trojan
+    server: 192.0.2.10
+    port: 4007
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇨🇳 台湾 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4003
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇨🇳 台湾 02'
+    type: trojan
+    server: 192.0.2.10
+    port: 4004
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇨🇳 台湾 03'
+    type: trojan
+    server: 192.0.2.10
+    port: 4027
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇸🇬 新加坡 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4000
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇸🇬 新加坡 02'
+    type: trojan
+    server: 192.0.2.10
+    port: 4008
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇸🇬 新加坡 03'
+    type: trojan
+    server: 192.0.2.10
+    port: 4012
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇯🇵 日本 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4002
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇯🇵 日本 02'
+    type: trojan
+    server: 192.0.2.10
+    port: 4010
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇯🇵 日本 03'
+    type: trojan
+    server: 192.0.2.10
+    port: 4029
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇺🇲 美国 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4001
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇺🇲 美国 02'
+    type: trojan
+    server: 192.0.2.10
+    port: 4011
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇺🇲 美国 03'
+    type: trojan
+    server: 192.0.2.10
+    port: 4009
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇷🇺 俄罗斯 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4059
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇨🇦 加拿大 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4065
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇮🇩 印尼 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4058
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇮🇳 印度 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4057
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇹🇷 土耳其 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4055
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇧🇷 巴西 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4062
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇩🇪 德国 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4064
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇹🇭 泰国 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4060
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇦🇺 澳大利亚 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4063
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇬🇧 英国 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4053
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇳🇱 荷兰 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4061
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇵🇭 菲律宾 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4056
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇰🇷 韩国 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4052
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+  -
+    name: '🇲🇾 马来西亚 01'
+    type: trojan
+    server: 192.0.2.10
+    port: 4054
+    password: TROJAN_TEST_PASSWORD
+    sni: example.com
+    skip-cert-verify: true
+    udp: true
+proxy-groups:
+  -
+    name: '🚀 节点选择'
+    type: select
+    proxies:
+      - '🇭🇰 套餐到期日期：2027-01-06'
+      - '🇭🇰 套餐重置日期：2026-05-12'
+      - '🇭🇰 订阅获取时间：2026-05-08 16:18'
+      - '🇭🇰 香港 01'
+      - '🇭🇰 香港 02'
+      - '🇭🇰 香港 03'
+      - '🇨🇳 台湾 01'
+      - '🇨🇳 台湾 02'
+      - '🇨🇳 台湾 03'
+      - '🇸🇬 新加坡 01'
+      - '🇸🇬 新加坡 02'
+      - '🇸🇬 新加坡 03'
+      - '🇯🇵 日本 01'
+      - '🇯🇵 日本 02'
+      - '🇯🇵 日本 03'
+      - '🇺🇲 美国 01'
+      - '🇺🇲 美国 02'
+      - '🇺🇲 美国 03'
+      - '🇷🇺 俄罗斯 01'
+      - '🇨🇦 加拿大 01'
+      - '🇮🇩 印尼 01'
+      - '🇮🇳 印度 01'
+      - '🇹🇷 土耳其 01'
+      - '🇧🇷 巴西 01'
+      - '🇩🇪 德国 01'
+      - '🇹🇭 泰国 01'
+      - '🇦🇺 澳大利亚 01'
+      - '🇬🇧 英国 01'
+      - '🇳🇱 荷兰 01'
+      - '🇵🇭 菲律宾 01'
+      - '🇰🇷 韩国 01'
+      - '🇲🇾 马来西亚 01'
+      - DIRECT
+  -
+    name: '🎯 全球直连'
+    type: select
+    proxies:
+      - DIRECT
+      - '🚀 节点选择'
+  -
+    name: '🐟 漏网之鱼'
+    type: select
+    proxies:
+      - '🚀 节点选择'
+      - DIRECT
+
+rules:
+  - DOMAIN-SUFFIX,localhost,DIRECT
+  - DOMAIN-SUFFIX,cn,🎯 全球直连
+  - GEOIP,LAN,DIRECT
+  - GEOIP,CN,🎯 全球直连
+  - MATCH,🚀 节点选择

--- a/MeowTests/Parsing/EmojiGroupSelectNodeTests.swift
+++ b/MeowTests/Parsing/EmojiGroupSelectNodeTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+@testable import meow_ios
+import Testing
+import Yams
+
+/// Real-world Clash YAML pulled from a third-party subscription
+/// (sanitized: server IP, password, SNI, and the `#!MANAGED-CONFIG` URL
+/// all replaced with TEST-NET / placeholder values; provider identifying
+/// strings stripped). Verifies the shape the app's "select node" UX
+/// depends on:
+///
+/// 1. The parser's sniff (`SubscriptionParser.looksLikeClashYAML`) accepts
+///    the file.
+/// 2. Yams can round-trip the file — emoji-named proxies/groups don't
+///    confuse the YAML decoder.
+/// 3. There is exactly one `type: select` group named `🚀 节点选择`, and
+///    every name it lists either resolves to a proxy in the `proxies:`
+///    block or is a built-in (`DIRECT`/`REJECT`). Dangling references are
+///    the bug class that breaks the picker — once mihomo-rust converts
+///    `select` → `Selector`, `ProxyGroupModel.build(from:)` would render
+///    a child the user can't actually switch to.
+@Suite("Emoji-named proxy groups · select-node", .tags(.parsing))
+struct EmojiGroupSelectNodeTests {
+    @Test
+    func `node-select group has every child resolvable`() throws {
+        let data = try Self.loadFixture("clash_emoji_groups_realworld")
+
+        #expect(SubscriptionParser.looksLikeClashYAML(data))
+
+        let text = try #require(String(data: data, encoding: .utf8))
+        let root = try #require(try Yams.load(yaml: text) as? [String: Any])
+
+        // Collect proxy names.
+        let proxies = try #require(root["proxies"] as? [[String: Any]])
+        let proxyNames = Set(proxies.compactMap { $0["name"] as? String })
+        #expect(proxies.count == 32)
+
+        // Find the select-node group.
+        let groups = try #require(root["proxy-groups"] as? [[String: Any]])
+        #expect(groups.count == 3)
+
+        let selectNode = try #require(groups.first { ($0["name"] as? String) == "🚀 节点选择" })
+        #expect(selectNode["type"] as? String == "select")
+
+        let children = try #require(selectNode["proxies"] as? [String])
+        #expect(children.count == 33)
+        #expect(children.last == "DIRECT")
+
+        // Every named child must resolve — either to a parsed proxy or to a
+        // mihomo built-in. A drift here is what makes "select node" silently
+        // surface a row the user can't actually switch to.
+        let builtins = Set(["DIRECT", "REJECT", "REJECT-DROP", "PASS", "COMPATIBLE"])
+        let unresolved = children.filter { !proxyNames.contains($0) && !builtins.contains($0) }
+        #expect(unresolved.isEmpty, "select-node references unresolved children: \(unresolved)")
+
+        // The two derived select groups should also be `select` and only
+        // reference DIRECT or 🚀 节点选择.
+        for derivedName in ["🎯 全球直连", "🐟 漏网之鱼"] {
+            let derived = try #require(groups.first { ($0["name"] as? String) == derivedName })
+            #expect(derived["type"] as? String == "select")
+            let derivedChildren = try #require(derived["proxies"] as? [String])
+            let allowed = Set(["DIRECT", "🚀 节点选择"])
+            #expect(Set(derivedChildren).isSubset(of: allowed))
+        }
+    }
+
+    @Test
+    func `sanitized fixture contains no real server credentials`() throws {
+        // Belt-and-braces: if the sanitization step ever regresses, this
+        // test fails before the fixture lands on someone's disk.
+        let data = try Self.loadFixture("clash_emoji_groups_realworld")
+        let text = try #require(String(data: data, encoding: .utf8))
+        #expect(!text.contains("113.46.151.169"))
+        #expect(!text.contains("3a27514d-b184-3fac-8980-0c77a59cf994"))
+        #expect(!text.contains("baidu.com"))
+        #expect(!text.contains("MANAGED-CONFIG"))
+    }
+
+    /// Locates a fixture YAML inside the test bundle. Resources land flat
+    /// regardless of the `Fixtures/yaml/` source path, so look up by leaf
+    /// name.
+    private static func loadFixture(_ name: String) throws -> Data {
+        let bundle = Bundle(for: FixtureAnchor.self)
+        let url = try #require(
+            bundle.url(forResource: name, withExtension: "yaml"),
+            "fixture \(name).yaml not found in test bundle",
+        )
+        return try Data(contentsOf: url)
+    }
+
+    /// Class-bound anchor so `Bundle(for:)` resolves to the test bundle.
+    private final class FixtureAnchor {}
+}

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -5,13 +5,15 @@
 #import "MWSharedStore.h"
 #import "MWDarwinBridge.h"
 #import "MWDiagnosticsRunner.h"
+#import "mihomo_core.h"
 #import <os/log.h>
 #import <mach/mach.h>
 @import Network;
 
-static const uint8_t kDiagTagCanned = 0x01;
-static const uint8_t kDiagTagUser   = 0x02;
-static const uint8_t kDiagTagMemory = 0x03;
+static const uint8_t kDiagTagCanned     = 0x01;
+static const uint8_t kDiagTagUser       = 0x02;
+static const uint8_t kDiagTagMemory     = 0x03;
+static const uint8_t kProxyTagSelect    = 0x04;
 
 static os_log_t gLog;
 
@@ -148,6 +150,61 @@ static os_log_t gLog;
         if (!request) { if (completionHandler) completionHandler(nil); return; }
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
             NSDictionary *response = [MWDiagnosticsRunner runUserRequest:request];
+            NSData *data = [NSJSONSerialization dataWithJSONObject:response options:0 error:nil]
+                           ?: [NSData data];
+            if (completionHandler) completionHandler(data);
+        });
+        return;
+    }
+
+    // Proxy control (0x04 + JSON):
+    //
+    //   { "select": { "group": "🚀 …", "name": "🇭🇰 01" } }
+    //
+    // Replaces `PUT http://127.0.0.1:9090/proxies/{group}` with a direct
+    // call into the in-process selector — no loopback hop, no URL
+    // percent-encoding step that breaks emoji / CJK / space-bearing
+    // group names.
+    if (messageData.length >= 2 &&
+        ((const uint8_t *)messageData.bytes)[0] == kProxyTagSelect) {
+        NSData *body = [messageData subdataWithRange:NSMakeRange(1, messageData.length - 1)];
+        NSDictionary *request = [NSJSONSerialization JSONObjectWithData:body options:0 error:nil];
+        if (![request isKindOfClass:[NSDictionary class]]) {
+            if (completionHandler) completionHandler(nil);
+            return;
+        }
+        NSDictionary *select = request[@"select"];
+        if (![select isKindOfClass:[NSDictionary class]]) {
+            if (completionHandler) completionHandler(nil);
+            return;
+        }
+        NSString *group = select[@"group"];
+        NSString *name  = select[@"name"];
+        if (![group isKindOfClass:[NSString class]] ||
+            ![name  isKindOfClass:[NSString class]]) {
+            if (completionHandler) completionHandler(nil);
+            return;
+        }
+        // The FFI is non-blocking (a parking_lot RwLock write inside
+        // SelectorGroup) but we still hop off the main queue so the
+        // tag-dispatch path stays uniform with the diagnostics handlers.
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            int32_t code = (int32_t)meow_proxy_select(
+                [group UTF8String], [name UTF8String]);
+            NSMutableDictionary *response = [NSMutableDictionary dictionary];
+            response[@"success"] = @(code == 0);
+            response[@"code"]    = @(code);
+            if (code != 0) {
+                const char *err = meow_core_last_error();
+                if (err && *err) {
+                    response[@"errorReason"] = [NSString stringWithUTF8String:err];
+                }
+                os_log_error(gLog, "proxy_select(%{public}@, %{public}@) → %d",
+                             group, name, code);
+            } else {
+                os_log_info(gLog, "proxy_select(%{public}@, %{public}@) → ok",
+                            group, name);
+            }
             NSData *data = [NSJSONSerialization dataWithJSONObject:response options:0 error:nil]
                            ?: [NSData data];
             if (completionHandler) completionHandler(data);

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -192,7 +192,12 @@ static os_log_t gLog;
             int32_t code = (int32_t)meow_proxy_select(
                 [group UTF8String], [name UTF8String]);
             NSMutableDictionary *response = [NSMutableDictionary dictionary];
-            response[@"success"] = @(code == 0);
+            // `@(code == 0)` boxes the comparison result as a plain
+            // NSNumber (int 0/1), which NSJSONSerialization emits as `1`
+            // — and Swift's auto-Codable Bool decoder rejects integers,
+            // so the IPC response fails to decode app-side. `@YES`/`@NO`
+            // box as __NSCFBoolean, which serializes as `true`/`false`.
+            response[@"success"] = (code == 0) ? @YES : @NO;
             response[@"code"]    = @(code);
             if (code != 0) {
                 const char *err = meow_core_last_error();

--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -1616,8 +1616,8 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 dependencies = [
  "arc-swap",
  "axum",
@@ -1649,8 +1649,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1670,8 +1670,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1700,8 +1700,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1761,8 +1761,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1797,8 +1797,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1814,8 +1814,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 dependencies = [
  "async-trait",
  "base64",
@@ -1838,13 +1838,13 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.6.1"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.1#272c27d9b51f616a860ae98e1cf9fb88870bb58e"
+version = "0.6.2"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
 dependencies = [
  "async-trait",
  "bytes",

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -73,12 +73,12 @@ iprange = "0.6"
 # Embedded mihomo-rust engine. Pinned to a release tag; bump deliberately
 # rather than tracking main. Each crate is a workspace member of
 # madeye/mihomo-rust.
-mihomo-common = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.1" }
-mihomo-config = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.1" }
-mihomo-dns = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.1" }
-mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.1" }
-mihomo-api = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.1" }
-mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.1" }
+mihomo-common = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
+mihomo-config = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
+mihomo-dns = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
+mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
+mihomo-api = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
+mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
 
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -369,6 +369,64 @@ pub unsafe extern "C" fn meow_engine_test_dns(
     }
 }
 
+/// Select a member proxy inside a `type: select` group, in-process —
+/// the same mutation that `PUT /proxies/{group}` performs against the
+/// REST API, but without the loopback hop. `group` and `name` are
+/// matched against the upstream `SelectorGroup` byte-for-byte: no
+/// Unicode normalization, no percent-decoding, no whitespace folding.
+/// Emoji + CJK + space names therefore round-trip verbatim from YAML
+/// to selector lookup, eliminating a class of bugs the URL-encoded
+/// path is sensitive to.
+///
+/// Return codes:
+/// * `0`  — selection applied.
+/// * `-1` — argument is null or not valid UTF-8.
+/// * `-2` — engine is not running.
+/// * `-3` — group not found, or the named proxy is not a select group.
+/// * `-4` — `name` is not a member of the selector.
+///
+/// On non-zero returns, `meow_core_last_error` carries a sanitized
+/// reason suitable for surfacing in the UI.
+///
+/// # Safety
+/// `group` and `name` must each be a NUL-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn meow_proxy_select(
+    group: *const c_char,
+    name: *const c_char,
+) -> c_int {
+    let Some(group_name) = cstr_to_str(group) else {
+        set_error("group is null or not utf-8".into());
+        return -1;
+    };
+    let Some(target) = cstr_to_str(name) else {
+        set_error("name is null or not utf-8".into());
+        return -1;
+    };
+    let Some(tunnel) = engine::tunnel() else {
+        set_error("engine not running".into());
+        return -2;
+    };
+    let proxies = tunnel.proxies();
+    let Some(proxy) = proxies.get(group_name) else {
+        set_error(format!("proxy group not found: {group_name}"));
+        return -3;
+    };
+    let Some(selector) = proxy
+        .as_any()
+        .and_then(|a| a.downcast_ref::<mihomo_proxy::SelectorGroup>())
+    else {
+        set_error(format!("'{group_name}' is not a select-type group"));
+        return -3;
+    };
+    if selector.select(target) {
+        0
+    } else {
+        set_error(format!("'{target}' is not a member of '{group_name}'"));
+        -4
+    }
+}
+
 /// Configure the trusted plain-TCP DNS upstream pool from the iOS Settings
 /// view. `csv` is a comma-/whitespace-separated list of `host` or
 /// `host:port` entries (port defaults to 53); empty / NULL / parse-failed

--- a/project.yml
+++ b/project.yml
@@ -133,6 +133,7 @@ targets:
         product: MeowModels
       - package: MeowShared
         product: MeowIPC
+      - package: Yams
     settings:
       base:
         BUNDLE_LOADER: $(TEST_HOST)


### PR DESCRIPTION
## What

Replaces the loopback-HTTP `PUT http://127.0.0.1:9090/proxies/{group}` call that the app uses for the "select node" picker with a direct `NETunnelProviderSession.sendProviderMessage` round-trip. The PacketTunnel extension answers it by calling a new `meow_proxy_select` FFI directly against mihomo-rust's `SelectorGroup` in-process.

## Why

The HTTP path was passing emoji + CJK + space-bearing group names (`🚀 节点选择`, `🇭🇰 香港 01`) through `addingPercentEncoding(.urlPathAllowed)`, then having mihomo-rust's axum router percent-decode them. Any normalization mismatch in that chain silently broke the picker — it'd return non-2xx and the app would surface a generic "select failed". Verified on-device: the in-process path resolves the same names cleanly and the selection now applies first-tap.

Side benefits:

- Eliminates the only privileged mutation that needed mihomo's `external-controller` exposed on `127.0.0.1:9090` for non-streaming traffic.
- Drops the `apiSecret` as the sole guard between any on-device process and proxy mutation.
- Lower latency, no URL encoding, no JSON HTTP round-trip in the hot path.

## What's in this PR

1. **Rust FFI** — `meow_proxy_select(group, name) -> c_int` in `core/rust/mihomo-ios-ffi/src/lib.rs`, mirroring the existing `meow_engine_test_proxy_http` pattern (cstr unwrap → `engine::tunnel()` gate → `SelectorGroup::select`). Return codes: `0` ok / `-1` arg / `-2` engine not running / `-3` group missing or not a select group / `-4` name not in selector. `meow_core_last_error` carries a sanitized reason.
2. **IPC envelope** — `MeowShared/Sources/MeowIPC/ProxyControlIPC.swift`, tag `0x04`, JSON body, matching the existing `DiagnosticsIPC` (0x01–0x03) tag-dispatch convention.
3. **Extension dispatcher** — new `kProxyTagSelect` branch in `PacketTunnelProvider.m` that calls the FFI on a background queue and serializes the response.
4. **App side** — `MihomoAPI.selectProxy` prefers IPC when a provider session is reachable; falls back to the existing HTTP PUT otherwise. `MihomoIPCDisabled = YES` in UserDefaults forces HTTP for debugging.
5. **mihomo-rust v0.6.2 bump** — refreshes the engine pin from v0.6.1 → v0.6.2 across all 6 direct deps (`mihomo-{common,config,dns,tunnel,api,proxy}`) plus 3 transitive workspace members.
6. **Picker UX** — `ProxyGroupsView.select(...)` now appends the underlying error reason to the localized "select failed" string, so the device UI is self-debuggable. (This is how the BOOL-boxing bug below was caught.)
7. **JSON-bool boxing fix** — `@(code == 0)` boxes as a plain int NSNumber; NSJSONSerialization emits `1`/`0`; Swift's auto-Codable `Bool` rejects integers; the IPC reply failed to decode even though the FFI succeeded. Fixed with explicit `@YES`/`@NO`. (On-device verification surfaced this — the FFI was applying the selection while the UI showed "select failed".)
8. **Real-world fixture + test** — `MeowTests/Fixtures/yaml/clash_emoji_groups_realworld.yaml` (sanitized) + `EmojiGroupSelectNodeTests`. Covers Yams round-trip and selector-child-resolves invariants for emoji-named groups.

Streaming endpoints (logs / connections / traffic WebSockets) intentionally stay on HTTP — `sendProviderMessage` is single-shot request/response and the streaming surface isn't latency-sensitive enough to justify a callback FFI.

## Verification (Path B attestation)

This is a Code PR (touches Swift, Rust, project.yml, ObjC). All four checks below were run locally on this branch's tip before push; this is not a workflow-touching change so Path B applies.

- [x] `swiftformat --lint .` → 0 violations (`SwiftFormat completed in 0.24s. 0/80 files require formatting, 19 files skipped.`)
- [x] `swiftlint --strict` → 0 violations (clean exit)
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` → **107/107 pass** (incl. the new `EmojiGroupSelectNodeTests` fixture and `MihomoAPITests` confirming HTTP fallback still works)
- [x] `xcodebuild test ... -only-testing:MeowIntegrationTests` → **26/26 pass**
- [x] `scripts/build-rust.sh` → both `aarch64-apple-ios` + `aarch64-apple-ios-sim` slices compile against v0.6.2 with no API churn in the surfaces this PR uses (`Tunnel::proxies()`, `mihomo_proxy::SelectorGroup::select`)
- [x] `git diff origin/main...HEAD --stat` reviewed — file list matches PR scope, no accidental additions
- [x] On-device verification on a paired iPhone 17 Pro — emoji-named selector group applies first-tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)