### PR TITLE
feat: lower minimum deployment target to iOS 17

### DIFF
--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -8,21 +8,16 @@ struct ContentView: View {
 
     var body: some View {
         TabView {
-            Tab("tabs.home", systemImage: "house.fill") {
-                NavigationStack { HomeView() }
-            }
-            Tab("tabs.subscriptions", systemImage: "text.document.fill") {
-                NavigationStack { SubscriptionsView() }
-            }
-            Tab("tabs.traffic", systemImage: "chart.bar.fill") {
-                NavigationStack { TrafficView() }
-            }
-            Tab("tabs.logs", systemImage: "list.bullet.rectangle.fill") {
-                NavigationStack { LogsView() }
-            }
-            Tab("tabs.settings", systemImage: "gearshape.fill") {
-                NavigationStack { SettingsView() }
-            }
+            NavigationStack { HomeView() }
+                .tabItem { Label("tabs.home", systemImage: "house.fill") }
+            NavigationStack { SubscriptionsView() }
+                .tabItem { Label("tabs.subscriptions", systemImage: "text.document.fill") }
+            NavigationStack { TrafficView() }
+                .tabItem { Label("tabs.traffic", systemImage: "chart.bar.fill") }
+            NavigationStack { LogsView() }
+                .tabItem { Label("tabs.logs", systemImage: "list.bullet.rectangle.fill") }
+            NavigationStack { SettingsView() }
+                .tabItem { Label("tabs.settings", systemImage: "gearshape.fill") }
         }
         .onOpenURL { url in
             if url.scheme == "meow", url.host == "diagnostics" {

--- a/App/Sources/Views/GlassCard.swift
+++ b/App/Sources/Views/GlassCard.swift
@@ -1,19 +1,23 @@
 import SwiftUI
 
-/// Liquid Glass container for major card surfaces. Routes the background
-/// through iOS 26's native `.glassEffect(in:)` modifier (PRD §4.1) so each
-/// instance picks up system vibrancy, adaptive contrast, and light/dark
-/// tuning without the hand-rolled `.regularMaterial` + stroke overlay the
-/// pre-T5.1 implementation used. Wrapper API is intentionally unchanged
-/// from the pre-T5.1 version so the ~11 existing call sites (Home, Traffic,
-/// Subscriptions, Providers, Rules, Connections) need no edits.
+/// Material container for major card surfaces. Uses `.regularMaterial` plus
+/// a thin stroke overlay so the wrapper renders consistently from iOS 17 up.
+/// Wrapper API is intentionally unchanged so the ~11 existing call sites
+/// (Home, Traffic, Subscriptions, Providers, Rules, Connections) need no edits.
 struct GlassCard<Content: View>: View {
     @ViewBuilder var content: Content
 
     var body: some View {
         content
             .padding(16)
-            .glassEffect(in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .background(
+                .regularMaterial,
+                in: RoundedRectangle(cornerRadius: 20, style: .continuous),
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5),
+            )
             .shadow(color: .black.opacity(0.06), radius: 10, y: 3)
     }
 }

--- a/MeowShared/Package.swift
+++ b/MeowShared/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "MeowShared",
     platforms: [
-        .iOS(.v26),
+        .iOS(.v17),
         // macOS 15 lets `swift test` drive MeowSharedTests from the command
         // line. Production builds always target iOS via `project.yml`; this
         // declaration is only so CI / local dev can run pure-logic tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # meow-ios
 
 Native iOS port of the Android "meow" VPN/proxy client. Full mihomo proxy engine
-wrapped in a SwiftUI iOS 26 Liquid Glass UI with a NetworkExtension packet
+wrapped in a SwiftUI material UI with a NetworkExtension packet
 tunnel provider.
 
 ## Install
@@ -9,7 +9,7 @@ tunnel provider.
 [<img src="https://img.shields.io/badge/TestFlight-Public%20Beta-0070F5?style=for-the-badge&logo=apple&logoColor=white" alt="Join the TestFlight public beta" height="60">](https://testflight.apple.com/join/nnDAn7ZH)
 
 Public beta is open on TestFlight: <https://testflight.apple.com/join/nnDAn7ZH>.
-Requires iOS 26 or later (iPhone and iPad). Bring your own Mihomo / Clash
+Requires iOS 17 or later (iPhone and iPad). Bring your own Mihomo / Clash
 subscription — meow does not provide proxy servers.
 
 Latest release: [**v1.3.0**](https://github.com/madeye/meow-ios/releases/tag/v1.3.0)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -16,7 +16,7 @@
 
 ### 1.1 What is meow-ios?
 
-meow-ios is a native iOS VPN/proxy client that ports the Android "meow" app to Apple platforms. It provides a full-featured proxy management experience — Clash-protocol subscriptions, Shadowsocks / Trojan / VLESS outbounds (the protocol set shipped by mihomo-rust v0.6.1), rule-based traffic routing, and DNS-over-HTTPS — wrapped in a modern iOS 26 Liquid Glass UI.
+meow-ios is a native iOS VPN/proxy client that ports the Android "meow" app to Apple platforms. It provides a full-featured proxy management experience — Clash-protocol subscriptions, Shadowsocks / Trojan / VLESS outbounds (the protocol set shipped by mihomo-rust v0.6.1), rule-based traffic routing, and DNS-over-HTTPS — wrapped in a SwiftUI material UI.
 
 ### 1.2 Target Audience
 
@@ -30,7 +30,7 @@ meow-ios offers the full power of the mihomo proxy engine in a native iOS app wi
 - **Zero-config subscriptions:** paste a URL, meow fetches and converts automatically
 - **Transparent VPN:** all system traffic routed through the proxy without per-app configuration
 - **Real-time visibility:** live connection table, traffic charts, rule matching logs
-- **iOS-native UX:** SwiftUI with iOS 26 Liquid Glass design, no cross-platform compromises
+- **iOS-native UX:** SwiftUI with material design, no cross-platform compromises
 
 ---
 
@@ -40,7 +40,7 @@ meow-ios offers the full power of the mihomo proxy engine in a native iOS app wi
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│              SwiftUI App (iOS 26, Liquid Glass)          │
+│              SwiftUI App (iOS 17+, material UI)          │
 │         Tab bar · Cards · Native controls · SwiftData    │
 └─────────────────────┬───────────────────────────────────┘
                       │ App ↔ Extension IPC
@@ -69,7 +69,7 @@ meow-ios offers the full power of the mihomo proxy engine in a native iOS app wi
 
 | Layer | Technology | Responsibility |
 |-------|-----------|----------------|
-| UI | SwiftUI + iOS 26 | All screens, navigation, state presentation |
+| UI | SwiftUI + iOS 17+ | All screens, navigation, state presentation |
 | App ↔ Extension IPC | CFNotificationCenter + App Group container | Commands (connect/disconnect) and state/traffic events |
 | Packet Tunnel Provider | NEPacketTunnelProvider | VPN lifecycle, TUN fd management |
 | MihomoCore (Rust) | Rust, cbindgen C header, single XCFramework | tun2socks (netstack-smoltcp), DoH, full proxy engine (mihomo-rust), REST controller at 127.0.0.1:9090 |
@@ -208,22 +208,24 @@ This avoids XPC complexity while remaining within Apple's sandbox restrictions.
 
 ---
 
-## 4. iOS 26 UI Design Direction
+## 4. UI Design Direction
 
 ### 4.1 Design Language
 
-meow-ios adopts **iOS 26 Liquid Glass** throughout:
-- `.glassEffect()` modifier on cards and panels
-- Tab bar uses the new floating glass tab bar (`.tabBarStyle(.prominent)` equivalent)
-- Frosted glass navigation bars and sheets
+meow-ios adopts a **SwiftUI material design** throughout:
+- `.regularMaterial` background on cards and panels (with a thin stroke overlay)
+- Standard SwiftUI `TabView` with system tab bar
+- Frosted navigation bars and sheets via system materials
 - Adaptive dark/light appearance with vibrancy
-- SF Symbols 7 iconography
+- SF Symbols iconography
 - Large title navigation where appropriate
+
+Minimum deployment target is iOS 17. On iOS 26 the system upgrades materials with Liquid Glass automatically; no app-side opt-in is required.
 
 ### 4.2 Navigation Structure
 
 ```
-TabView (Liquid Glass tab bar)
+TabView (system tab bar)
 ├── Home          (house.fill)
 ├── Subscriptions (text.document.fill)
 ├── Traffic       (chart.bar.fill)
@@ -614,7 +616,7 @@ Both app target and PacketTunnel extension must share:
 
 ### Milestone 1.5: Manual Smoke Passes (End of Week 3)
 - T2.6 (Debug Diagnostics Panel) complete; all 5 checks rendering on device with `MEOW_DEBUG=1`
-- User runs manual smoke on their iPhone (iOS 26, real device) and confirms all 5 checks read `PASS`
+- User runs manual smoke on their iPhone (iOS 17+ real device) and confirms all 5 checks read `PASS`
 - Gate is user sign-off, not an automated assertion; vphone-cli nightly harness is retired (v1.4)
 
 ### Milestone 2: VPN Toggle + Basic UI (Weeks 4–5)
@@ -640,12 +642,12 @@ Both app target and PacketTunnel extension must share:
 - Daily traffic accumulation in SwiftData
 - Traffic screen with Swift Charts
 - **T2.9 (non-DNS UDP):** wire netstack-smoltcp UDP → `mihomo_tunnel::udp::handle_udp` (pending upstream API maturity)
-- iOS 26 Liquid Glass UI polish pass
+- SwiftUI material UI polish pass
 - Dark mode, Dynamic Type, accessibility audit
 - App icons, launch screen
 
 ### Milestone 6: Testing & App Store Submission (Weeks 11–12)
-- Full regression test pass on physical devices (iPhone 15+, iOS 26)
+- Full regression test pass on physical devices (iPhone running iOS 17+)
 - Performance profiling (memory target ≤40 MB, hard-fail 50 MB)
 - App Store metadata, screenshots, privacy policy
 - TestFlight beta

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>meow — iOS Mihomo proxy client (public beta)</title>
     <meta
       name="description"
-      content="meow is a native iOS Mihomo proxy client for iOS 26: Clash-style YAML subscriptions, rule-based routing, DNS over HTTPS, and a Liquid Glass UI. Public beta on TestFlight."
+      content="meow is a native iOS Mihomo proxy client for iOS 17+: Clash-style YAML subscriptions, rule-based routing, DNS over HTTPS, and a SwiftUI material design. Public beta on TestFlight."
     />
     <meta name="theme-color" content="#E8843A" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#FFA458" media="(prefers-color-scheme: dark)" />
@@ -16,7 +16,7 @@
     <meta property="og:title" content="meow — iOS Mihomo proxy client" />
     <meta
       property="og:description"
-      content="Native iOS Mihomo proxy client. Clash-style YAML subscriptions, rule-based routing, DNS over HTTPS, and a Liquid Glass UI on iOS 26. Public beta on TestFlight."
+      content="Native iOS Mihomo proxy client for iOS 17+. Clash-style YAML subscriptions, rule-based routing, DNS over HTTPS, and a SwiftUI material design. Public beta on TestFlight."
     />
     <meta property="og:url" content="https://madeye.github.io/meow-ios/" />
     <meta property="og:type" content="website" />
@@ -35,7 +35,7 @@
     <meta name="twitter:title" content="meow — iOS Mihomo proxy client" />
     <meta
       name="twitter:description"
-      content="Native iOS Mihomo proxy client. Clash-style YAML subscriptions, rule-based routing, DoH, and a Liquid Glass UI on iOS 26. Public beta on TestFlight."
+      content="Native iOS Mihomo proxy client for iOS 17+. Clash-style YAML subscriptions, rule-based routing, DoH, and a SwiftUI material design. Public beta on TestFlight."
     />
     <meta name="twitter:image" content="https://madeye.github.io/meow-ios/appicon.png" />
     <meta name="twitter:image:alt" content="meow app icon — an orange tabby cat with a blue scarf leaping over brick blocks on a blue background" />
@@ -443,11 +443,11 @@
     <div class="stage">
       <main>
         <header>
-          <span class="eyebrow"><span class="dot"></span>Public beta · iOS 26</span>
+          <span class="eyebrow"><span class="dot"></span>Public beta · iOS 17+</span>
           <h1>meow</h1>
           <p class="tagline">
             A native iOS Mihomo proxy client. Clash-style YAML subscriptions,
-            rule-based routing, DNS over HTTPS, and a Liquid Glass UI.
+            rule-based routing, DNS over HTTPS, and a SwiftUI material design.
           </p>
         </header>
 
@@ -491,7 +491,7 @@
           </a>
         </div>
         <p class="req">
-          Requires iOS 26 or later · Bring your own Mihomo / Clash subscription
+          Requires iOS 17 or later · Bring your own Mihomo / Clash subscription
         </p>
         <p class="req-detail">
           <strong>TestFlight</strong> is the recommended channel — install Apple's
@@ -602,7 +602,7 @@
           Sibling project:
           <a href="https://github.com/madeye/meow">madeye/meow</a> (Android, Flutter UI).
           <span class="built">
-            Built with mihomo-rust · SwiftUI · NetworkExtension · iOS 26 Liquid Glass.
+            Built with mihomo-rust · SwiftUI · NetworkExtension · iOS 17+.
           </span>
         </footer>
       </main>

--- a/project.yml
+++ b/project.yml
@@ -3,7 +3,7 @@ name: meow-ios
 options:
   bundleIdPrefix: io.github.madeye.meow
   deploymentTarget:
-    iOS: "26.0"
+    iOS: "17.0"
   createIntermediateGroups: true
   generateEmptyDirectories: true
   groupSortPosition: top
@@ -12,7 +12,7 @@ options:
 settings:
   base:
     SWIFT_VERSION: "6.0"
-    IPHONEOS_DEPLOYMENT_TARGET: "26.0"
+    IPHONEOS_DEPLOYMENT_TARGET: "17.0"
     TARGETED_DEVICE_FAMILY: "1,2"
     SUPPORTS_MACCATALYST: NO
     CODE_SIGN_STYLE: Automatic

--- a/scripts/build-rust.sh
+++ b/scripts/build-rust.sh
@@ -12,6 +12,10 @@ HEADER_DST="$ROOT/MeowCore/include/mihomo_core.h"
 TARGETS_REQUIRED=(aarch64-apple-ios aarch64-apple-ios-sim)
 PROFILE="release"
 
+# Match the iOS deployment target declared in project.yml so the Rust static
+# libs and the Xcode targets agree on LC_BUILD_VERSION minos.
+export IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-17.0}"
+
 for target in "${TARGETS_REQUIRED[@]}"; do
     if ! rustup target list --installed | grep -qx "$target"; then
         echo "==> Adding rust target $target"


### PR DESCRIPTION
## Summary
- Drops the iOS 26 deployment floor to iOS 17, opening up a much larger install base.
- Only iOS-26-only API in the codebase was `.glassEffect()` on `GlassCard`. Replaced with `.regularMaterial` plus a thin stroke overlay so the wrapper renders consistently from iOS 17 up. On iOS 26 the system upgrades materials with Liquid Glass automatically — no app-side opt-in is needed.
- Marketing copy (`README.md`, `docs/index.html`, `docs/PRD.md`) repositioned from "iOS 26 Liquid Glass UI" to "iOS 17+ material UI."

## Changes
- `project.yml`: `deploymentTarget.iOS` and `IPHONEOS_DEPLOYMENT_TARGET` → `17.0`. `xcodeVersion: "26.0"` left as-is (toolchain ≠ target).
- `MeowShared/Package.swift`: `.iOS(.v26)` → `.iOS(.v17)`.
- `App/Sources/Views/GlassCard.swift`: `.glassEffect(in:)` → `.background(.regularMaterial, in:)` + `.strokeBorder` overlay; doc comment updated.
- `scripts/build-rust.sh`: exports `IPHONEOS_DEPLOYMENT_TARGET=17.0` (overridable) so the Rust static libs land with `LC_BUILD_VERSION` minos 17.0 instead of 26.x.
- Docs: `README.md`, `docs/index.html`, `docs/PRD.md` reworded; OG/Twitter descriptions updated.
- CI (`.github/workflows/ci.yml`) intentionally untouched — `OS=latest` on Xcode 26 runners builds an iOS 17 deployment target fine.

## Local checks
- [x] `swiftformat --lint .` → 0 violations
- [x] `swiftlint --strict` → 0 violations
- [x] `scripts/build-rust.sh` → xcframework rebuilt; `otool -l` confirms `minos 17.0` on both `ios-arm64` and `ios-arm64-simulator` slices
- [ ] `xcodebuild test` (MeowTests, MeowIntegrationTests) — **not run locally**: SwiftPM is timing out on the Firebase binary artifact downloads in this environment (curl to `dl.google.com` succeeds in milliseconds; `xcodebuild` SPM downloader fails after ~15s). Relying on CI for this coverage.

## Risks / follow-ups
- **iOS 17 device smoke pass needed for the NE path** before TestFlight cut. The accumulated NE lessons (loopback-route bug, writePackets backpressure, includeAllNetworks pitfalls) were characterized on iOS 26 — the underlying APIs are older but their iOS 17 behavior should be re-validated on a real device.
- Brand/positioning shift: landing page no longer leads with Liquid Glass. Worth a separate marketing pass if the App Store description references the iOS 26 hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)