### PR TITLE
chore(release): bump app to 1.2.1 (build 2026051301)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026051201</string>
+	<string>2026051301</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>2026051201</string>
+	<string>2026051301</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/metadata/testflight/whats_new/2026051301.txt
+++ b/metadata/testflight/whats_new/2026051301.txt
@@ -1,0 +1,62 @@
+Build 2026051301 (1.2.1)
+
+WHAT'S NEW
+• CN IP-range bypass for fake-IP DNS. For every A / AAAA query the
+  PacketTunnel now consults the engine resolver first (500 ms budget)
+  and, if the upstream answer falls inside an offline-built CN
+  address-range table (APNIC delegated stats — 4109 v4 intervals,
+  2009 v6 intervals shipped in the app bundle), the synthesized
+  answer is the REAL IP. Those connections then take mihomo's DIRECT
+  outbound instead of being routed through a proxy via a 28.x.x.x
+  fake address. Non-CN hosts and timeouts fall through to the
+  unchanged fake-IP path.
+
+• Pinned DNS upstream. The engine now uses a fixed nameserver set —
+  119.29.29.29 (DNSPod), 223.5.5.5 (AliDNS), 1.1.1.1 (Cloudflare) —
+  regardless of what the subscription's dns: block contains. The
+  user-supplied dns: block is stripped before load. Fast CN-side
+  resolution for the CN-bypass probe, with Cloudflare as the global
+  fallback.
+
+• tun2socks: real-IP flows skip the fake-IP reverse-lookup. TCP and
+  UDP dispatch now CIDR-gates the pool mutex — CN-bypass real-IP
+  handshakes and direct-IP dials no longer touch the fake-IP pool
+  lock and can't accidentally pick up a stale hostname. Flows whose
+  destination falls inside the fake-IP CIDR but has no live pool
+  entry (LRU-evicted or TTL-expired) are now dropped instead of
+  being routed as literal 28.x.x.x — the client will re-resolve.
+
+KNOWN LIMITATIONS
+• In-TUN TCP/53 traffic is intentionally dropped. iOS's stub
+  resolver only falls back to TCP/53 for very large UDP replies,
+  which fake-IP responses never produce, so this should not be
+  user-visible. If you see a "DNS failure" from a tool that hard-
+  codes TCP DNS, please report it.
+
+• UDP-to-remote IS supported (dispatch into mihomo's UDP path,
+  full NAT-keyed reply injection) but requires the outbound to
+  support UDP relay. SS / Trojan / VLESS all do when the server
+  side enables it; if a node is TCP-only on the server, UDP flows
+  through it will silently drop.
+
+WHAT TO TEST
+1. CN-bypass smoke test:
+   - On a clean install (or after Reset Network Settings), open
+     Safari and hit a CN site (baidu.com, taobao.com, weibo.com) and
+     a non-CN site (github.com). Both should load.
+   - In the meow-ios Connections tab, the CN site's flow should
+     show the real CN IP as destination (e.g. 14.215.x.x for
+     baidu.com), not a 28.x.x.x address. The non-CN site should
+     still show 28.x.x.x.
+
+2. Subscription DNS override:
+   - Edit your subscription to add a custom dns: block with weird
+     nameservers (e.g. 8.8.8.8). Reconnect.
+   - The block should be silently ignored — engine logs show
+     119.29.29.29 / 223.5.5.5 / 1.1.1.1 in use regardless.
+
+3. Connect / disconnect cycles, subscription refresh, settings YAML
+   editor — no new crashes or UI hangs vs 2026051201.
+
+Please send TestFlight feedback or open an issue at:
+https://github.com/madeye/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026051301.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026051301.txt
@@ -1,0 +1,50 @@
+Build 2026051301 (1.2.1)
+
+新特性
+• Fake-IP DNS 新增国内 IP 段直连。每个 A / AAAA 查询都会先经引擎
+  resolver 解析(500 ms 超时),若上游返回的 IP 命中离线构建的
+  CN 段表(APNIC delegated stats — App 包内随版本随附 4109 条 v4
+  区间、2009 条 v6 区间),返回的就是 REAL IP,后续连接走 mihomo
+  的 DIRECT 出栈,不再走代理 + 28.x.x.x 虚拟地址。非国内域名 / 超时
+  仍走原本的 fake-IP 流程,行为不变。
+
+• 引擎 DNS 上游已固定。无论订阅里的 dns: 块写了什么,统一替换为
+  119.29.29.29(DNSPod)、223.5.5.5(AliDNS)、1.1.1.1(Cloudflare)。
+  用户提供的 dns: 块会在加载前被剥离。国内查询走快路径,Cloudflare
+  作为全球兜底。
+
+• tun2socks 真实 IP 流量不再做 fake-IP 反查。TCP / UDP 分发现在会
+  先用 CIDR 过滤 — 国内直连 + 用户直接拨打字面 IP 的连接不再争抢
+  fake-IP 池的互斥锁,也杜绝偶发的"反查命中过期映射"。落在 fake-IP
+  段但池中无对应条目的流量(被 LRU 淘汰或 TTL 过期)现在会直接丢弃,
+  而不是当成 28.x.x.x 字面地址发给 mihomo;客户端会重新发起 DNS。
+
+已知限制
+• In-TUN 的 TCP/53 仍然丢弃。iOS stub resolver 只在 UDP 应答超出
+  512 字节时才回退到 TCP/53,而 fake-IP 应答永远是单包,因此实际
+  不会触发。若你看到某个硬编码 TCP DNS 的工具报错,请反馈。
+
+• UDP 转发已经接入(走 mihomo 的 UDP 路径 + 基于 NAT 表的应答回注)
+  但需要出栈本身支持 UDP 中继。SS / Trojan / VLESS 三者只要服务端
+  开启了 UDP 即可工作;若节点的服务端仅启用 TCP,经过它的 UDP 报文
+  会被静默丢弃。
+
+测试要点
+1. 国内直连烟雾测试:
+   - 干净安装(或重置网络设置后),用 Safari 分别打开国内站点
+     (baidu.com、taobao.com、weibo.com)和国外站点(github.com),
+     都应能正常加载。
+   - 进入 meow-ios 的 Connections 页,国内站点的目标 IP 应为真实
+     国内 IP(如 baidu.com 显示 14.215.x.x),不再是 28.x.x.x;
+     国外站点仍显示 28.x.x.x。
+
+2. 订阅 DNS 强制覆盖:
+   - 修改订阅,加入一个奇怪的 dns: 块(例如 8.8.8.8),重新连接。
+   - 该块应被静默忽略 — 引擎日志会显示实际使用的还是
+     119.29.29.29 / 223.5.5.5 / 1.1.1.1。
+
+3. 连接 / 断开循环、订阅刷新、设置 YAML 编辑器,相比 2026051201
+   应无新的崩溃或 UI 卡顿。
+
+如有反馈请通过 TestFlight 或前往
+https://github.com/madeye/meow-ios/issues

--- a/project.yml
+++ b/project.yml
@@ -46,8 +46,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.2.0"
-        CFBundleVersion: "2026051201"
+        CFBundleShortVersionString: "1.2.1"
+        CFBundleVersion: "2026051301"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -193,8 +193,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.2.0"
-        CFBundleVersion: "2026051201"
+        CFBundleShortVersionString: "1.2.1"
+        CFBundleVersion: "2026051301"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

Version bump for the 1.2.1 release.

- \`App/Info.plist\` + \`PacketTunnel/Info.plist\` + \`project.yml\` — 1.2.0 → 1.2.1, build 2026051201 → 2026051301.
- TestFlight release notes (en-US + zh-Hans) describing what landed in the 1.2.x series since 1.2.0: fake-IP CN-bypass, pinned 119.29.29.29 / 223.5.5.5 / 1.1.1.1 DNS upstream, real-IP tun2socks CIDR gate + orphan-fake-IP drop. Stale "UDP not forwarded" line from the 2026051201 notes is corrected — UDP is dispatched into mihomo's UDP path, gated only on the outbound supporting UDP relay server-side.

No Swift / Rust code touched.

## Path B attestation

- [x] \`swiftformat --lint .\` → 0 violations
- [x] \`swiftlint --strict\` → 0 violations
- [x] \`xcodebuild test -only-testing:MeowTests\` on iPhone 17 Pro → TEST SUCCEEDED
- [x] \`git diff origin/main...HEAD --stat\` verified: only project.yml + two Info.plists + two metadata files

🤖 Generated with [Claude Code](https://claude.com/claude-code)