### PR TITLE
chore(deps): pin mihomo-rust v0.7.0, bump app to 1.2.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.6</string>
+	<string>1.2.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026050702</string>
+	<string>2026051201</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.6</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>2026050702</string>
+	<string>2026051201</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -273,6 +273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,13 +380,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -438,6 +459,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +479,16 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -909,6 +950,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1018,32 +1060,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "hickory-proto 0.26.1",
+ "http",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "rustls",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
- "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2",
- "http",
  "idna",
  "ipnet",
  "once_cell",
  "rand 0.9.4",
  "ring",
- "rustls",
- "serde",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
- "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
  "tracing",
  "url",
 ]
@@ -1056,15 +1142,41 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
  "parking_lot",
  "rand 0.9.4",
  "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
  "rustls",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -1073,17 +1185,17 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-util",
- "hickory-proto",
+ "hickory-net",
+ "hickory-proto 0.26.1",
  "ipnet",
  "prefix-trie",
  "serde",
@@ -1436,6 +1548,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,10 +1777,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 dependencies = [
- "arc-swap",
  "axum",
  "base64",
  "dashmap 6.1.0",
@@ -1638,7 +1798,6 @@ dependencies = [
  "serde_yaml",
  "subtle",
  "sysinfo",
- "thiserror 2.0.18",
  "time",
  "tokio",
  "tower",
@@ -1649,8 +1808,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1661,23 +1820,23 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "smol_str",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]
 name = "mihomo-config"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-proto 0.26.1",
+ "hickory-resolver 0.26.1",
  "ipnet",
  "maxminddb",
  "mihomo-common",
@@ -1690,25 +1849,19 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
- "serde_json",
  "serde_yaml",
- "subtle",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "mihomo-dns"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 dependencies = [
- "anyhow",
- "async-trait",
  "dashmap 6.1.0",
  "futures",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "hickory-server",
  "ipnet",
  "lru",
@@ -1716,7 +1869,6 @@ dependencies = [
  "mihomo-common",
  "mihomo-trie",
  "parking_lot",
- "serde",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1731,7 +1883,7 @@ dependencies = [
  "cbindgen",
  "dashmap 6.1.0",
  "futures",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "libc",
  "log",
  "maxminddb",
@@ -1758,44 +1910,35 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64",
  "bytes",
- "dashmap 6.1.0",
  "futures",
- "futures-util",
  "hex",
- "http",
  "libc",
  "mihomo-common",
  "mihomo-dns",
  "mihomo-transport",
  "parking_lot",
  "rand 0.9.4",
- "regex",
- "reqwest",
  "rustls",
- "serde",
  "serde_json",
  "sha2",
  "shadowsocks",
  "socket2 0.5.10",
- "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite 0.24.0",
  "tracing",
  "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "mihomo-rules"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1803,7 +1946,6 @@ dependencies = [
  "mihomo-common",
  "mihomo-trie",
  "regex",
- "serde",
  "thiserror 2.0.18",
  "tracing",
  "zstd",
@@ -1811,8 +1953,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 dependencies = [
  "async-trait",
  "base64",
@@ -1821,7 +1963,6 @@ dependencies = [
  "h2",
  "http",
  "httparse",
- "mihomo-common",
  "rand 0.9.4",
  "rustls",
  "rustls-pemfile",
@@ -1835,16 +1976,15 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.6.2"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.6.2#144497da950e0ffe199596be50f21cc4649c1762"
+version = "0.7.0"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.0#63a193e57dab0d26d12f044ce2e7e61e43b0799b"
 dependencies = [
  "async-trait",
- "bytes",
  "dashmap 6.1.0",
  "mihomo-common",
  "mihomo-dns",
@@ -1853,8 +1993,6 @@ dependencies = [
  "mihomo-trie",
  "parking_lot",
  "serde",
- "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1900,6 +2038,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netstack-smoltcp"
@@ -2146,10 +2290,11 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
+ "either",
  "ipnet",
  "num-traits",
 ]
@@ -2316,6 +2461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2508,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2487,6 +2649,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2725,7 +2896,7 @@ dependencies = [
  "cfg-if",
  "dynosaur",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "libc",
  "log",
  "lru_time_cache",
@@ -2761,7 +2932,7 @@ dependencies = [
  "bytes",
  "camellia",
  "cfg-if",
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "ctr",
  "hkdf",
@@ -2803,6 +2974,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,6 +3000,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "smoltcp"
@@ -2937,6 +3134,27 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3453,6 +3671,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -60,12 +60,12 @@ hickory-proto = "0.25"
 # Embedded mihomo-rust engine. Pinned to a release tag; bump deliberately
 # rather than tracking main. Each crate is a workspace member of
 # madeye/mihomo-rust.
-mihomo-common = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
-mihomo-config = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
-mihomo-dns = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
-mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
-mihomo-api = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
-mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.6.2" }
+mihomo-common = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.0" }
+mihomo-config = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.0" }
+mihomo-dns = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.0" }
+mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.0" }
+mihomo-api = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.0" }
+mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.0" }
 
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -587,7 +587,7 @@ async fn dispatch_tcp_via_mihomo(
         src_port: src.port(),
         dst_ip,
         dst_port: dst.port(),
-        host,
+        host: host.into(),
         ..Default::default()
     };
 
@@ -747,7 +747,7 @@ async fn dispatch_udp(
         src_port: src.port(),
         dst_ip,
         dst_port: dst.port(),
-        host,
+        host: host.into(),
         ..Default::default()
     };
 

--- a/metadata/testflight/whats_new/2026051201.txt
+++ b/metadata/testflight/whats_new/2026051201.txt
@@ -1,0 +1,61 @@
+Build 2026051201 (1.2.0)
+
+WHAT'S NEW
+• Fake-IP DNS replaces the previous split-horizon DoH / china-DNS /
+  dns_table stack. The PacketTunnel now answers every A query with a
+  synthetic IP from a private pool (28.0.0.0/8), suppresses AAAA, and
+  routes the original hostname through the embedded mihomo resolver
+  via mihomo's own dns: configuration. TCP/UDP flows reverse the fake
+  IP back to the qname captured at allocation time, so mihomo sees
+  the real hostname (not a sniffed SNI) when matching domain rules.
+
+• Bumped mihomo-rust to v0.7.0. Brings in upstream bug fixes; the
+  shipped outbound set (Shadowsocks / Trojan / VLESS / Direct /
+  Reject + selector & url-test groups) is unchanged.
+
+• Proxy group selector is now driven via an in-process NE app-message
+  channel instead of a REST round-trip. Picking a node in the UI is
+  noticeably faster and no longer surfaces transient HTTP errors.
+
+• Internal cleanup: removed orphan "DNS servers" settings field (the
+  setting had no effect after the fake-IP migration), gated verbose
+  diagnostic HTTP logging to debug builds only, downgraded the
+  500 ms traffic-pump heartbeat from .error to .debug so crash logs
+  don't drown in routine telemetry.
+
+WHAT TO TEST
+1. DNS smoke test (the biggest change in this build):
+   - Open Safari, hit several first-load sites (e.g. github.com,
+     news.ycombinator.com, baidu.com, taobao.com). All should resolve
+     and load.
+   - Open an app with embedded webviews (WeChat moments, Twitter).
+     IPv6-preferring apps in particular — they should fall back to
+     IPv4 silently (we return empty NOERROR for AAAA).
+   - Watch the Connections tab in the meow-ios app: every flow should
+     show the hostname (e.g. "github.com:443"), not a raw 28.x.y.z IP.
+
+2. Proxy group switching: tap through several selector groups in
+   the UI. Each switch should apply in under a second; no spinning
+   spinners, no toast errors.
+
+3. Connect / disconnect cycles, subscription refresh, settings YAML
+   editor — no new crashes or UI hangs vs 2026043001.
+
+KNOWN LIMITATIONS
+• In-TUN TCP/53 traffic is intentionally dropped. iOS's stub
+  resolver only falls back to TCP/53 for very large UDP replies,
+  which fake-IP responses never produce, so this should not be
+  user-visible. If you see a "DNS failure" from a tool that hard-codes
+  TCP DNS, please report it.
+
+• Non-DNS UDP traffic is still not forwarded by the tunnel.
+  WireGuard outbounds will not pass traffic. QUIC / HTTP3 falls back
+  to TCP HTTP/2 (usually transparent).
+
+• If you previously set a custom "DNS servers" list in Settings, the
+  field is gone in this build — that input has been ignored since
+  fake-IP shipped. Configure DNS via the dns: block in your
+  subscription / config YAML instead.
+
+Please send TestFlight feedback or open an issue at:
+https://github.com/madeye/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026051201.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026051201.txt
@@ -1,0 +1,50 @@
+Build 2026051201 (1.2.0)
+
+新特性
+• 引入 Fake-IP DNS,取代此前的 DoH / china-DNS / dns_table 分流栈。
+  PacketTunnel 现在为每个 A 查询返回 28.0.0.0/8 私有段内的一个虚拟
+  IP,屏蔽 AAAA,并通过 mihomo 自带的 dns: 配置把真实域名交由内嵌
+  resolver 处理。TCP / UDP 连接在分发前会用虚拟 IP 反查出域名,因此
+  mihomo 看到的是分配时记录的真实 qname(而不是 SNI 嗅探结果),
+  域名规则匹配更可靠。
+
+• mihomo-rust 升级到 v0.7.0。包含上游修复;实际出栈协议集(Shadowsocks /
+  Trojan / VLESS / Direct / Reject 加 selector & url-test 组)未变化。
+
+• 代理组切换改走 NE 进程内 app-message,不再走 REST。UI 选节点明显
+  更快,也不再有偶发的 HTTP 报错弹窗。
+
+• 内部清理:删除了无用的"DNS 服务器"设置项(自 Fake-IP 上线后该输入
+  已不再被读取),把诊断 HTTP 日志限制在 debug 构建中,把 500 ms 流量
+  心跳日志从 .error 降到 .debug,避免淹没崩溃日志。
+
+测试要点
+1. DNS 烟雾测试(这是本次最大改动):
+   - 用 Safari 打开多个站点(如 github.com、news.ycombinator.com、
+     baidu.com、taobao.com),都应能解析和加载。
+   - 打开带内嵌 WebView 的 App(微信朋友圈、Twitter)。尤其是优先
+     IPv6 的 App —— 应能静默回退到 IPv4(我们对 AAAA 返回空
+     NOERROR)。
+   - 在 meow-ios App 的 "连接" 页观察:每条流都应该显示域名(如
+     "github.com:443"),不应是裸的 28.x.y.z 地址。
+
+2. 代理组切换:点选几个 selector 组。每次切换应在 1 秒内生效,无
+   转圈、无错误提示。
+
+3. 连接 / 断开循环、订阅刷新、设置 YAML 编辑器 —— 相比 2026043001
+   无新增崩溃或界面卡顿。
+
+已知限制
+• 隧道内 TCP/53 流量会被丢弃。iOS 自身的 stub resolver 只在 UDP 回包
+  过大时才回落到 TCP/53,而 fake-IP 应答永远不会触发该路径,因此用户
+  通常感知不到。如果某个硬编码 TCP DNS 的工具报"DNS 失败",请反馈。
+
+• 隧道仍未转发非 DNS 的 UDP 流量。WireGuard 出站不工作;QUIC /
+  HTTP3 会回落到 TCP HTTP/2(通常透明)。
+
+• 如果之前在设置里填过自定义 "DNS 服务器" 列表 —— 该输入项在本构建
+  中已被移除。自 Fake-IP 上线起该输入就已被忽略。请改在订阅 / 配置
+  YAML 的 dns: 段里指定 DNS。
+
+请通过 TestFlight 反馈或在以下地址提 issue:
+https://github.com/madeye/meow-ios/issues

--- a/project.yml
+++ b/project.yml
@@ -46,8 +46,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.1.6"
-        CFBundleVersion: "2026050701"
+        CFBundleShortVersionString: "1.2.0"
+        CFBundleVersion: "2026051201"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -110,6 +110,7 @@ targets:
       - framework: MeowCore/Frameworks/MihomoCore.xcframework
         embed: false
         optional: true
+      - sdk: SystemConfiguration.framework
     postBuildScripts:
       - name: Strip Release binary (strip -Sx)
         runOnlyWhenInstalling: false
@@ -192,8 +193,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.1.6"
-        CFBundleVersion: "2026050701"
+        CFBundleShortVersionString: "1.2.0"
+        CFBundleVersion: "2026051201"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider
@@ -222,6 +223,7 @@ targets:
       - framework: MeowCore/Frameworks/MihomoCore.xcframework
         embed: false
         optional: true
+      - sdk: SystemConfiguration.framework
     postBuildScripts:
       - name: Strip Release binary (strip -Sx)
         runOnlyWhenInstalling: false


### PR DESCRIPTION
## Summary

- Pin all six `mihomo-*` crates to **v0.7.0** (was v0.6.2).
- Bump app marketing version **1.1.6 → 1.2.0**, build **2026051201**.
- Adapt to the v0.7.0 API/dep changes (see below).

## Notes on the v0.7.0 bump

1. `Metadata.host` changed from `String` to `SmolStr` → added `.into()` at the two shorthand call sites in `core/rust/mihomo-ios-ffi/src/tun2socks.rs`.
2. hickory-resolver 0.26 (pulled in by v0.7.0) calls `SCDynamicStore*` on Apple, so `SystemConfiguration.framework` is now a hard linker requirement. Added it as an `sdk:` dep on both the **meow-ios** app and **PacketTunnel** extension targets in `project.yml`.

## Local verification

- ✅ `scripts/build-rust.sh` — clean build, both `ios-arm64` and `ios-arm64-simulator` slices
- ✅ `cd core/rust/mihomo-ios-ffi && cargo test --lib` — 38 passed
- ✅ `swiftformat --lint .` — 0 violations
- ✅ `swiftlint --strict` — 0 violations, 71 files
- ✅ `xcodebuild archive` (Release) — succeeded for both targets
- ✅ `xcodebuild -exportArchive` (release-testing / Ad Hoc) — IPA produced
- ✅ `devicectl device install` on iPhone 17 Pro — installed and launching cleanly
- ⚠️ `xcodebuild test -only-testing:MeowTests` against local simulators (iPhone 17 / iPhone 17 Pro, iOS 26.2 + 26.4) crashes the host app with `EXC_BAD_ACCESS` deep in SwiftUI `SettingsView` rendering. Reproduced on a clean stash of `origin/main` too — pre-existing simulator/Xcode flake unrelated to this diff, which touches no Swift sources. Routing to remote CI (where the CI sim runs MeowTests fine) instead of Path B.

## Diff scope

```
App/Info.plist                            |   4 +-
PacketTunnel/Info.plist                   |   4 +-
core/rust/mihomo-ios-ffi/Cargo.lock       | 343 ++++++++++++++++++++++++------
core/rust/mihomo-ios-ffi/Cargo.toml       |  12 +-
core/rust/mihomo-ios-ffi/src/tun2socks.rs |   4 +-
metadata/testflight/whats_new/2026051201.txt        |   4 +-
metadata/testflight/zh-Hans/whats_new/2026051201.txt|   4 +-
project.yml                               |  10 +-
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)