### PR TITLE
v1.3.0 — RSS reductions + stress test harness

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.3.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026051301</string>
+	<string>2026051501</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/MeowCore/include/mihomo_core.h
+++ b/MeowCore/include/mihomo_core.h
@@ -196,4 +196,35 @@ int meow_tun_ingest(const uint8_t *data, uintptr_t len);
  */
 void meow_tun_stop(void);
 
+/**
+ * Set the TCP accept-side cap. Bounds the number of concurrent
+ * `dispatch_tcp` tasks live at once, which is the dominant factor in
+ * peak FFI RSS under burst (1000+ concurrent dispatches each carrying
+ * per-flow Metadata, Box<dyn ProxyConn>, mihomo outbound dial state,
+ * and netstack ring buffers can push the extension past the 50 MiB
+ * jetsam cap). Default 128.
+ *
+ * Takes effect on the next `meow_tun_start`. Calls during a live
+ * tunnel are accepted but do not resize the running semaphore.
+ *
+ * Returns 0 on success, -1 on invalid input (`cap == 0`, which would
+ * deadlock the accept loop).
+ */
+int meow_tun_set_accept_cap(int cap);
+
+/**
+ * Read the currently-configured TCP accept cap. Reflects the value the
+ * next `meow_tun_start` will use; does not query the running semaphore.
+ */
+int meow_tun_accept_cap(void);
+
+/**
+ * Resident memory size of the FFI's containing process, in bytes. Same
+ * number macOS jetsam compares against the 50 MiB PacketTunnel cap, so
+ * Swift can poll this to chart the on-device RSS curve during a stress
+ * run without depending on Instruments. Returns 0 on platforms where
+ * the mach call isn't available (non-Apple targets).
+ */
+uint64_t meow_resident_bytes(void);
+
 #endif  /* MIHOMO_CORE_H */

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>2026051301</string>
+	<string>2026051501</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/core/rust/macos-utun-harness/src/main.rs
+++ b/core/rust/macos-utun-harness/src/main.rs
@@ -45,7 +45,7 @@ use utun::Utun;
 // so we are exercising the exact bytes the PacketTunnel extension runs.
 use mihomo_ios_ffi::{
     meow_core_init, meow_core_last_error, meow_core_set_home_dir, meow_engine_start,
-    meow_engine_stop, meow_tun_ingest, meow_tun_start, meow_tun_stop,
+    meow_engine_stop, meow_tun_ingest, meow_tun_start, meow_tun_stop, rss,
 };
 
 #[derive(Parser, Debug)]
@@ -67,6 +67,38 @@ struct Args {
     /// first free unit.
     #[arg(long, default_value_t = 0)]
     unit: u32,
+
+    /// If > 0, sample resident memory every N seconds and log it. Use
+    /// this to chart the FFI's RSS curve under whatever traffic shape
+    /// the operator drives through the tun. Cheap (one mach_task call
+    /// per tick); leave at 0 for normal interactive runs.
+    #[arg(long, default_value_t = 0)]
+    rss_monitor_interval_secs: u64,
+
+    /// If set, spawn a background load generator that opens
+    /// `stress_conns` concurrent TCP connections to this host:port,
+    /// holds each open for `stress_hold_ms`, then closes and repeats.
+    /// All originate from the harness process — under a default
+    /// `route add -net 0.0.0.0/1 172.19.0.2` they enter the tun and
+    /// drive real flow churn through the engine, surfacing per-flow
+    /// memory leaks that the cargo integration test can't see.
+    #[arg(long)]
+    stress_target: Option<String>,
+
+    /// Concurrent connections held open by the stress loop. Ignored
+    /// when `--stress-target` is unset.
+    #[arg(long, default_value_t = 32)]
+    stress_conns: usize,
+
+    /// Per-connection hold time before the stress loop tears it down
+    /// and reopens. Short holds (≤200 ms) maximise churn per second.
+    #[arg(long, default_value_t = 200)]
+    stress_hold_ms: u64,
+
+    /// Total wall time the stress loop runs before exiting. 0 = run
+    /// until Ctrl-C.
+    #[arg(long, default_value_t = 0)]
+    stress_duration_secs: u64,
 }
 
 /// The egress callback runs on a tokio worker thread (inside the FFI's
@@ -203,6 +235,42 @@ fn main() -> Result<()> {
         thread::spawn(move || ingest_loop(tun_fd))
     };
 
+    // Optional RSS monitor — emits one info-level line per tick with the
+    // mach `resident_size` for this process. Same number jetsam compares
+    // against on the device, so the curve here is directly meaningful for
+    // sizing the 50 MB extension budget.
+    let rss_monitor_thread = if args.rss_monitor_interval_secs > 0 {
+        let interval = std::time::Duration::from_secs(args.rss_monitor_interval_secs);
+        Some(thread::spawn(move || rss_monitor_loop(interval)))
+    } else {
+        None
+    };
+
+    // Optional load generator — drives real flow churn through the
+    // engine to surface per-flow leaks the cargo integration test can't
+    // see (it has no engine + no real outbound). The connections
+    // originate from this process; with the standard
+    // `route add -net 0.0.0.0/1 172.19.0.2` they enter the tun and walk
+    // the dispatch path mihomo's PacketTunnel exercises on-device.
+    let stress_thread = if let Some(target) = args.stress_target.clone() {
+        let conns = args.stress_conns.max(1);
+        let hold = std::time::Duration::from_millis(args.stress_hold_ms);
+        let duration = if args.stress_duration_secs == 0 {
+            None
+        } else {
+            Some(std::time::Duration::from_secs(args.stress_duration_secs))
+        };
+        info!(
+            "stress: target={} conns={} hold={:?} duration={:?}",
+            target, conns, hold, duration
+        );
+        Some(thread::spawn(move || {
+            stress_loop(target, conns, hold, duration)
+        }))
+    } else {
+        None
+    };
+
     // Park the main thread on the shutdown flag; ingestion runs on its own
     // thread so a blocking utun read doesn't gate signal handling.
     while !SHUTDOWN.load(Ordering::SeqCst) {
@@ -220,8 +288,135 @@ fn main() -> Result<()> {
     // explicitly here.
     utun::force_close(tun.as_raw_fd());
     let _ = ingest_thread.join();
+    if let Some(h) = rss_monitor_thread {
+        let _ = h.join();
+    }
+    if let Some(h) = stress_thread {
+        let _ = h.join();
+    }
     info!("clean exit");
     Ok(())
+}
+
+fn rss_monitor_loop(interval: std::time::Duration) {
+    let mut ticks = 0u64;
+    let mut peak_mib: f64 = 0.0;
+    while !SHUTDOWN.load(Ordering::Relaxed) {
+        if let Some(mib) = rss::resident_mib() {
+            if mib > peak_mib {
+                peak_mib = mib;
+            }
+            info!(
+                "rss_monitor t={}s rss={:.2} MiB peak={:.2} MiB",
+                ticks * interval.as_secs(),
+                mib,
+                peak_mib
+            );
+        }
+        ticks += 1;
+        // Sleep in short slices so shutdown is responsive.
+        let mut remaining = interval;
+        while remaining > std::time::Duration::ZERO && !SHUTDOWN.load(Ordering::Relaxed) {
+            let slice = remaining.min(std::time::Duration::from_millis(200));
+            thread::sleep(slice);
+            remaining = remaining.saturating_sub(slice);
+        }
+    }
+}
+
+/// Hammer `target` with `conns` concurrent short-lived TCP connections.
+/// Each worker thread re-opens its connection as soon as the previous
+/// one drops, so steady-state churn is roughly `conns / hold`/sec. Errors
+/// are counted but do not stop the loop — the goal is to pin the engine
+/// in steady-state flow churn while RSS is being sampled, not to assert
+/// reachability.
+fn stress_loop(
+    target: String,
+    conns: usize,
+    hold: std::time::Duration,
+    duration: Option<std::time::Duration>,
+) {
+    use std::net::ToSocketAddrs;
+    use std::sync::atomic::AtomicU64;
+
+    let started = std::time::Instant::now();
+    let opened = std::sync::Arc::new(AtomicU64::new(0));
+    let failed = std::sync::Arc::new(AtomicU64::new(0));
+
+    let mut workers = Vec::with_capacity(conns);
+    for _ in 0..conns {
+        let target = target.clone();
+        let opened = opened.clone();
+        let failed = failed.clone();
+        workers.push(thread::spawn(move || {
+            while !SHUTDOWN.load(Ordering::Relaxed) {
+                if let Some(limit) = duration {
+                    if started.elapsed() >= limit {
+                        return;
+                    }
+                }
+                let addr = match target.to_socket_addrs() {
+                    Ok(mut it) => it.next(),
+                    Err(_) => None,
+                };
+                let Some(addr) = addr else {
+                    failed.fetch_add(1, Ordering::Relaxed);
+                    thread::sleep(std::time::Duration::from_millis(100));
+                    continue;
+                };
+                match std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_secs(5))
+                {
+                    Ok(stream) => {
+                        opened.fetch_add(1, Ordering::Relaxed);
+                        thread::sleep(hold);
+                        drop(stream);
+                    }
+                    Err(_) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                        thread::sleep(std::time::Duration::from_millis(50));
+                    }
+                }
+            }
+        }));
+    }
+
+    // Reporter: prints aggregate counters every 5s so the operator can
+    // correlate RSS_MONITOR samples with the load profile.
+    let opened_r = opened.clone();
+    let failed_r = failed.clone();
+    let reporter = thread::spawn(move || {
+        let mut last = 0u64;
+        while !SHUTDOWN.load(Ordering::Relaxed) {
+            if let Some(limit) = duration {
+                if started.elapsed() >= limit {
+                    return;
+                }
+            }
+            thread::sleep(std::time::Duration::from_secs(5));
+            let now_o = opened_r.load(Ordering::Relaxed);
+            let f = failed_r.load(Ordering::Relaxed);
+            let rate = (now_o - last) as f64 / 5.0;
+            info!(
+                "stress: opened={} (Δ{:.1}/s) failed={} elapsed={:.0}s",
+                now_o,
+                rate,
+                f,
+                started.elapsed().as_secs_f64()
+            );
+            last = now_o;
+        }
+    });
+
+    for w in workers {
+        let _ = w.join();
+    }
+    let _ = reporter.join();
+    info!(
+        "stress: done — opened={} failed={} elapsed={:.1}s",
+        opened.load(Ordering::Relaxed),
+        failed.load(Ordering::Relaxed),
+        started.elapsed().as_secs_f64()
+    );
 }
 
 fn ingest_loop(fd: RawFd) {

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -24,6 +24,7 @@
 mod diagnostics;
 mod engine;
 mod logging;
+pub mod rss;
 mod subscription;
 mod tun2socks;
 

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -584,3 +584,45 @@ pub extern "C" fn meow_tun_stop() {
     logging::bridge_log("meow_tun_stop");
     tun2socks::stop();
 }
+
+/// Set the TCP accept-side cap. Bounds the number of concurrent
+/// `dispatch_tcp` tasks live at once, which is the dominant factor in
+/// peak FFI RSS under burst (1000+ concurrent dispatches each carrying
+/// per-flow Metadata, Box<dyn ProxyConn>, mihomo outbound dial state,
+/// and netstack ring buffers can push the extension past the 50 MiB
+/// jetsam cap). Default 128.
+///
+/// Takes effect on the next `meow_tun_start`. Calls during a live
+/// tunnel are accepted but do not resize the running semaphore.
+///
+/// Returns 0 on success, -1 on invalid input (`cap == 0`, which would
+/// deadlock the accept loop).
+#[no_mangle]
+pub extern "C" fn meow_tun_set_accept_cap(cap: c_int) -> c_int {
+    if cap <= 0 {
+        set_error("accept cap must be > 0".into());
+        return -1;
+    }
+    if tun2socks::set_accept_cap(cap as usize) {
+        0
+    } else {
+        -1
+    }
+}
+
+/// Read the currently-configured TCP accept cap. Reflects the value the
+/// next `meow_tun_start` will use; does not query the running semaphore.
+#[no_mangle]
+pub extern "C" fn meow_tun_accept_cap() -> c_int {
+    tun2socks::accept_cap() as c_int
+}
+
+/// Resident memory size of the FFI's containing process, in bytes. Same
+/// number macOS jetsam compares against the 50 MiB PacketTunnel cap, so
+/// Swift can poll this to chart the on-device RSS curve during a stress
+/// run without depending on Instruments. Returns 0 on platforms where
+/// the mach call isn't available (non-Apple targets).
+#[no_mangle]
+pub extern "C" fn meow_resident_bytes() -> u64 {
+    rss::resident_bytes().unwrap_or(0)
+}

--- a/core/rust/mihomo-ios-ffi/src/rss.rs
+++ b/core/rust/mihomo-ios-ffi/src/rss.rs
@@ -1,0 +1,105 @@
+//! Resident-memory sampling for the FFI.
+//!
+//! The PacketTunnel extension is killed by jetsam when its physical-footprint
+//! reading crosses ~50 MB on a real device. The same `resident_size` field
+//! that jetsam watches is available to userland through `mach_task_self` +
+//! `task_info(TASK_BASIC_INFO)`, and on macOS the same call works for the
+//! `macos-utun-harness` and `cargo test` binaries — so this module lets us
+//! sample the exact number the OS would penalise us for both on-device and
+//! on the dev box.
+//!
+//! Returns `None` on platforms where the mach call isn't available
+//! (linux / windows CI runners), so callers can degrade to "skip the
+//! assertion" rather than fail.
+
+#[cfg(target_vendor = "apple")]
+pub fn resident_bytes() -> Option<u64> {
+    // mach_task_basic_info layout — see <mach/task_info.h>. Hard-coded so
+    // we don't need to pull in the `mach2` crate just to read one field.
+    #[repr(C)]
+    #[derive(Default)]
+    struct MachTaskBasicInfo {
+        virtual_size: u64,
+        resident_size: u64,
+        resident_size_max: u64,
+        user_time: [u32; 2],
+        system_time: [u32; 2],
+        policy: i32,
+        suspend_count: i32,
+    }
+
+    const MACH_TASK_BASIC_INFO: i32 = 20;
+    // sizeof(MachTaskBasicInfo) / sizeof(u32). The flavor count is in
+    // natural_t units, which is u32 on both arm64 and x86_64 Apple targets.
+    const COUNT: u32 =
+        (std::mem::size_of::<MachTaskBasicInfo>() / std::mem::size_of::<u32>()) as u32;
+
+    extern "C" {
+        fn mach_task_self() -> u32;
+        fn task_info(
+            target_task: u32,
+            flavor: i32,
+            task_info_out: *mut MachTaskBasicInfo,
+            task_info_out_count: *mut u32,
+        ) -> i32;
+    }
+
+    let mut info = MachTaskBasicInfo::default();
+    let mut count = COUNT;
+    // SAFETY: `task_info` writes at most `count * sizeof(u32)` bytes into
+    // `info`, which is sized to hold exactly `COUNT` u32 words. The target
+    // task self handle is always valid.
+    let rc = unsafe {
+        task_info(
+            mach_task_self(),
+            MACH_TASK_BASIC_INFO,
+            &mut info,
+            &mut count,
+        )
+    };
+    if rc == 0 {
+        Some(info.resident_size)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_vendor = "apple"))]
+pub fn resident_bytes() -> Option<u64> {
+    None
+}
+
+/// Convenience: `resident_bytes` rounded to MiB. `None` propagates from the
+/// underlying sampler.
+pub fn resident_mib() -> Option<f64> {
+    resident_bytes().map(|b| b as f64 / (1024.0 * 1024.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_vendor = "apple")]
+    fn resident_bytes_is_nonzero_on_apple() {
+        let rss = resident_bytes().expect("mach call succeeds on Apple targets");
+        assert!(rss > 0, "task RSS must be > 0 in a running test process");
+        assert!(
+            rss < 16 * 1024 * 1024 * 1024,
+            "task RSS sanity (< 16 GiB), got {} bytes",
+            rss
+        );
+    }
+
+    #[test]
+    fn resident_mib_matches_resident_bytes() {
+        match (resident_bytes(), resident_mib()) {
+            (Some(b), Some(m)) => {
+                let expected = b as f64 / (1024.0 * 1024.0);
+                assert!((m - expected).abs() < f64::EPSILON, "MiB conversion exact");
+            }
+            (None, None) => {} // non-Apple platform, both return None
+            (b, m) => panic!("inconsistent sampler: bytes={:?} mib={:?}", b, m),
+        }
+    }
+}

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -91,13 +91,36 @@ pub(crate) static ACTIVE_TCP_CONNS: std::sync::atomic::AtomicI64 =
 // peaked at 440 MiB of RSS in the first ~10 s of load — 8.8× the on-device
 // 50 MB jetsam cap — almost entirely from the size of this in-flight set.
 //
-// The cap holds the smoltcp listener until a permit is available; smoltcp
-// keeps the SYN in its accept queue (bounded internally by stack_buffer_size),
-// so the cap manifests as TCP backpressure on the originating apps rather
-// than dropped flows. Sized at 128: enough to keep typical foreground page
-// loads at full concurrency, low enough that 128 × per-flow allocation
-// stays comfortably under the cap even with mihomo's heavier outbound paths.
-const TCP_ACCEPT_CAP: usize = 128;
+// Tunable at runtime via [`set_accept_cap`] / `meow_tun_set_accept_cap`.
+// The atomic is sampled at `start()` to size the per-tunnel semaphore;
+// changes after start take effect on the next `meow_tun_start`. We don't
+// reseat a live semaphore — tokio's Semaphore can `add_permits` but not
+// shrink without forgetting permits mid-flight, which would let live flows
+// outrun the new cap until they drain. Restart-scoped is cleaner.
+//
+// 128 default: enough to keep typical foreground page loads at full
+// concurrency, low enough that 128 × per-flow allocation stays comfortably
+// under the cap on iOS hardware. Slow-DNS environments may need more.
+const TCP_ACCEPT_CAP_DEFAULT: usize = 128;
+static TCP_ACCEPT_CAP: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(TCP_ACCEPT_CAP_DEFAULT);
+
+/// Set the TCP accept cap. Takes effect on the next `meow_tun_start`.
+/// `cap` must be > 0 — zero would deadlock the accept loop. Returns true
+/// if applied, false on invalid input.
+pub fn set_accept_cap(cap: usize) -> bool {
+    if cap == 0 {
+        return false;
+    }
+    TCP_ACCEPT_CAP.store(cap, Ordering::Relaxed);
+    true
+}
+
+/// Read the currently-configured accept cap. Reflects the value the next
+/// `meow_tun_start` will use, not the size of any live semaphore.
+pub fn accept_cap() -> usize {
+    TCP_ACCEPT_CAP.load(Ordering::Relaxed)
+}
 
 // Sweep window. Tightened from 90 / 30 s to 30 / 10 s: dead-flow state
 // holds for at most one sweep interval past the idle deadline, so the
@@ -318,7 +341,7 @@ async fn run_tun2socks(
     let (egress_tx, mut egress_rx) = mpsc::channel::<Vec<u8>>(1024);
 
     let udp_sem = Arc::new(Semaphore::new(UDP_BURST_CAP));
-    let tcp_accept_sem = Arc::new(Semaphore::new(TCP_ACCEPT_CAP));
+    let tcp_accept_sem = Arc::new(Semaphore::new(accept_cap()));
 
     let runner_handle = tokio::spawn(async move {
         if let Err(e) = tcp_runner.await {

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -827,7 +827,16 @@ fn spawn_udp_reply_reader(
     tunnel_inner: Arc<TunnelInner>,
 ) {
     tokio::spawn(async move {
-        let mut buf = vec![0u8; 64 * 1024];
+        // Per-session reply buffer. Sized for the iOS TUN MTU (1500) plus
+        // headroom for the rare oversized UDP datagram that survives path
+        // fragmentation. Was 64 KiB — at N concurrent UDP sessions (DNS,
+        // QUIC, NAT-traversal probes) that sums to N * 64 KiB pinned for
+        // each session's idle lifetime, blowing past the 50 MB jetsam cap
+        // long before mihomo's NAT timeout reaps the session. 4 KiB covers
+        // every UDP datagram that can actually round-trip through a
+        // 1500-MTU tun without fragmentation; oversized datagrams are
+        // truncated at the read, which matches the on-wire reality.
+        let mut buf = vec![0u8; 4 * 1024];
         loop {
             match session.conn.read_packet(&mut buf).await {
                 Ok((n, _from)) => {

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -82,25 +82,39 @@ static TUN2SOCKS_RUNNING: AtomicBool = AtomicBool::new(false);
 pub(crate) static ACTIVE_TCP_CONNS: std::sync::atomic::AtomicI64 =
     std::sync::atomic::AtomicI64::new(0);
 
-// TCP flows have no accept-time burst cap: every smoltcp-accepted flow is
-// dispatched. Memory is bounded instead by the 30-second idle sweeper
-// (`TCP_IDLE_SECS`) plus the hourly registry-size watchdog below — the cap
-// was a defensive backstop for an earlier "bursty-on-flow" leak that has
-// since been chased back to its real cause.
+// TCP accept-side burst cap. Without this, every smoltcp-accepted flow
+// spawns a `dispatch_tcp` task immediately — and under a real burst (e.g.
+// loading a content-rich CN homepage that fans out to 50+ subdomains in
+// the first second), 1000+ concurrent dispatch tasks each hold their own
+// per-flow state (Metadata, Box<dyn ProxyConn>, mihomo's outbound dial
+// buffers, the netstack stream's tx/rx ring). The 10-min VM stress run
+// peaked at 440 MiB of RSS in the first ~10 s of load — 8.8× the on-device
+// 50 MB jetsam cap — almost entirely from the size of this in-flight set.
 //
-// UDP and DNS keep their accept-time burst caps because their listeners
-// don't have an equivalent registry / idle-sweeper to bound growth.
-const TCP_IDLE_SECS: u64 = 90;
-const TCP_IDLE_SWEEP_INTERVAL_SECS: u64 = 30;
+// The cap holds the smoltcp listener until a permit is available; smoltcp
+// keeps the SYN in its accept queue (bounded internally by stack_buffer_size),
+// so the cap manifests as TCP backpressure on the originating apps rather
+// than dropped flows. Sized at 128: enough to keep typical foreground page
+// loads at full concurrency, low enough that 128 × per-flow allocation
+// stays comfortably under the cap even with mihomo's heavier outbound paths.
+const TCP_ACCEPT_CAP: usize = 128;
+
+// Sweep window. Tightened from 90 / 30 s to 30 / 10 s: dead-flow state
+// holds for at most one sweep interval past the idle deadline, so the
+// post-burst tail (~50 s in the 10-min stress run) is what we're trying
+// to compress. iOS jetsam doesn't wait — once we're past the cap any
+// retention beyond the next sweep tick is a jetsam risk.
+const TCP_IDLE_SECS: u64 = 30;
+const TCP_IDLE_SWEEP_INTERVAL_SECS: u64 = 10;
 const UDP_BURST_CAP: usize = 512;
 
-// Hourly watchdog: belt-and-suspenders backstop on the live `tcp_flows()`
-// registry. Once an hour, if the registry exceeds
-// `TCP_HOURLY_WATCHDOG_THRESHOLD` (e.g. a runaway reconnect storm or a leaked
-// abort handle) abort *every* flow in the table. Aggressive, but the
-// alternative is sitting at jetsam risk for another 59 minutes.
-const TCP_HOURLY_WATCHDOG_INTERVAL_SECS: u64 = 3600;
-const TCP_HOURLY_WATCHDOG_THRESHOLD: usize = 1024;
+// Emergency watchdog: when registry size crosses the threshold, abort
+// *every* flow in the table. Was 3600 s / 1024 flows — the on-device
+// 50 MB cap can't tolerate a runaway-flow window measured in hours.
+// 60 s / 256 flows makes the registry-size backstop measurable in the
+// same units (seconds, MB) the OS will jetsam us in.
+const TCP_WATCHDOG_INTERVAL_SECS: u64 = 60;
+const TCP_WATCHDOG_THRESHOLD: usize = 256;
 
 static UDP_CAP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
 
@@ -169,8 +183,8 @@ fn sweep_idle_tcp_flows() -> usize {
 
 /// Abort every flow in the registry. Same `abort()` semantics as the idle
 /// sweeper — dropping the `dispatch_tcp` future closes both halves of the
-/// relay. Returns the number of flows closed. Used by the hourly watchdog
-/// when the live count exceeds `TCP_HOURLY_WATCHDOG_THRESHOLD`.
+/// relay. Returns the number of flows closed. Used by the registry watchdog
+/// when the live count exceeds `TCP_WATCHDOG_THRESHOLD`.
 fn close_all_tcp_flows() -> usize {
     let flows = tcp_flows();
     let mut closed: Vec<(u64, SocketAddr, SocketAddr)> = Vec::with_capacity(flows.len());
@@ -181,7 +195,7 @@ fn close_all_tcp_flows() -> usize {
     });
     if !closed.is_empty() {
         warn!(
-            "tun2socks: hourly watchdog closed {} TCP flows",
+            "tun2socks: registry watchdog closed {} TCP flows",
             closed.len()
         );
         for (id, src, dst) in &closed {
@@ -304,6 +318,7 @@ async fn run_tun2socks(
     let (egress_tx, mut egress_rx) = mpsc::channel::<Vec<u8>>(1024);
 
     let udp_sem = Arc::new(Semaphore::new(UDP_BURST_CAP));
+    let tcp_accept_sem = Arc::new(Semaphore::new(TCP_ACCEPT_CAP));
 
     let runner_handle = tokio::spawn(async move {
         if let Err(e) = tcp_runner.await {
@@ -340,6 +355,7 @@ async fn run_tun2socks(
         }
     });
 
+    let tcp_accept_sem_for_task = tcp_accept_sem.clone();
     let tcp_accept_handle = tokio::spawn(async move {
         while let Some((stream, local_addr, remote_addr)) = tcp_listener.next().await {
             // Fake-IP mode: TCP DNS (rare, but RFC 1035 § 4.2.2 allows it
@@ -357,7 +373,21 @@ async fn run_tun2socks(
                 drop(stream);
                 continue;
             }
-            logging::bridge_log(&format!("tun2socks: TCP {} -> {}", local_addr, remote_addr));
+            // Hold accept until a permit is available — caps the number of
+            // dispatch_tcp tasks live at once and, transitively, the peak
+            // per-flow allocation footprint. `acquire_owned` returns a permit
+            // we move into the spawned task; permit drops on task exit, freeing
+            // a slot for the next accept. smoltcp keeps unaccepted SYNs in its
+            // accept queue (bounded by `stack_buffer_size`), so the cap shows
+            // up as TCP backpressure rather than dropped flows.
+            let Ok(permit) = tcp_accept_sem_for_task.clone().acquire_owned().await else {
+                break; // semaphore closed → tunnel shutting down
+            };
+            // Per-accept logging was INFO; under burst (16k accepts in 600 s
+            // measured in the VM stress run) the formatter + oslog writer
+            // become a measurable cost. Trace level keeps it available for
+            // dev diagnosis without paying the bytes on prod runs.
+            trace!("tun2socks: TCP {} -> {}", local_addr, remote_addr);
 
             let flow_id = TCP_FLOW_ID_SEQ.fetch_add(1, Ordering::Relaxed);
             let state = Arc::new(FlowState {
@@ -365,6 +395,7 @@ async fn run_tun2socks(
             });
             let state_for_task = state.clone();
             let task = tokio::spawn(async move {
+                let _permit = permit;
                 dispatch_tcp(stream, local_addr, remote_addr, state_for_task).await;
                 tcp_flows().remove(&flow_id);
             });
@@ -403,9 +434,8 @@ async fn run_tun2socks(
     // registry is the source of truth — `ACTIVE_TCP_CONNS` is incremented
     // inside `dispatch_tcp` and can briefly disagree at flow boundaries).
     let watchdog_handle = tokio::spawn(async move {
-        let mut tick = tokio::time::interval(std::time::Duration::from_secs(
-            TCP_HOURLY_WATCHDOG_INTERVAL_SECS,
-        ));
+        let mut tick =
+            tokio::time::interval(std::time::Duration::from_secs(TCP_WATCHDOG_INTERVAL_SECS));
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // Skip the immediate first tick so we don't fire right at startup.
         tick.tick().await;
@@ -415,10 +445,10 @@ async fn run_tun2socks(
                 break;
             }
             let live = tcp_flows().len();
-            if live > TCP_HOURLY_WATCHDOG_THRESHOLD {
+            if live > TCP_WATCHDOG_THRESHOLD {
                 warn!(
-                    "tun2socks: hourly watchdog tripped: {} live TCP flows > {} threshold, closing all",
-                    live, TCP_HOURLY_WATCHDOG_THRESHOLD
+                    "tun2socks: registry watchdog tripped: {} live TCP flows > {} threshold, closing all",
+                    live, TCP_WATCHDOG_THRESHOLD
                 );
                 close_all_tcp_flows();
             }
@@ -575,7 +605,7 @@ async fn run_tun2socks(
 /// RAII guard that decrements `ACTIVE_TCP_CONNS` on drop. Replaces the
 /// manual `fetch_add` / `fetch_sub` pair so the counter stays balanced
 /// when `dispatch_tcp` is dropped mid-`.await` — i.e. when the idle
-/// sweeper, the hourly watchdog, or the tunnel-shutdown loop calls
+/// sweeper, the registry watchdog, or the tunnel-shutdown loop calls
 /// `FlowRecord::abort.abort()`. Without the guard, every aborted flow
 /// leaked +1 on the counter, which is what users saw as a "1k+ active
 /// connections" reading after hours of normal sweeper activity.

--- a/core/rust/mihomo-ios-ffi/tests/stress_rss.rs
+++ b/core/rust/mihomo-ios-ffi/tests/stress_rss.rs
@@ -1,0 +1,201 @@
+//! RSS-pressure stress tests for the FFI.
+//!
+//! These tests don't replace the on-device profile against the 50 MiB jetsam
+//! cap — they're a fast, hermetic guard rail that surfaces obvious regressions
+//! in the FFI's bookkeeping (channels, registries, runtime overhead) before
+//! they ever ship to a device. The on-device verification still happens
+//! through `macos-utun-harness`'s `stress` subcommand, which exercises real
+//! flows through real proxies.
+//!
+//! What runs here:
+//!
+//!   * `tun_start_stop_cycles_do_not_leak` — repeatedly starts and stops the
+//!     tun2socks driver. The runtime, channels, registries, and
+//!     stack/listener tasks all get torn down between cycles. RSS after the
+//!     cooldown must not exceed the baseline by more than a small budget.
+//!
+//!   * `sustained_ingest_burst_drops_under_load` — pushes a large burst of
+//!     synthesized IP packets through `meow_tun_ingest` while tun2socks is
+//!     running. Checks that the ingress mpsc back-pressures (drops on full
+//!     rather than allocating unboundedly) and that post-cooldown RSS is
+//!     close to the pre-burst baseline.
+//!
+//! The tests must run serially because the FFI owns global state. Cargo
+//! ships them as a single integration binary, which already serializes
+//! `#[test]` functions within the file unless `--test-threads=N>1`. Each test
+//! also calls `meow_tun_stop` in its own teardown so a panic in one doesn't
+//! leave the next test fighting over the same `TUN2SOCKS_RUNNING` flag.
+
+#![cfg(target_vendor = "apple")]
+
+use mihomo_ios_ffi::{meow_core_init, meow_tun_ingest, meow_tun_start, meow_tun_stop, rss};
+use std::os::raw::c_void;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+static EGRESS_BYTES: AtomicU64 = AtomicU64::new(0);
+static EGRESS_PACKETS: AtomicU64 = AtomicU64::new(0);
+
+unsafe extern "C" fn count_egress(_ctx: *mut c_void, _data: *const u8, len: usize) {
+    EGRESS_BYTES.fetch_add(len as u64, Ordering::Relaxed);
+    EGRESS_PACKETS.fetch_add(1, Ordering::Relaxed);
+}
+
+fn ensure_init() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| meow_core_init());
+}
+
+/// Hand-built minimal IPv4 + UDP packet bound for 172.19.0.2:53 (the
+/// fake-IP pool's DNS server address). The intercept path in `tun2socks.rs`
+/// matches on `dst_port == 53` regardless of dst_ip, so this is enough to
+/// exercise the spawn-per-DNS-query branch without a real engine: the
+/// spawned task short-circuits on `engine::tunnel() == None` and unwinds.
+/// Source port is parameterised so each packet looks like a distinct flow.
+fn synth_dns_packet(src_port: u16) -> Vec<u8> {
+    let payload: &[u8] = &[
+        // DNS header: ID 0xABCD, RD set, 1 question
+        0xAB, 0xCD, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // qname "a.b" (1 'a' . 1 'b' . 0)
+        0x01, b'a', 0x01, b'b', 0x00, // qtype A (1), qclass IN (1)
+        0x00, 0x01, 0x00, 0x01,
+    ];
+    let udp_len: u16 = 8 + payload.len() as u16;
+    let total_len: u16 = 20 + udp_len;
+
+    let mut pkt = Vec::with_capacity(total_len as usize);
+    // IPv4 header (20 bytes, no options)
+    pkt.push(0x45);
+    pkt.push(0x00);
+    pkt.extend_from_slice(&total_len.to_be_bytes());
+    pkt.extend_from_slice(&[0x12, 0x34]); // identification
+    pkt.extend_from_slice(&[0x40, 0x00]); // flags=DF, fragment offset=0
+    pkt.push(64); // TTL
+    pkt.push(17); // protocol = UDP
+    pkt.extend_from_slice(&[0x00, 0x00]); // header checksum (not validated by the intercept)
+    pkt.extend_from_slice(&[10, 0, 0, 7]); // src 10.0.0.7
+    pkt.extend_from_slice(&[172, 19, 0, 2]); // dst 172.19.0.2
+                                             // UDP header
+    pkt.extend_from_slice(&src_port.to_be_bytes());
+    pkt.extend_from_slice(&53u16.to_be_bytes());
+    pkt.extend_from_slice(&udp_len.to_be_bytes());
+    pkt.extend_from_slice(&[0x00, 0x00]); // UDP checksum 0 (legal on IPv4)
+    pkt.extend_from_slice(payload);
+    pkt
+}
+
+/// Settle the runtime so async cleanup catches up before sampling RSS.
+/// Drops jitter from the post-burst measurement: if we sample immediately
+/// after the last `meow_tun_ingest` call, the spawned tasks are still in
+/// flight and their per-task allocations look like a leak.
+fn cooldown(d: Duration) {
+    std::thread::sleep(d);
+}
+
+fn rss_mib() -> f64 {
+    rss::resident_mib().expect("RSS sampler must succeed on Apple targets")
+}
+
+#[test]
+fn tun_start_stop_cycles_do_not_leak() {
+    ensure_init();
+
+    // Warm-up: the very first start spins up the tokio runtime, allocates
+    // the smoltcp stack, etc. That cost is paid once per process lifetime
+    // and is not what this test is policing — fold it into the baseline.
+    unsafe {
+        let rc = meow_tun_start(std::ptr::null_mut(), count_egress);
+        assert_eq!(rc, 0, "warm-up start succeeds");
+        meow_tun_stop();
+    }
+    cooldown(Duration::from_millis(200));
+    let baseline = rss_mib();
+
+    const CYCLES: usize = 50;
+    for i in 0..CYCLES {
+        unsafe {
+            let rc = meow_tun_start(std::ptr::null_mut(), count_egress);
+            assert_eq!(rc, 0, "cycle {} start", i);
+            meow_tun_stop();
+        }
+    }
+    cooldown(Duration::from_millis(500));
+    let after = rss_mib();
+    let delta = after - baseline;
+    eprintln!(
+        "tun_start_stop_cycles: baseline={:.2} MiB, after {} cycles={:.2} MiB, delta={:.2} MiB",
+        baseline, CYCLES, after, delta
+    );
+    // Budget: 8 MiB. Pre-fix bursty-on-flow growth would cross this
+    // immediately; nominal post-fix growth across 50 cycles should be
+    // under 1 MiB once the stack/runtime allocations have stabilised.
+    assert!(
+        delta < 8.0,
+        "RSS grew {:.2} MiB across {} start/stop cycles (budget 8.0 MiB)",
+        delta,
+        CYCLES
+    );
+}
+
+#[test]
+fn sustained_ingest_burst_drops_under_load() {
+    ensure_init();
+    EGRESS_BYTES.store(0, Ordering::Relaxed);
+    EGRESS_PACKETS.store(0, Ordering::Relaxed);
+
+    unsafe {
+        let rc = meow_tun_start(std::ptr::null_mut(), count_egress);
+        assert_eq!(rc, 0, "tun2socks start");
+    }
+    // Let the runtime warm.
+    cooldown(Duration::from_millis(100));
+    let baseline = rss_mib();
+
+    // 10k synthetic DNS packets across distinct src ports. The ingress
+    // mpsc capacity is 256 — sustained sends well above that surface
+    // either back-pressure (drops, fine) or unbounded growth (the bug).
+    const PACKETS: u32 = 10_000;
+    let mut peak = baseline;
+    for i in 0..PACKETS {
+        let port = 1024 + (i as u16 % 60_000);
+        let pkt = synth_dns_packet(port);
+        unsafe { meow_tun_ingest(pkt.as_ptr(), pkt.len()) };
+        if i % 1000 == 0 {
+            let now = rss_mib();
+            if now > peak {
+                peak = now;
+            }
+        }
+    }
+    cooldown(Duration::from_secs(4)); // > DNS_PASSTHROUGH_TIMEOUT (3s)
+    let after = rss_mib();
+    meow_tun_stop();
+    cooldown(Duration::from_millis(500));
+    let post_stop = rss_mib();
+
+    eprintln!(
+        "sustained_ingest_burst: baseline={:.2} MiB, peak~={:.2} MiB, after_cooldown={:.2} MiB, post_stop={:.2} MiB",
+        baseline, peak, after, post_stop
+    );
+
+    // Two assertions, decreasing strictness:
+    //   * peak under sustained load < 30 MiB above baseline. The on-device
+    //     budget is 50 MiB total; if a 10k burst alone eats 30+ above
+    //     baseline, on-device load will jetsam well before that.
+    //   * post-cooldown < 8 MiB above baseline. The spawned passthrough
+    //     tasks all unwind on `engine::tunnel() == None`; nothing should
+    //     remain pinned past their unwind.
+    let peak_delta = peak - baseline;
+    let cool_delta = after - baseline;
+    assert!(
+        peak_delta < 30.0,
+        "RSS peaked at +{:.2} MiB during burst (budget 30 MiB)",
+        peak_delta
+    );
+    assert!(
+        cool_delta < 8.0,
+        "RSS held +{:.2} MiB above baseline 4s after burst (budget 8 MiB)",
+        cool_delta
+    );
+}

--- a/project.yml
+++ b/project.yml
@@ -46,8 +46,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.2.1"
-        CFBundleVersion: "2026051301"
+        CFBundleShortVersionString: "1.3.0"
+        CFBundleVersion: "2026051501"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -193,8 +193,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.2.1"
-        CFBundleVersion: "2026051301"
+        CFBundleShortVersionString: "1.3.0"
+        CFBundleVersion: "2026051501"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

- **TCP accept cap (default 128, runtime-tunable)** — new semaphore on the smoltcp accept side bounds in-flight `dispatch_tcp` tasks. VM stress run (10 min, ~22k curl reqs, DIRECT-only) showed peak RSS drop **440 → 107 MiB** (−76%). Tunable from Swift via `meow_tun_set_accept_cap()` so the value can be retuned on-device.
- **Per-UDP-session reply buffer 64 KiB → 4 KiB** — at N concurrent UDP sessions the previous sizing pinned N × 64 KiB for each session's idle lifetime.
- **Sweep windows tightened to iOS timescales** — idle 90 → 30 s, sweep 30 → 10 s, registry watchdog 3600 s/1024 → 60 s/256.
- **RSS stress harness** — cargo integration test (`stress_rss.rs`) with hermetic burst + start/stop assertions, plus `--rss-monitor-interval-secs` and load-generator flags on `macos-utun-harness` for real-flow churn.
- **`meow_resident_bytes()`** — exports the same mach RSS field jetsam compares against, so PacketTunnel can chart its own curve without depending on Instruments.

## Path B attestation (code PR, admin-merge)

- [x] `swiftformat --lint .` → 0/88 files require formatting
- [x] `swiftlint --strict` → 0 violations in 79 files
- [x] `xcodebuild test -only-testing MeowTests` on iPhone 17 Pro (iOS 26.4) → 129 tests passed in 24 suites
- [x] `cargo test --lib` in `core/rust/mihomo-ios-ffi/` → 30 passed
- [x] `cargo test --test stress_rss` → 2 passed (start/stop cycles + sustained ingest burst)
- [x] `git diff origin/main...HEAD --stat` reviewed; touches Rust FFI + harness + project version bump only, no accidental additions
- [x] `scripts/build-rust.sh` rebuilds xcframework cleanly with new exports (`meow_tun_set_accept_cap`, `meow_tun_accept_cap`, `meow_resident_bytes`)

## Test plan

- [x] 10-min VM stress run with new caps (logged in commit message of c325783)
- [x] Ad Hoc IPA installed on iPhone 17 Pro for smoke test
- [ ] On-device RSS curve via TestFlight build 2026051501 (uploaded; processing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)