### PR TITLE
fix(config): inject asn geox URL so IP-ASN rules don't fail engine start

### DIFF
--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -27,6 +27,7 @@ public enum EffectiveConfigWriter {
         "geoip": "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb",
         "mmdb": "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/country.mmdb",
         "geosite": "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat",
+        "asn": "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb",
     ]
 
     public static func write(

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -82,10 +82,10 @@ struct EffectiveConfigWriterTests {
         #expect(geo?["mmdb"]?.contains("country.mmdb") == true)
     }
 
-    // Regression guard: subscriptions with `IP-ASN,<num>,<group>` rules
-    // fail engine_start with "GeoLite2-ASN.mmdb: No such file or directory"
-    // unless geox-url.asn is injected. mihomo lazy-fetches the ASN db on
-    // first IP-ASN eval — the URL has to be there for that to work.
+    /// Regression guard: subscriptions with `IP-ASN,<num>,<group>` rules
+    /// fail engine_start with "GeoLite2-ASN.mmdb: No such file or directory"
+    /// unless geox-url.asn is injected. mihomo lazy-fetches the ASN db on
+    /// first IP-ASN eval — the URL has to be there for that to work.
     @Test
     func `injects geox-url asn entry for IP-ASN rules`() throws {
         let out = try EffectiveConfigWriter.patch(sourceYAML: "proxies: []\n", prefs: Preferences())

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -82,6 +82,20 @@ struct EffectiveConfigWriterTests {
         #expect(geo?["mmdb"]?.contains("country.mmdb") == true)
     }
 
+    // Regression guard: subscriptions with `IP-ASN,<num>,<group>` rules
+    // fail engine_start with "GeoLite2-ASN.mmdb: No such file or directory"
+    // unless geox-url.asn is injected. mihomo lazy-fetches the ASN db on
+    // first IP-ASN eval — the URL has to be there for that to work.
+    @Test
+    func `injects geox-url asn entry for IP-ASN rules`() throws {
+        let out = try EffectiveConfigWriter.patch(sourceYAML: "proxies: []\n", prefs: Preferences())
+        let parsed = try Yams.load(yaml: out) as? [String: Any]
+        let geo = parsed?["geox-url"] as? [String: String]
+        let asn = try #require(geo?["asn"])
+        #expect(asn.contains("GeoLite2-ASN"))
+        #expect(asn.contains("jsdelivr.net"))
+    }
+
     @Test
     func `preserves user-supplied geox-url`() throws {
         let source = """

--- a/metadata/testflight/whats_new/2026051603.txt
+++ b/metadata/testflight/whats_new/2026051603.txt
@@ -1,0 +1,13 @@
+Build 2026051603 (1.3.0)
+
+WHAT'S NEW
+• Subscriptions with IP-ASN rules now load. The effective-config writer
+  injects an `asn:` URL into the `geox-url:` block alongside the existing
+  `mmdb` / `geoip` / `geosite` entries, so mihomo lazy-fetches
+  `GeoLite2-ASN.mmdb` from jsDelivr on first IP-ASN rule eval instead
+  of bailing engine-start with "GeoLite2-ASN.mmdb: No such file or directory".
+
+KNOWN
+• First IP-ASN rule eval per fresh install will incur a one-time
+  download (~8 MiB). Not blocking; subsequent evals are cached.
+• Non-DNS UDP forwarding still pending (QUIC/HTTP3 degraded to TCP).

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.0"
-        CFBundleVersion: "2026051602"
+        CFBundleVersion: "2026051603"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -194,7 +194,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.0"
-        CFBundleVersion: "2026051602"
+        CFBundleVersion: "2026051603"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

`EffectiveConfigWriter.defaultGeoXURL` was injecting `mmdb` / `geoip` / `geosite` URLs but not `asn`. Subscriptions containing an `IP-ASN,<num>,<group>` rule (common in real-world configs) fail `meow_engine_start` with:

```
Failed to load GeoLite2-ASN database at <AppGroup>/mihomo/GeoLite2-ASN.mmdb
required by rule: IP-ASN,20473,AI AIRS,no-resolve
underlying error: No such file or directory (os error 2)
```

This adds the missing entry pointing at MetaCubeX's mirror on jsDelivr — same provenance as the other three.

## Behavior

mihomo lazy-fetches `GeoLite2-ASN.mmdb` (~8 MiB) on the first IP-ASN rule eval and caches it under the AppGroup home. Subsequent evals are cached. No additional bundling, no fixed cost on subscriptions that don't use IP-ASN.

## Future work (not in this PR)

We discussed moving geox fetching to engine startup and routing through the upstream proxy (so users on censored networks can bootstrap), and dropping the bundled `Country.mmdb` to shrink the IPA. That's a multi-day mihomo-rust fork + Swift bootstrap rework — tracked separately. This PR is the hotfix that unblocks the immediate symptom.

## Local checks
- [x] `swiftformat --lint .` → 0 violations
- [x] `swiftlint --strict` → 0 violations
- [x] `swift test` in `MeowShared/` → 26/26 pass

## Path B attestation status

xcodebuild test (MeowTests / MeowUITests / MeowIntegrationTests) — not run locally (same Firebase SPM artifact-download timeout that blocked #144/#146/#147 — environmental). Routing through full remote CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)