### PR TITLE
fix(rules): prepend China DIRECT preset so its rows match first

### DIFF
--- a/App/Sources/Models/ChinaDirectKeywords.swift
+++ b/App/Sources/Models/ChinaDirectKeywords.swift
@@ -364,15 +364,33 @@ enum ChinaDirectKeywords {
         }
     }
 
+    /// Prepend `preset` to `existing` so the preset rows match first.
+    /// Preset rows already present in `existing` (same TYPE / payload) are
+    /// skipped so re-tapping the action is a no-op. The relative order of
+    /// `existing` is preserved behind the preset block.
+    ///
+    /// Mihomo evaluates `rules:` top-down and stops at the first hit, so
+    /// front-of-list placement is what guarantees a China-app domain
+    /// reaches `DIRECT` even when a user's later rule would have sent the
+    /// same hostname through a proxy group.
+    static func prepend(preset: [EditableRule], to existing: [EditableRule]) -> (merged: [EditableRule], added: Int) {
+        var existingKeys = Set<String>()
+        for rule in existing {
+            existingKeys.insert(key(for: rule))
+        }
+        let fresh = preset.filter { !existingKeys.contains(key(for: $0)) }
+        return (fresh + existing, fresh.count)
+    }
+
     /// Merge `preset` into `existing`, skipping any preset row whose
     /// (type, payload) pair is already present (case-insensitive on type,
     /// case-sensitive on payload — keywords are matched verbatim by
     /// mihomo). New rows are appended in preset order. Returns the merged
     /// list and the count of rows actually inserted.
     ///
-    /// Insertion above `MATCH` is the caller's responsibility — see the
-    /// `RulesEditorView.applyChinaPreset` site, which slices around the
-    /// MATCH index just like the manual Add path does.
+    /// This is the append-flavoured sibling of `prepend(preset:to:)`;
+    /// kept for callers (and tests) that want preset rows added to the
+    /// tail of an existing list rather than the head.
     static func merge(preset: [EditableRule], into existing: [EditableRule]) -> (merged: [EditableRule], added: Int) {
         var seen = Set<String>()
         for rule in existing {

--- a/App/Sources/Views/RulesEditorView.swift
+++ b/App/Sources/Views/RulesEditorView.swift
@@ -170,20 +170,22 @@ struct RulesEditorView: View {
         hasUnsavedChanges = true
     }
 
-    /// Insert the curated `ChinaDirectKeywords` preset above the trailing
-    /// `MATCH` rule (or appended if no MATCH exists). Existing rows with
-    /// the same (type, payload) are skipped — re-tapping the preset is a
-    /// no-op, so the user can safely use it as "make sure these are
-    /// installed" rather than worrying about duplicates.
+    /// Prepend the curated `ChinaDirectKeywords` preset to the rule list
+    /// so the keyword rows match BEFORE any existing entries. Existing
+    /// rows with the same (type, payload) are skipped — re-tapping the
+    /// preset is a no-op rather than producing duplicates.
+    ///
+    /// Front-of-list placement is the whole point of the preset: mihomo
+    /// walks `rules:` top-down and stops at the first match, so for the
+    /// "send China-app traffic to DIRECT regardless of the user's other
+    /// routing" intent to hold, these rows must precede everything else.
+    /// The trailing `MATCH` (and any other prior rows) stay in their
+    /// original order behind the preset.
     private func applyChinaPreset() {
         let preset = ChinaDirectKeywords.presetRules()
-        let matchIndex = rules.firstIndex { $0.type.uppercased() == "MATCH" }
-        let head: [EditableRule] = matchIndex.map { Array(rules.prefix($0)) } ?? rules
-        let tail: [EditableRule] = matchIndex.map { Array(rules.suffix(from: $0)) } ?? []
-
-        let (mergedHead, added) = ChinaDirectKeywords.merge(preset: preset, into: head)
+        let (merged, added) = ChinaDirectKeywords.prepend(preset: preset, to: rules)
         guard added > 0 else { return }
-        rules = mergedHead + tail
+        rules = merged
         hasUnsavedChanges = true
     }
 

--- a/MeowTests/Models/ChinaDirectKeywordsTests.swift
+++ b/MeowTests/Models/ChinaDirectKeywordsTests.swift
@@ -78,4 +78,40 @@ struct ChinaDirectKeywordsTests {
         let alipay = merged.filter { $0.payload == "alipay" }
         #expect(alipay.count == 1, "lower-cased TYPE must still dedup against preset")
     }
+
+    @Test
+    func `prepend(preset:to:) puts every preset row in front of existing rules`() {
+        let existing: [EditableRule] = [
+            EditableRule(type: "DOMAIN-SUFFIX", payload: "example.com", proxy: "PROXY"),
+            EditableRule(type: "MATCH", payload: "", proxy: "PROXY"),
+        ]
+        let preset = ChinaDirectKeywords.presetRules()
+        let (merged, added) = ChinaDirectKeywords.prepend(preset: preset, to: existing)
+
+        #expect(added == preset.count)
+        #expect(merged.count == preset.count + existing.count)
+        // First N rows must be the preset, in preset order, ahead of the
+        // user's existing rows — that's the whole "match before others"
+        // contract.
+        for (offset, row) in preset.enumerated() {
+            #expect(merged[offset].type == row.type)
+            #expect(merged[offset].payload == row.payload)
+            #expect(merged[offset].proxy == row.proxy)
+        }
+        // Existing rules survive in their original relative order at the tail.
+        #expect(merged[preset.count].payload == "example.com")
+        #expect(merged.last?.type == "MATCH")
+    }
+
+    @Test
+    func `prepend is idempotent — re-applying adds zero and keeps order stable`() {
+        let preset = ChinaDirectKeywords.presetRules()
+        let existing: [EditableRule] = [EditableRule(type: "MATCH", payload: "", proxy: "PROXY")]
+        let (firstPass, addedFirst) = ChinaDirectKeywords.prepend(preset: preset, to: existing)
+        let (secondPass, addedSecond) = ChinaDirectKeywords.prepend(preset: preset, to: firstPass)
+        #expect(addedFirst == preset.count)
+        #expect(addedSecond == 0)
+        #expect(secondPass.count == firstPass.count)
+        #expect(secondPass.map(\.payload) == firstPass.map(\.payload))
+    }
 }


### PR DESCRIPTION
Mihomo's rule engine is top-down / first-match-wins. The previous `merge` placed the China preset above MATCH but **after** the user's existing rows, so any prior `DOMAIN-SUFFIX,…,PROXY` would still win and the preset's DIRECT routing wouldn't apply.

Switch `RulesEditorView.applyChinaPreset` to `ChinaDirectKeywords.prepend(...)` — preset rows now sit at index 0 in preset order; the user's existing rules (and MATCH) trail unchanged. Re-tapping the action is still a no-op via the same (type,payload) dedup.

Path B attestation:
- `swiftformat --lint .` → 0
- `swiftlint --strict` → 0 / 78 files
- `xcodebuild test -only-testing:MeowTests/ChinaDirectKeywordsTests` → 9/9 green (2 new prepend cases)
- `git diff origin/main...HEAD --stat` → 3 files, scoped to preset prepend

🤖 Generated with [Claude Code](https://claude.com/claude-code)