### PR TITLE
docs: v1.3.0 release callout + refresh UDP limitation copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Public beta is open on TestFlight: <https://testflight.apple.com/join/nnDAn7ZH>.
 Requires iOS 26 or later (iPhone and iPad). Bring your own Mihomo / Clash
 subscription — meow does not provide proxy servers.
 
+Latest release: [**v1.3.0**](https://github.com/madeye/meow-ios/releases/tag/v1.3.0)
+— RSS reductions targeting the NetworkExtension jetsam cap (peak FFI RSS
+−76% in stress tests), runtime-tunable TCP accept cap, hermetic stress
+test harness. See the [release notes](https://github.com/madeye/meow-ios/releases)
+for the full per-version changelog.
+
 ## Status
 
 Public beta. See [`docs/PRD.md`](docs/PRD.md) and

--- a/docs/index.html
+++ b/docs/index.html
@@ -562,9 +562,10 @@
         <div class="panel warn">
           <span class="label warn-c">Known limitation</span>
           <p>
-            Some features are still under active development. The tunnel does
-            not yet forward non-DNS UDP traffic — QUIC / HTTP3 falls back to
-            TCP HTTP/2 on most sites.
+            UDP (including QUIC / HTTP3) is forwarded through the
+            packet tunnel, but reliability varies with your proxy outbound's
+            UDP support — QUIC may fall back to TCP HTTP/2 on outbounds that
+            don't carry UDP cleanly.
           </p>
           <p>
             Please report issues via


### PR DESCRIPTION
## Summary

Path A docs-only PR.

- README gets a Latest release callout linking the v1.3.0 release notes.
- docs/index.html refreshes the QUIC/UDP limitation copy — UDP is forwarded today, reliability tracks the chosen outbound's UDP support.

Diff: README + docs/index.html, no code paths touched, qualifies for Path A admin merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)