### PR TITLE
feat(geo): bootstrap geo download via first proxy

### DIFF
--- a/App/Sources/Services/GeoAssetService.swift
+++ b/App/Sources/Services/GeoAssetService.swift
@@ -31,6 +31,21 @@ enum GeoAssetService {
         }
     }
 
+    /// True when every URL in the user profile's `geox-url:` block already
+    /// has a non-empty file in `mihomoConfigDir`. Used to decide whether the
+    /// connect flow needs the proxy-bootstrap detour or can go straight to
+    /// `startVPNTunnel` with the production config.
+    static func allFilesPresent() -> Bool {
+        let urls = geoXURLs(prefs: Preferences.load(from: AppGroup.defaults))
+        guard !urls.isEmpty else { return true }
+        for (_, source) in urls {
+            let destination = AppGroup.mihomoConfigDir.appending(path: source.lastPathComponent)
+            let size = (try? FileManager.default.attributesOfItem(atPath: destination.path)[.size] as? Int) ?? 0
+            if size <= 0 { return false }
+        }
+        return true
+    }
+
     /// Stage every URL listed in the effective config's `geox-url:` block —
     /// patched in-memory from the user's source profile so first connect
     /// works before the extension has ever written `effective-config.yaml`.
@@ -63,9 +78,19 @@ enum GeoAssetService {
 
     private static func download(name: String, from source: URL, to destination: URL) async throws {
         log.info("downloading \(name, privacy: .public) from \(source.absoluteString, privacy: .public)")
-        let (tempURL, response): (URL, URLResponse)
+        let session: URLSession = {
+            let config = URLSessionConfiguration.ephemeral
+            config.timeoutIntervalForRequest = 60
+            config.timeoutIntervalForResource = 180
+            config.waitsForConnectivity = false
+            return URLSession(configuration: config)
+        }()
+        defer { session.invalidateAndCancel() }
+
+        let tempURL: URL
+        let response: URLResponse
         do {
-            (tempURL, response) = try await URLSession.shared.download(from: source)
+            (tempURL, response) = try await session.download(from: source)
         } catch {
             throw Failure.downloadFailed(name: name, underlying: error)
         }

--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -67,12 +67,64 @@ final class VpnManager {
         guard let manager else { return }
         stage = .preparing
         do {
-            try await GeoAssetService.ensureFiles(prefs: Preferences.load(from: AppGroup.defaults))
+            if !GeoAssetService.allFilesPresent() {
+                try await bootstrapGeoDownload(manager: manager)
+            }
             try manager.connection.startVPNTunnel()
         } catch {
             lastError = error.localizedDescription
             stage = .error
         }
+    }
+
+    /// Two-step bootstrap when the GeoIP/ASN databases aren't on disk yet:
+    ///
+    ///   1. Swap `configURL` for a `MinimalConfigBuilder` config that uses
+    ///      only the first proxy from the user profile + a `MATCH` rule.
+    ///   2. Start the tunnel, wait for `.connected`, and download the geo
+    ///      files via URLSession — the app's traffic is routed through the
+    ///      tunnel's TUN, so jsDelivr is reached *through* the proxy.
+    ///   3. Stop the tunnel, wait for `.disconnected`, restore the original
+    ///      `configURL`.
+    ///
+    /// The caller then issues `startVPNTunnel` against the restored config.
+    private func bootstrapGeoDownload(manager: NETunnelProviderManager) async throws {
+        let sourceYAML = try String(contentsOf: AppGroup.configURL, encoding: .utf8)
+        let minimal = try MinimalConfigBuilder.build(sourceYAML: sourceYAML)
+
+        try minimal.write(to: AppGroup.configURL, atomically: true, encoding: .utf8)
+        defer {
+            // Best-effort restore. If a crash happens between here and the
+            // restore line below, the user's next profile reselect will
+            // re-stamp the real config.
+            try? sourceYAML.write(to: AppGroup.configURL, atomically: true, encoding: .utf8)
+        }
+
+        try manager.connection.startVPNTunnel()
+        try await waitForStatus(manager: manager, target: .connected, timeout: 30)
+        do {
+            try await GeoAssetService.ensureFiles(prefs: Preferences.load(from: AppGroup.defaults))
+        } catch {
+            manager.connection.stopVPNTunnel()
+            try? await waitForStatus(manager: manager, target: .disconnected, timeout: 10)
+            throw error
+        }
+        manager.connection.stopVPNTunnel()
+        try await waitForStatus(manager: manager, target: .disconnected, timeout: 10)
+    }
+
+    private func waitForStatus(
+        manager: NETunnelProviderManager,
+        target: NEVPNStatus,
+        timeout: TimeInterval,
+    ) async throws {
+        if manager.connection.status == target { return }
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            try await Task.sleep(for: .milliseconds(200))
+            if manager.connection.status == target { return }
+        }
+        throw URLError(.timedOut)
     }
 
     /// Disable on-demand first, then tear down the tunnel. iOS reclaims the NE

--- a/MeowShared/Sources/MeowModels/MinimalConfigBuilder.swift
+++ b/MeowShared/Sources/MeowModels/MinimalConfigBuilder.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Yams
+
+/// Produces a bootstrap config containing only the user's first proxy plus a
+/// catch-all `MATCH,<first-proxy>` rule. The app uses this to bring the
+/// tunnel up briefly so it can download GeoIP/ASN databases through the
+/// proxy — the production config can't start until the geo files are on
+/// disk, but the geo file CDNs (jsDelivr) are often unreachable directly
+/// from mainland China. Routing through one already-trusted proxy is the
+/// cheapest way to break the chicken-and-egg.
+///
+/// The minimal config deliberately omits `geox-url`, `rule-providers`,
+/// `dns`, and everything else that would force the engine to touch the
+/// network for anything other than the proxy itself.
+public enum MinimalConfigBuilder {
+    public enum BuildError: Error, LocalizedError {
+        case noProxies
+
+        public var errorDescription: String? {
+            switch self {
+            case .noProxies: "Profile has no proxies — cannot bootstrap geo download."
+            }
+        }
+    }
+
+    public static func build(sourceYAML: String) throws -> String {
+        let loaded = try Yams.load(yaml: sourceYAML)
+        let root = (loaded as? [String: Any]) ?? [:]
+        let proxies = (root["proxies"] as? [[String: Any]]) ?? []
+        guard let first = proxies.first, let name = first["name"] as? String, !name.isEmpty else {
+            throw BuildError.noProxies
+        }
+
+        let minimal: [String: Any] = [
+            "mixed-port": EffectiveConfigWriter.defaultMixedPort,
+            "external-controller": EffectiveConfigWriter.defaultExternalController,
+            "log-level": "warning",
+            "proxies": [first],
+            "rules": ["MATCH,\(name)"],
+        ]
+        return try Yams.dump(object: minimal, sortKeys: true)
+    }
+}


### PR DESCRIPTION
## Summary
- Previous lazy-download flow (PR #150) assumed jsDelivr was reachable directly. From mainland China, \`cdn.jsdelivr.net\` regularly isn't — first connect surfaced as 请求超时 / timeout.
- New approach: when any geo file is missing on connect, the app generates a minimal one-proxy + \`MATCH,<first-proxy>\` config via the new \`MinimalConfigBuilder\`, swaps it into \`configURL\`, brings the tunnel up, downloads the geo files via URLSession (now routed through the proxy via the TUN), tears the tunnel down, restores the original config, and starts the real tunnel.
- All within one user-facing \"Preparing…\" badge. Subsequent connects skip the bootstrap entirely. URLSession timeouts bumped to 60s/180s so a slow proxy hop doesn't trip defaults.

## Path B attestation
- [x] \`swiftformat --lint .\` — 0 violations
- [x] \`swiftlint --strict\` — 0 violations
- [x] \`xcodebuild test -scheme meow-ios -only-testing:MeowTests\` — all passed
- [x] On-device verified by user: first connect downloads geo through proxy, transitions to Connected; second connect skips the bootstrap.

## Test plan
- [ ] Fresh install in a network where jsdelivr is blocked: first connect bootstraps via proxy, geo files appear in App Group container, real tunnel comes up.
- [ ] Second connect (geo files present): no bootstrap, straight Preparing→Connecting→Connected.
- [ ] Profile with no proxies: bootstrap surfaces \"Profile has no proxies — cannot bootstrap geo download.\" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)