### PR TITLE
refactor(app): cleanup pass — drop orphan prefs, gate DIAGNOSTIC logs, docs alignment, profile expiry guard

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -120,9 +120,6 @@
 "settings.logLevel.warning" = "Warning";
 "settings.logLevel.error" = "Error";
 "settings.logLevel.silent" = "Silent";
-"settings.section.dns" = "DNS";
-"settings.field.dnsServers" = "DNS Servers";
-"settings.footer.dnsServers" = "Comma-separated plain-TCP DNS servers (host or host:port). Leave empty to use 1.1.1.1 and 8.8.8.8. Routed through the active proxy.";
 "settings.section.diagnostics" = "Diagnostics";
 "settings.label.diagnostics" = "Diagnostics";
 "settings.section.about" = "About";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -124,9 +124,6 @@
 "settings.logLevel.warning" = "Warning";
 "settings.logLevel.error" = "Error";
 "settings.logLevel.silent" = "Silent";
-"settings.section.dns" = "DNS";
-"settings.field.dnsServers" = "DNS 服务器";
-"settings.footer.dnsServers" = "逗号分隔的纯 TCP DNS 服务器（host 或 host:port）。留空使用 1.1.1.1 和 8.8.8.8。流量经活动代理转发。";
 "settings.section.diagnostics" = "Diagnostics";
 "settings.label.diagnostics" = "Diagnostics";
 "settings.section.about" = "About";

--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -37,7 +37,6 @@ final class AppModel {
         AppGroup.containerURL.path.withCString { meow_core_set_home_dir($0) }
 
         let defaults = AppGroup.defaults
-        let prefs = Preferences.load(from: defaults)
         vpnManager = VpnManager()
         mihomoAPI = MihomoAPI(port: 9090, secret: defaults.string(forKey: PreferenceKey.apiSecret) ?? "")
         subscriptionService = SubscriptionService(
@@ -47,7 +46,6 @@ final class AppModel {
         dailyTrafficAccumulator = DailyTrafficAccumulator(
             modelContext: AppModelContainer.shared.container.mainContext,
         )
-        _ = prefs
     }
 
     func bootstrap() async {

--- a/App/Sources/Services/AppIPCBridge.swift
+++ b/App/Sources/Services/AppIPCBridge.swift
@@ -2,6 +2,7 @@ import Foundation
 import MeowIPC
 import MeowModels
 import Observation
+import os
 
 /// App-side IPC: posts tunnel intents to the extension and observes the state
 /// and traffic snapshots the extension writes to the shared container.
@@ -10,6 +11,8 @@ import Observation
 final class AppIPCBridge {
     private(set) var currentState: VpnState = .init()
     private(set) var currentTraffic: TrafficSnapshot = .init()
+
+    private static let log = Logger(subsystem: "io.github.madeye.meow", category: "ipc-bridge")
 
     private var stateObserver: DarwinObserver?
     private var trafficObserver: DarwinObserver?
@@ -45,7 +48,7 @@ final class AppIPCBridge {
             // Queue failures are local-only (JSON encoding, disk write); log
             // via OSLog in a real build. The observable-state layer is the
             // user-visible surface, so we don't need to elevate here.
-            NSLog("IPCBridge: failed to queue intent: %@", String(describing: error))
+            Self.log.error("failed to queue intent: \(String(describing: error), privacy: .public)")
         }
     }
 

--- a/App/Sources/Services/AssetSeeder.swift
+++ b/App/Sources/Services/AssetSeeder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MeowModels
+import os
 
 /// Seeds the bundled `Country.mmdb` into the App Group container so
 /// `mihomo-config::default_geoip_path()` resolves (via `XDG_CONFIG_HOME`) to
@@ -7,9 +8,11 @@ import MeowModels
 /// it skips if the destination already matches the bundled size, and
 /// overwrites on a mismatch so a refreshed bundle beats a stale seeded copy.
 enum AssetSeeder {
+    private static let log = Logger(subsystem: "io.github.madeye.meow", category: "asset-seeder")
+
     static func seedIfNeeded() async {
         guard let src = Bundle.main.url(forResource: "Country", withExtension: "mmdb") else {
-            NSLog("AssetSeeder: Country.mmdb missing from app bundle — GEOIP lookups will fall back to geox-url")
+            log.error("Country.mmdb missing from app bundle — GEOIP lookups will fall back to geox-url")
             return
         }
         let dst = AppGroup.countryMmdbURL
@@ -25,7 +28,7 @@ enum AssetSeeder {
             }
             try FileManager.default.copyItem(at: src, to: dst)
         } catch {
-            NSLog("AssetSeeder: failed to seed Country.mmdb: %@", String(describing: error))
+            log.error("failed to seed Country.mmdb: \(String(describing: error), privacy: .public)")
         }
     }
 

--- a/App/Sources/Services/MihomoAPI.swift
+++ b/App/Sources/Services/MihomoAPI.swift
@@ -16,6 +16,25 @@ final class MihomoAPI: @unchecked Sendable {
     // Mirrors the ingress-instrumentation pattern kept around #54.
     private let log = Logger(subsystem: "io.github.madeye.meow.app", category: "mihomo-api")
 
+    private enum URLBuildError: Error {
+        case invalidComponents(endpoint: URL)
+    }
+
+    private static func buildTestDelayURL(base: URL, proxy: String, url: String, timeout: Int) throws -> URL {
+        let endpoint = base.appending(path: "/proxies/\(proxy.urlEscaped)/delay")
+        guard var comps = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+            throw URLBuildError.invalidComponents(endpoint: endpoint)
+        }
+        comps.queryItems = [
+            .init(name: "url", value: url),
+            .init(name: "timeout", value: String(timeout)),
+        ]
+        guard let target = comps.url else {
+            throw URLBuildError.invalidComponents(endpoint: endpoint)
+        }
+        return target
+    }
+
     init(
         port: Int = 9090,
         secret: String = "",
@@ -67,7 +86,9 @@ final class MihomoAPI: @unchecked Sendable {
         name: String,
     ) async throws {
         let payload = try ProxyControlIPC.encodeRequest(.select(group: group, name: name))
-        log.info("IPC proxy_select group=\(group, privacy: .public) name=\(name, privacy: .public)")
+        #if DEBUG
+            log.info("IPC proxy_select group=\(group, privacy: .public) name=\(name, privacy: .public)")
+        #endif
         let response: ProxyControlResponse = try await withCheckedThrowingContinuation { cont in
             do {
                 try session.sendProviderMessage(payload) { data in
@@ -113,15 +134,11 @@ final class MihomoAPI: @unchecked Sendable {
 
     func testDelay(proxy: String, url: String, timeout: Int = 5000) async throws -> Int {
         struct Resp: Decodable { let delay: Int? }
-        let endpoint = baseURL.appending(path: "/proxies/\(proxy.urlEscaped)/delay")
-        var comps = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)!
-        comps.queryItems = [
-            .init(name: "url", value: url),
-            .init(name: "timeout", value: String(timeout)),
-        ]
-        let target = comps.url!
-        // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
-        log.info("HTTP GET \(target.absoluteString, privacy: .public)")
+        let target = try Self.buildTestDelayURL(base: baseURL, proxy: proxy, url: url, timeout: timeout)
+        #if DEBUG
+            // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
+            log.info("HTTP GET \(target.absoluteString, privacy: .public)")
+        #endif
         let (data, resp) = try await session.data(for: request(for: target))
         logResponse(resp, body: data, url: target)
         return try (JSONDecoder().decode(Resp.self, from: data).delay) ?? -1
@@ -152,23 +169,13 @@ final class MihomoAPI: @unchecked Sendable {
     /// 204 on success; fresh delays are surfaced on the next `getProviders()`.
     func healthCheckProvider(name: String) async throws {
         let url = baseURL.appending(path: "/providers/proxies/\(name.urlEscaped)/healthcheck")
-        // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
-        log.info("HTTP GET \(url.absoluteString, privacy: .public)")
+        #if DEBUG
+            // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
+            log.info("HTTP GET \(url.absoluteString, privacy: .public)")
+        #endif
         let (data, resp) = try await session.data(for: request(for: url))
         logResponse(resp, body: data, url: url)
         try throwIfHTTPError(resp)
-    }
-
-    func getMemory() async throws -> MemoryResponse {
-        try await get("/memory")
-    }
-
-    func getConfigs() async throws -> ConfigsResponse {
-        try await get("/configs")
-    }
-
-    func patchConfigs(_ patch: ConfigsPatch) async throws {
-        try await patchJSON("/configs", body: patch)
     }
 
     /// Stream mihomo logs via WebSocket. Caller owns the AsyncStream — it
@@ -184,16 +191,20 @@ final class MihomoAPI: @unchecked Sendable {
                 if !secret.isEmpty {
                     req.setValue("Bearer \(secret)", forHTTPHeaderField: "Authorization")
                 }
-                // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
-                log.info("WS upgrade \(url.absoluteString, privacy: .public)")
+                #if DEBUG
+                    // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
+                    log.info("WS upgrade \(url.absoluteString, privacy: .public)")
+                #endif
                 let ws = session.webSocketTask(with: req)
                 ws.resume()
                 do {
                     while !Task.isCancelled {
                         let msg = try await ws.receive()
                         if case let .string(s) = msg {
-                            // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
-                            log.info("WS frame /logs: \(s.prefix(200), privacy: .public)")
+                            #if DEBUG
+                                // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
+                                log.info("WS frame /logs: \(s.prefix(200), privacy: .public)")
+                            #endif
                             if let entry = LogEntry.from(jsonString: s) {
                                 continuation.yield(entry)
                             }
@@ -215,8 +226,10 @@ final class MihomoAPI: @unchecked Sendable {
 
     private func get<T: Decodable>(_ path: String) async throws -> T {
         let url = baseURL.appending(path: path)
-        // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
-        log.info("HTTP GET \(url.absoluteString, privacy: .public)")
+        #if DEBUG
+            // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
+            log.info("HTTP GET \(url.absoluteString, privacy: .public)")
+        #endif
         let (data, resp) = try await session.data(for: request(for: url))
         logResponse(resp, body: data, url: url)
         try throwIfHTTPError(resp)
@@ -232,7 +245,9 @@ final class MihomoAPI: @unchecked Sendable {
         // currently safe (proxy-name selections), but the policy is no bodies
         // because it'd leak any future credential-bearing payload.
         req.httpBody = try JSONSerialization.data(withJSONObject: body)
-        log.info("HTTP PUT \(url.absoluteString, privacy: .public)")
+        #if DEBUG
+            log.info("HTTP PUT \(url.absoluteString, privacy: .public)")
+        #endif
         let (data, resp) = try await session.data(for: req)
         logResponse(resp, body: data, url: url)
         try throwIfHTTPError(resp)
@@ -242,19 +257,9 @@ final class MihomoAPI: @unchecked Sendable {
         let url = baseURL.appending(path: path)
         var req = request(for: url)
         req.httpMethod = "DELETE"
-        log.info("HTTP DELETE \(url.absoluteString, privacy: .public)")
-        let (data, resp) = try await session.data(for: req)
-        logResponse(resp, body: data, url: url)
-        try throwIfHTTPError(resp)
-    }
-
-    private func patchJSON(_ path: String, body: some Encodable) async throws {
-        let url = baseURL.appending(path: path)
-        var req = request(for: url)
-        req.httpMethod = "PATCH"
-        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try JSONEncoder().encode(body)
-        log.info("HTTP PATCH \(url.absoluteString, privacy: .public)")
+        #if DEBUG
+            log.info("HTTP DELETE \(url.absoluteString, privacy: .public)")
+        #endif
         let (data, resp) = try await session.data(for: req)
         logResponse(resp, body: data, url: url)
         try throwIfHTTPError(resp)
@@ -262,9 +267,15 @@ final class MihomoAPI: @unchecked Sendable {
 
     /// DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
     private func logResponse(_ response: URLResponse, body: Data, url: URL) {
-        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
-        let preview = String(data: body.prefix(200), encoding: .utf8) ?? "<non-utf8 \(body.count) bytes>"
-        log.info("HTTP \(status, privacy: .public) from \(url.path, privacy: .public): \(preview, privacy: .public)")
+        #if DEBUG
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let preview = String(data: body.prefix(200), encoding: .utf8) ?? "<non-utf8 \(body.count) bytes>"
+            log.info(
+                "HTTP \(status, privacy: .public) from \(url.path, privacy: .public): \(preview, privacy: .public)",
+            )
+        #else
+            _ = (response, body, url)
+        #endif
     }
 
     private func request(for url: URL) -> URLRequest {

--- a/App/Sources/Services/MihomoAPITypes.swift
+++ b/App/Sources/Services/MihomoAPITypes.swift
@@ -83,25 +83,6 @@ struct ProvidersResponse: Decodable {
     let providers: [String: Provider]
 }
 
-struct MemoryResponse: Decodable {
-    let inuse: Int64
-    let oslimit: Int64?
-}
-
-struct ConfigsResponse: Decodable {
-    let mode: String
-    let logLevel: String
-    let allowLan: Bool
-    let ipv6: Bool
-}
-
-struct ConfigsPatch: Encodable {
-    var mode: String?
-    var logLevel: String?
-    var allowLan: Bool?
-    var ipv6: Bool?
-}
-
 struct LogEntry: Decodable {
     let type: String
     let payload: String

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -28,21 +28,6 @@ struct SettingsView: View {
                 }
                 .accessibilityIdentifier("settings.picker.logLevel")
             }
-            Section {
-                TextField(
-                    "settings.field.dnsServers",
-                    text: binding(\.dnsServers),
-                    prompt: Text("1.1.1.1, 8.8.8.8"),
-                )
-                .keyboardType(.URL)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled(true)
-                .accessibilityIdentifier("settings.field.dnsServers")
-            } header: {
-                Text("settings.section.dns")
-            } footer: {
-                Text("settings.footer.dnsServers")
-            }
             Section("settings.section.diagnostics") {
                 NavigationLink {
                     UserDiagnosticsView()
@@ -87,7 +72,6 @@ struct SettingsView: View {
             .onChange(of: preferences.allowLan) { _, _ in persist() }
             .onChange(of: preferences.ipv6) { _, _ in persist() }
             .onChange(of: preferences.logLevel) { _, _ in persist() }
-            .onChange(of: preferences.dnsServers) { _, _ in persist() }
             .task { await pollMemory() }
     }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 To save GitHub Actions minutes and keep the red-main failure mode from coming back, always run lint and the full relevant test suite locally before pushing to the remote.
 
 - Before `git push` on any Swift / Rust / YAML change, run the local equivalents of the CI jobs your diff touches:
-  - **Swift:** `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17'` against the relevant test bundles (`MeowTests`, `MeowUITests`, `MeowIntegrationTests`).
+  - **Swift:** `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 16 Pro'` against the relevant test bundles (`MeowTests`, `MeowUITests`, `MeowIntegrationTests`).
   - **Rust:** `scripts/build-rust.sh`, plus `cargo test` in `core/rust/mihomo-ios-ffi/` where relevant.
   - **Swift lint:** `swiftlint` **and** `swiftformat --lint .` at the repo root. CI's `lint` job runs both and fails if either does — passing one is not sufficient. The two tools have non-overlapping rule sets: swiftlint catches style/API-usage issues, swiftformat catches formatting/structural ones (`redundantSelf`, spacing, ordering, etc.). Install via `brew install swiftlint swiftformat` if missing.
 - If a local run fails, fix it before pushing. Do not push "to see what CI says."
@@ -30,8 +30,8 @@ If a PR's diff touches only non-code paths, bypass CI regardless of local test s
 If a PR's diff touches code paths (Swift, Rust, project.yml, Podfile, etc.), bypass is permitted **only** when ALL of the following are true and the PR description explicitly attests to each:
 
 1. `swiftformat --lint .` ran locally at the repo root → 0 violations.
-2. `swiftlint` ran locally at the repo root → 0 violations.
-3. The `xcodebuild test` suites matching the diff ran locally on an iOS 26 simulator (e.g., iPhone 17) → all green. For Swift changes: at minimum `MeowTests`; add `MeowUITests` for UI diffs, `MeowIntegrationTests` for service-layer diffs. For Rust / FFI changes: add `scripts/build-rust.sh` + `cargo test` in `core/rust/mihomo-ios-ffi/`.
+2. `swiftlint --strict` ran locally at the repo root → 0 violations.
+3. The `xcodebuild test` suites matching the diff ran locally on an iOS 26 simulator (e.g., iPhone 16 Pro) → all green. For Swift changes: at minimum `MeowTests`; add `MeowUITests` for UI diffs, `MeowIntegrationTests` for service-layer diffs. For Rust / FFI changes: add `scripts/build-rust.sh` + `cargo test` in `core/rust/mihomo-ios-ffi/`.
 4. `git diff origin/main...HEAD --stat` was verified — the file list matches what the PR intends to change and contains no accidental additions. (The PR #28 admin-with-code lesson: bypassing without checking the diff base is how unintended code ends up in a skip-CI merge.)
 5. PR description includes a checklist attesting to (1)-(4), with the concrete command lines that were run.
 

--- a/MeowIntegrationTests/ProtocolFixtures/UDPProtocolTests.swift
+++ b/MeowIntegrationTests/ProtocolFixtures/UDPProtocolTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import XCTest
 
 /// End-to-end assertions for the three UDP-backed protocols in the
 /// §6.3 protocol matrix: WireGuard, Hysteria2, TUIC. Each one exercises
@@ -111,5 +112,8 @@ private enum FixtureAssertion {
 }
 
 private func drive(proxy _: String, assertion _: FixtureAssertion) throws {
-    Issue.record("drive(proxy:assertion:) not implemented — test should be skipped via .disabled until T2.9")
+    XCTFail(
+        "drive() must not run while UDP protocol stack is disabled — "
+            + "remove .disabled() and replace this stub when re-enabling",
+    )
 }

--- a/MeowShared/Sources/MeowModels/Preferences.swift
+++ b/MeowShared/Sources/MeowModels/Preferences.swift
@@ -1,15 +1,13 @@
 import Foundation
 
+// keep in sync with PacketTunnel/Sources/MWPreferences.h MWPrefKey* constants
+
 /// Keys used for preferences shared via the App Group UserDefaults suite.
 public enum PreferenceKey {
     public static let mixedPort = "com.meow.mixedPort"
-    public static let localDnsPort = "com.meow.localDnsPort"
-    public static let dnsServers = "com.meow.dnsServers"
     public static let logLevel = "com.meow.logLevel"
     public static let allowLan = "com.meow.allowLan"
     public static let ipv6 = "com.meow.ipv6"
-    public static let perAppMode = "com.meow.perAppMode"
-    public static let perAppPackages = "com.meow.perAppPackages"
     public static let pendingIntent = "com.meow.pendingIntent"
     public static let selectedProfileID = "com.meow.selectedProfileID"
     public static let apiSecret = "com.meow.apiSecret"
@@ -17,35 +15,24 @@ public enum PreferenceKey {
 
 public enum PreferenceDefaults {
     public static let mixedPort: Int = 7890
-    public static let localDnsPort: Int = 1053
-    /// Comma-separated list of plain-TCP DNS upstreams. Empty → the Rust
-    /// engine falls back to its built-in defaults (1.1.1.1 / 8.8.8.8).
-    public static let dnsServers: String = ""
     public static let logLevel: String = "info"
     public static let allowLan: Bool = false
     public static let ipv6: Bool = false
-    public static let perAppMode: String = "proxy"
 }
 
 public struct Preferences: Sendable {
     public var mixedPort: Int
-    public var localDnsPort: Int
-    public var dnsServers: String
     public var logLevel: String
     public var allowLan: Bool
     public var ipv6: Bool
 
     public init(
         mixedPort: Int = PreferenceDefaults.mixedPort,
-        localDnsPort: Int = PreferenceDefaults.localDnsPort,
-        dnsServers: String = PreferenceDefaults.dnsServers,
         logLevel: String = PreferenceDefaults.logLevel,
         allowLan: Bool = PreferenceDefaults.allowLan,
         ipv6: Bool = PreferenceDefaults.ipv6,
     ) {
         self.mixedPort = mixedPort
-        self.localDnsPort = localDnsPort
-        self.dnsServers = dnsServers
         self.logLevel = logLevel
         self.allowLan = allowLan
         self.ipv6 = ipv6
@@ -56,10 +43,6 @@ public struct Preferences: Sendable {
         if defaults.object(forKey: PreferenceKey.mixedPort) != nil {
             prefs.mixedPort = defaults.integer(forKey: PreferenceKey.mixedPort)
         }
-        if defaults.object(forKey: PreferenceKey.localDnsPort) != nil {
-            prefs.localDnsPort = defaults.integer(forKey: PreferenceKey.localDnsPort)
-        }
-        prefs.dnsServers = defaults.string(forKey: PreferenceKey.dnsServers) ?? PreferenceDefaults.dnsServers
         prefs.logLevel = defaults.string(forKey: PreferenceKey.logLevel) ?? PreferenceDefaults.logLevel
         if defaults.object(forKey: PreferenceKey.allowLan) != nil {
             prefs.allowLan = defaults.bool(forKey: PreferenceKey.allowLan)
@@ -72,8 +55,6 @@ public struct Preferences: Sendable {
 
     public func save(to defaults: UserDefaults) {
         defaults.set(mixedPort, forKey: PreferenceKey.mixedPort)
-        defaults.set(localDnsPort, forKey: PreferenceKey.localDnsPort)
-        defaults.set(dnsServers, forKey: PreferenceKey.dnsServers)
         defaults.set(logLevel, forKey: PreferenceKey.logLevel)
         defaults.set(allowLan, forKey: PreferenceKey.allowLan)
         defaults.set(ipv6, forKey: PreferenceKey.ipv6)

--- a/MeowShared/Tests/MeowSharedTests/PreferencesTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/PreferencesTests.swift
@@ -20,12 +20,10 @@ struct PreferencesTests {
         defaults.removePersistentDomain(forName: "preferences-test-rt")
         var prefs = Preferences()
         prefs.mixedPort = 9999
-        prefs.dnsServers = "1.1.1.1, 8.8.8.8"
         prefs.allowLan = true
         prefs.save(to: defaults)
         let loaded = Preferences.load(from: defaults)
         #expect(loaded.mixedPort == 9999)
-        #expect(loaded.dnsServers == "1.1.1.1, 8.8.8.8")
         #expect(loaded.allowLan == true)
     }
 }

--- a/PacketTunnel/Sources/MWPreferences.h
+++ b/PacketTunnel/Sources/MWPreferences.h
@@ -1,8 +1,8 @@
 #pragma once
 #import <Foundation/Foundation.h>
 
+// keep in sync with MeowShared/Sources/MeowModels/Preferences.swift PreferenceKey.*
 extern NSString *const MWPrefKeyMixedPort;
-extern NSString *const MWPrefKeyDnsServers;
 extern NSString *const MWPrefKeyLogLevel;
 extern NSString *const MWPrefKeyAllowLan;
 extern NSString *const MWPrefKeyIpv6;
@@ -10,7 +10,6 @@ extern NSString *const MWPrefKeyPendingIntent;
 
 @interface MWPreferences : NSObject
 @property (nonatomic, assign) NSInteger mixedPort;
-@property (nonatomic, copy)   NSString *dnsServers;
 @property (nonatomic, copy)   NSString *logLevel;
 @property (nonatomic, assign) BOOL allowLan;
 @property (nonatomic, assign) BOOL ipv6;

--- a/PacketTunnel/Sources/MWPreferences.m
+++ b/PacketTunnel/Sources/MWPreferences.m
@@ -1,7 +1,6 @@
 #import "MWPreferences.h"
 
 NSString *const MWPrefKeyMixedPort     = @"com.meow.mixedPort";
-NSString *const MWPrefKeyDnsServers    = @"com.meow.dnsServers";
 NSString *const MWPrefKeyLogLevel      = @"com.meow.logLevel";
 NSString *const MWPrefKeyAllowLan      = @"com.meow.allowLan";
 NSString *const MWPrefKeyIpv6          = @"com.meow.ipv6";
@@ -13,7 +12,6 @@ NSString *const MWPrefKeyPendingIntent = @"com.meow.pendingIntent";
     self = [super init];
     if (self) {
         _mixedPort  = 7890;
-        _dnsServers = @"";
         _logLevel   = @"info";
         _allowLan   = NO;
         _ipv6       = NO;
@@ -25,8 +23,6 @@ NSString *const MWPrefKeyPendingIntent = @"com.meow.pendingIntent";
     MWPreferences *p = [[MWPreferences alloc] init];
     if ([defaults objectForKey:MWPrefKeyMixedPort])
         p.mixedPort = [defaults integerForKey:MWPrefKeyMixedPort];
-    NSString *dns = [defaults stringForKey:MWPrefKeyDnsServers];
-    p.dnsServers = dns ?: @"";
     NSString *level = [defaults stringForKey:MWPrefKeyLogLevel];
     p.logLevel = level ?: @"info";
     if ([defaults objectForKey:MWPrefKeyAllowLan])

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -84,12 +84,6 @@ static const NSTimeInterval kRestartCooldownS = 60.0;
         return NO;
     }
 
-    // DNS upstream selection now lives entirely in the embedded mihomo
-    // engine's `dns:` block — fake-IP NAT mode means a Settings-configured
-    // resolver list at this boundary would have no effect (the synthesized
-    // A records never leave the FFI). `prefs.dnsServers` is retained as a
-    // preference for future use but no longer wired into the Rust side.
-
     MWPacketWriter *writer = [[MWPacketWriter alloc] initWithFlow:_flow];
     _writer    = writer;
     _writerCtx = (void *)CFBridgingRetain(writer);
@@ -179,7 +173,7 @@ static const NSTimeInterval kRestartCooldownS = 60.0;
 // MARK: - Traffic pump (500 ms interval)
 
 - (void)startTrafficPump {
-    os_log_error(gLog, "engine: startTrafficPump entry");
+    os_log_debug(gLog, "engine: startTrafficPump entry");
     _lastUp   = 0;
     _lastDown = 0;
     _lastTime = [[NSDate date] timeIntervalSinceReferenceDate];
@@ -206,7 +200,7 @@ static const NSTimeInterval kRestartCooldownS = 60.0;
 }
 
 - (void)emitTrafficSnapshot {
-    os_log_error(gLog, "engine: emitTrafficSnapshot tick=%d", _pumpTick);
+    os_log_debug(gLog, "engine: emitTrafficSnapshot tick=%d", _pumpTick);
     int64_t up = 0, down = 0;
     meow_engine_traffic(&up, &down);
 
@@ -238,7 +232,7 @@ static const NSTimeInterval kRestartCooldownS = 60.0;
          "up=%lldB/s down=%lldB/s totalUp=%lldB totalDown=%lldB\n",
         _pumpTick, (long)footprintMB, (long)heapUsedKB, (long)heapFreeKB, tcpConns,
         upRate, downRate, up, down];
-    os_log_error(gLog, "memstats %{public}@", memline);
+    os_log_debug(gLog, "memstats %{public}@", memline);
 
     // Also write to a file in the App Group container so the Mac can poll it
     // via `xcrun devicectl device copy from --domain-type appGroupDataContainer`.
@@ -352,9 +346,6 @@ static const NSTimeInterval kRestartCooldownS = 60.0;
         atomic_store_explicit(&_restarting, NO, memory_order_relaxed);
         return NO;
     }
-
-    // See first-start branch: DNS upstream config now lives inside the
-    // mihomo engine, not at the FFI boundary.
 
     MWPacketWriter *writer = [[MWPacketWriter alloc] initWithFlow:_flow];
     _writer    = writer;

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -10,6 +10,8 @@
 #import <mach/mach.h>
 @import Network;
 
+// keep in sync with MeowShared/Sources/MeowIPC/DiagnosticsIPC.swift and
+// MeowShared/Sources/MeowIPC/ProxyControlIPC.swift tag values
 static const uint8_t kDiagTagCanned     = 0x01;
 static const uint8_t kDiagTagUser       = 0x02;
 static const uint8_t kDiagTagMemory     = 0x03;
@@ -227,8 +229,11 @@ static os_log_t gLog;
     if ([command isEqualToString:@"stop"]) {
         [self cancelTunnelWithError:nil];
     } else if ([command isEqualToString:@"reload"]) {
-        // Full stop/start reload — M3 will add hot-reload via REST API
-        os_log_info(gLog, "reload intent received (stop/start path)");
+        // `reload` is currently a stop-only shim: the extension cancels the
+        // tunnel and the app is expected to re-trigger `start` once it
+        // observes the disconnected stage. M3 will add hot-reload via the
+        // mihomo REST API and avoid the round-trip.
+        os_log_info(gLog, "reload intent received (stop-only shim; app must restart)");
         [self cancelTunnelWithError:nil];
     }
     // "start" while running: no-op

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,96 @@
+# scripts/
+
+Build, packaging, and release-automation helpers for meow-ios. Run all
+scripts from the repo root unless noted; they re-resolve `$ROOT` from
+`$BASH_SOURCE` so absolute vs. relative `cwd` doesn't matter.
+
+## build-rust.sh
+
+Builds `core/rust/mihomo-ios-ffi` for `aarch64-apple-ios` (device) and the
+two simulator targets (`aarch64-apple-ios-sim`, `x86_64-apple-ios`), packs
+them into `MeowCore/MihomoCore.xcframework`, and regenerates the C header
+`MeowCore/include/mihomo_core.h` via cbindgen. Prerequisites: stable Rust
+toolchain with the three iOS targets installed (`rustup target add ...`)
+and `cbindgen` on `$PATH`. No env vars required.
+
+## build-release.sh
+
+Builds a Release-configuration iOS app bundle and optionally installs it
+onto a USB-connected device. Mostly used during local QA; for distribution
+prefer `build-adhoc.sh` or `upload-testflight.sh`. No required env vars,
+but reads `$DEVELOPMENT_TEAM` if you want to override the default team
+(`SK4GFF6AHN`).
+
+## build-adhoc.sh
+
+Builds a Release IPA signed with the **Ad Hoc** App Store Connect
+distribution profile (`release-testing` method) and exports it to
+`build/export-adhoc/meow-ios.ipa` for Firebase App Distribution. Calls
+`build-rust.sh` and `fetch-geo-assets.sh` first unless `--skip-rust-build`
+is passed. Warns when the bundled provisioning profiles are within 30 days
+of expiry. Env vars: `APP_PROFILE`, `PT_PROFILE` (UUIDs under
+`~/Library/MobileDevice/Provisioning Profiles/`), `DEVELOPMENT_TEAM`,
+`ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH`. Prerequisites: Xcode 16+,
+the matching profiles + Apple Distribution identity in the login keychain,
+and the App Store Connect API key on disk.
+
+## upload-testflight.sh
+
+Builds a Release IPA signed with the **App Store** distribution profile
+and uploads it to App Store Connect / TestFlight (`destination=upload`,
+`method=app-store-connect`). Warns on provisioning profile near-expiry.
+Flags: `--skip-rust-build`, `--skip-archive` (reuses
+`build/meow-ios-appstore.xcarchive`), `--skip-upload` (archive-only). Env
+vars: same as `build-adhoc.sh`, but with the App Store profile UUIDs.
+Pair with `upload-testflight-metadata.py` to push the build's "What to
+Test" notes once App Store Connect finishes processing.
+
+## upload-firebase-distribution.sh
+
+Uploads the IPA produced by `build-adhoc.sh` to Firebase App Distribution,
+reading release notes from
+`metadata/testflight/whats_new/<build>.txt` for parity with TestFlight.
+Prerequisites: `firebase` CLI on `$PATH`, a service-account JSON for the
+project, and an IPA at `build/export-adhoc/meow-ios.ipa`. Env vars:
+`GOOGLE_APPLICATION_CREDENTIALS` (path to the service account JSON);
+optionally `FIREBASE_APP_ID`, `FIREBASE_TESTER_GROUP` to override the
+defaults baked into the script.
+
+## upload-testflight-metadata.py
+
+Pushes per-locale TestFlight metadata (`betaAppLocalizations`,
+`betaBuildLocalizations`) from a fastlane-shaped `metadata/` tree via the
+App Store Connect REST API. Reads the API key from
+`~/.appstoreconnect/api_key.json` (or `$ASC_API_KEY_JSON`). Run after
+`upload-testflight.sh` once App Store Connect has finished processing the
+build. Prerequisites: Python 3.11+, `pyjwt`, `requests`.
+
+## sync-firebase-udids.py
+
+Reconciles tester UDIDs collected through Firebase App Distribution with
+the device registry in App Store Connect: reads a CSV exported from
+Firebase, fetches the current ASC device list, and registers any UDIDs not
+already present. Re-runnable; safe to invoke after every batch of new
+testers. Env: App Store Connect API key (same path as above). Inputs: a
+Firebase CSV path passed positionally.
+
+## fetch-geo-assets.sh
+
+Fetches `Country.mmdb` from `MetaCubeX/meta-rules-dat`, verifies it
+against the pinned SHA-256, and stages it under `App/Resources/` so the
+build can embed it. Pinned by commit SHA + artifact hash because upstream
+only ships a rolling `latest` tag. Re-run when bumping the pin in the
+script. No env vars; requires `curl` and `shasum`.
+
+## generate-app-icon.sh
+
+Regenerates the iOS `AppIcon.appiconset` PNGs from the upstream Android
+Play Store icon at
+`/Volumes/DATA/workspace/mihomo-android/fastlane/metadata/android/en-US/images/icon.png`.
+Idempotent; prerequisites: `sips` (ships with macOS) and that source path
+existing on the build host.
+
+## generate-xcodeproj.sh
+
+Regenerates `meow-ios.xcodeproj` from `project.yml` via `xcodegen`. Run
+whenever `project.yml` changes. Prerequisite: `brew install xcodegen`.

--- a/scripts/build-adhoc.sh
+++ b/scripts/build-adhoc.sh
@@ -6,6 +6,45 @@
 # delivery to manually-registered tester UDIDs.
 set -euo pipefail
 
+# Warn (warn-only, exit 0) if any provisioning profile UUID expires within
+# 30 days. Each argument is a UUID under
+# ~/Library/MobileDevice/Provisioning Profiles/. Missing profile files are
+# reported as a warning but do not fail the script — the xcodebuild step
+# below will surface the hard error if signing actually fails.
+check_profile_expiry() {
+    local profiles_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
+    local now_epoch
+    now_epoch=$(date +%s)
+    local threshold=$((30 * 24 * 60 * 60))
+    local uuid path exp_iso exp_epoch delta
+    for uuid in "$@"; do
+        path="$profiles_dir/$uuid.mobileprovision"
+        if [[ ! -f "$path" ]]; then
+            echo "WARNING: provisioning profile $uuid not found at $path" >&2
+            continue
+        fi
+        exp_iso=$(security cms -D -i "$path" 2>/dev/null \
+            | /usr/libexec/PlistBuddy -c "Print :ExpirationDate" /dev/stdin 2>/dev/null \
+            || true)
+        if [[ -z "$exp_iso" ]]; then
+            echo "WARNING: could not read ExpirationDate for profile $uuid" >&2
+            continue
+        fi
+        # PlistBuddy prints dates like "Mon Apr 19 12:34:56 PDT 2027".
+        exp_epoch=$(date -j -f "%a %b %d %T %Z %Y" "$exp_iso" +%s 2>/dev/null || echo "")
+        if [[ -z "$exp_epoch" ]]; then
+            echo "WARNING: could not parse ExpirationDate '$exp_iso' for $uuid" >&2
+            continue
+        fi
+        delta=$((exp_epoch - now_epoch))
+        if (( delta < threshold )); then
+            local days=$((delta / 86400))
+            echo "WARNING: provisioning profile $uuid expires in $days day(s) ($exp_iso)" >&2
+        fi
+    done
+    return 0
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -36,6 +75,8 @@ while [[ $# -gt 0 ]]; do
         *) echo "unknown arg: $1" >&2; exit 1;;
     esac
 done
+
+check_profile_expiry "$APP_PROFILE" "$PT_PROFILE"
 
 mkdir -p "$ROOT/build"
 rm -rf "$ARCHIVE_PATH" "$EXPORT_DIR"

--- a/scripts/upload-testflight.sh
+++ b/scripts/upload-testflight.sh
@@ -25,6 +25,44 @@
 
 set -euo pipefail
 
+# Warn (warn-only, exit 0) if any provisioning profile UUID expires within
+# 30 days. Each argument is a UUID under
+# ~/Library/MobileDevice/Provisioning Profiles/. Missing profile files are
+# reported as a warning but do not fail the script — the xcodebuild step
+# below will surface the hard error if signing actually fails.
+check_profile_expiry() {
+    local profiles_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
+    local now_epoch
+    now_epoch=$(date +%s)
+    local threshold=$((30 * 24 * 60 * 60))
+    local uuid path exp_iso exp_epoch delta
+    for uuid in "$@"; do
+        path="$profiles_dir/$uuid.mobileprovision"
+        if [[ ! -f "$path" ]]; then
+            echo "WARNING: provisioning profile $uuid not found at $path" >&2
+            continue
+        fi
+        exp_iso=$(security cms -D -i "$path" 2>/dev/null \
+            | /usr/libexec/PlistBuddy -c "Print :ExpirationDate" /dev/stdin 2>/dev/null \
+            || true)
+        if [[ -z "$exp_iso" ]]; then
+            echo "WARNING: could not read ExpirationDate for profile $uuid" >&2
+            continue
+        fi
+        exp_epoch=$(date -j -f "%a %b %d %T %Z %Y" "$exp_iso" +%s 2>/dev/null || echo "")
+        if [[ -z "$exp_epoch" ]]; then
+            echo "WARNING: could not parse ExpirationDate '$exp_iso' for $uuid" >&2
+            continue
+        fi
+        delta=$((exp_epoch - now_epoch))
+        if (( delta < threshold )); then
+            local days=$((delta / 86400))
+            echo "WARNING: provisioning profile $uuid expires in $days day(s) ($exp_iso)" >&2
+        fi
+    done
+    return 0
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -66,6 +104,8 @@ if [[ ! -f "$ASC_KEY_PATH" ]]; then
     echo "       Set ASC_KEY_PATH or place the .p8 at the default location." >&2
     exit 1
 fi
+
+check_profile_expiry "$APP_PROFILE" "$PT_PROFILE"
 
 mkdir -p "$ROOT/build"
 rm -rf "$EXPORT_DIR"


### PR DESCRIPTION
Slice B of the cleanup pass tracked in `.cleanup-scratch/PLAN.md`. Sister PR (Slice A) covers Rust FFI.

## Items applied

Each maps to a finding ID in `.cleanup-scratch/findings-app.md`:

- **S-1 / O-2 / D-3** — Delete `dnsServers` end-to-end (SettingsView, Preferences, MWPreferences.h/m, MWTunnelEngine.m dead comments, en/zh-Hans .strings keys, PreferencesTests).
- **S-7** — Delete dead pref keys `localDnsPort`, `perAppMode`, `perAppPackages` and their defaults / fields.
- **S-2** — Gate the DIAGNOSTIC `Logger.info` calls in `MihomoAPI.swift` behind `#if DEBUG`; error-level logs untouched.
- **S-3** — Delete dead REST surface `getMemory()` / `getConfigs()` / `patchConfigs()` plus the matching response/patch types. `patchJSON` helper drops with its only caller.
- **S-4** — Replace force-unwraps in `testDelay()` URL construction with a throwing helper.
- **S-5** — `NSLog` → `os.Logger` in `AppIPCBridge.swift` and `AssetSeeder.swift`.
- **S-6** — Remove the `_ = prefs` discard in `AppModel.init`.
- **S-9** — Downgrade traffic-pump heartbeat logs (`os_log_error` → `os_log_debug`) in `MWTunnelEngine.m`.
- **O-1 / O-4** — Add "keep in sync with…" cross-reference comments in `MWPreferences.h` and `PacketTunnelProvider.m`'s IPC tag block.
- **O-5** — Document `reload` as a stop-only shim in `handleIntent:`.
- **T-2** — `UDPProtocolTests.drive()` stub: `Issue.record(...)` → `XCTFail(...)` so a future `.disabled()` removal blows up immediately.
- **T-3 / D-1** — CLAUDE.md Path B item 3: `iPhone 17` → `iPhone 16 Pro`.
- **D-2** — CLAUDE.md Path B item 2: `swiftlint` → `swiftlint --strict`.
- **B-2** — `check_profile_expiry()` helper in `scripts/build-adhoc.sh` + `scripts/upload-testflight.sh`; warns (exit 0) when any profile UUID is within 30 days of expiry.
- **B-4** — New `scripts/README.md` documenting purpose, env vars, and prerequisites for each helper script.

No scope expansion. No version bump. The `settings.section.dns` localization key was removed along with `settings.field.dnsServers` and `settings.footer.dnsServers` — the plan text listed only the two, but the section header was orphaned by the same UI delete so dropping it was mechanically part of the same change.

## Path B attestation

- [x] `swiftformat --lint .` ran at the repo root → 0 violations.
  ```
  $ swiftformat --lint .
  Reading config file at /Volumes/DATA/workspace/meow-ios-cleanup-app/.swiftformat
  …
  SwiftFormat completed in 0.06s.
  0/80 files require formatting, 18 files skipped.
  ```
- [x] `swiftlint --strict` ran at the repo root → 0 violations.
  ```
  $ swiftlint --strict
  …
  Done linting! Found 0 violations, 0 serious in 71 files.
  ```
- [ ] **xcodebuild test suites — BLOCKED in agent sandbox.** `xcodebuild -resolvePackageDependencies` cannot fetch the Firebase binary XCFrameworks from `dl.google.com` in this environment: the shell-level `HTTP_PROXY=http://127.0.0.1:8080` is a sandbox-only interceptor that xcodebuild's NSURLSession ignores, direct `curl --max-time 5` to `dl.google.com` times out without the proxy, and no `scutil --proxy` system proxy is configured for xcodebuild to inherit. Cached `SourcePackages` directories (both `build/SourcePackages` from a previous full build and the live `~/Library/Developer/Xcode/DerivedData/meow-ios-…/SourcePackages` with the artifacts already extracted) are rejected with the same "downloadError: timed out" because the package resolver re-validates against the network before reusing artifacts. **Reviewer please run on a machine with direct internet:**
  ```
  xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios \
    -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
    -only-testing:MeowTests
  xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios \
    -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
    -only-testing:MeowIntegrationTests
  ```
  Diff is mechanical (orphan-pref removal + `#if DEBUG` gating + log-level downgrade + docs + helper scripts). The only spots that could regress at runtime are the `testDelay` throwing-URL-builder refactor (covered by `MihomoAPITests`) and the Preferences load/save changes (covered by `PreferencesTests`).
- [x] `bash -n scripts/build-adhoc.sh && bash -n scripts/upload-testflight.sh` → OK.
- [x] `git diff origin/main...HEAD --stat` verified — 19 files modified + 1 new (`scripts/README.md`); no accidental additions.

## Do not merge

Path B is a speed optimization but the test suites are part of attestation (3) — without them green, this must be merged through full remote CI, not admin-rebase. PM (orchestrator) will merge after reviewer audit and a CI pass.