### PR TITLE
docs: load landing-page video from media.githubusercontent.com

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
     />
     <meta property="og:url" content="https://madeye.github.io/meow-ios/" />
     <meta property="og:type" content="website" />
-    <meta property="og:video" content="https://madeye.github.io/meow-ios/meow-intro.mp4" />
+    <meta property="og:video" content="https://media.githubusercontent.com/media/madeye/meow-ios/main/docs/meow-intro.mp4" />
     <meta property="og:video:type" content="video/mp4" />
     <meta property="og:video:width" content="1920" />
     <meta property="og:video:height" content="1080" />
@@ -445,9 +445,12 @@
             width="1920"
             height="1080"
           >
-            <source src="meow-intro.mp4" type="video/mp4" />
+            <source
+              src="https://media.githubusercontent.com/media/madeye/meow-ios/main/docs/meow-intro.mp4"
+              type="video/mp4"
+            />
             Your browser does not support embedded video. Watch on
-            <a href="meow-intro.mp4">meow-intro.mp4</a>.
+            <a href="https://media.githubusercontent.com/media/madeye/meow-ios/main/docs/meow-intro.mp4">meow-intro.mp4</a>.
           </video>
         </div>
 


### PR DESCRIPTION
GitHub Pages does not serve Git LFS objects — it returns the LFS pointer
text instead of the binary, so the <video> element on
madeye.github.io/meow-ios/ failed to play meow-intro.mp4. Point the video
<source> and og:video URL at media.githubusercontent.com/media/...,
which does serve the actual LFS-backed binary for public repos.