### PR TITLE
fix(tun2socks): bound DNS handler + iCloud import

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -69,6 +69,9 @@
 "subscriptions.row.a11y.edit %@" = "Edit YAML for %@";
 "subscriptions.row.a11y.refresh %@" = "Refresh %@";
 "subscriptions.toolbar.a11y.add" = "Add subscription";
+"subscriptions.toolbar.addFromURL" = "Add from URL";
+"subscriptions.toolbar.importFromFile" = "Import from iCloud Drive…";
+"subscriptions.import.invalidEncoding" = "The selected file isn't valid UTF-8 text.";
 "subscriptions.empty.title" = "No subscriptions yet";
 "subscriptions.empty.description" = "Tap + to add a Mihomo or Clash subscription URL.";
 

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -75,6 +75,9 @@
 "subscriptions.row.a11y.edit %@" = "编辑 %@ 的 YAML";
 "subscriptions.row.a11y.refresh %@" = "刷新 %@";
 "subscriptions.toolbar.a11y.add" = "添加订阅";
+"subscriptions.toolbar.addFromURL" = "从 URL 添加";
+"subscriptions.toolbar.importFromFile" = "从 iCloud 云盘导入…";
+"subscriptions.import.invalidEncoding" = "所选文件不是有效的 UTF-8 文本。";
 "subscriptions.empty.title" = "暂无订阅";
 "subscriptions.empty.description" = "点击右上角的 + 添加 Mihomo 或 Clash 订阅链接。";
 

--- a/App/Sources/Services/SubscriptionService.swift
+++ b/App/Sources/Services/SubscriptionService.swift
@@ -34,7 +34,20 @@ final class SubscriptionService {
         return profile
     }
 
+    /// Import a profile from a local YAML payload (Files / iCloud Drive
+    /// picker). No remote URL — `url` is empty, which the row UI uses to
+    /// hide the refresh affordance.
+    @discardableResult
+    func addLocal(name: String, yamlContent: String) async throws -> Profile {
+        let normalized = try await normalize(body: Data(yamlContent.utf8))
+        let profile = Profile(name: name, url: "", yamlContent: normalized, yamlBackup: normalized)
+        modelContext.insert(profile)
+        try modelContext.save()
+        return profile
+    }
+
     func refresh(_ profile: Profile) async throws {
+        guard !profile.url.isEmpty else { throw SubscriptionError.invalidURL }
         let yaml = try await fetchAndNormalize(url: profile.url)
         profile.yamlBackup = profile.yamlContent
         profile.yamlContent = yaml

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -1,10 +1,12 @@
 import SwiftData
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SubscriptionsView: View {
     @Environment(SubscriptionService.self) private var service
     @Query(sort: \Profile.lastUpdated, order: .reverse) private var profiles: [Profile]
     @State private var showingAdd = false
+    @State private var showingImporter = false
     @State private var editing: Profile?
     @State private var error: String?
 
@@ -35,15 +37,17 @@ struct SubscriptionsView: View {
                         .buttonStyle(.borderless)
                         .accessibilityLabel(Text("subscriptions.row.a11y.edit \(profile.name)"))
                         .accessibilityIdentifier("subscriptions.row.editYaml")
-                        Button {
-                            Task { try? await service.refresh(profile) }
-                        } label: {
-                            Image(systemName: "arrow.clockwise")
-                                .frame(minWidth: 44, minHeight: 44)
-                                .contentShape(Rectangle())
+                        if !profile.url.isEmpty {
+                            Button {
+                                Task { try? await service.refresh(profile) }
+                            } label: {
+                                Image(systemName: "arrow.clockwise")
+                                    .frame(minWidth: 44, minHeight: 44)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityLabel(Text("subscriptions.row.a11y.refresh \(profile.name)"))
                         }
-                        .buttonStyle(.borderless)
-                        .accessibilityLabel(Text("subscriptions.row.a11y.refresh \(profile.name)"))
                     }
                 }
                 .listRowBackground(Color.clear)
@@ -75,8 +79,20 @@ struct SubscriptionsView: View {
         .navigationTitle("subscriptions.nav.title")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button {
-                    showingAdd = true
+                Menu {
+                    Button {
+                        showingAdd = true
+                    } label: {
+                        Label("subscriptions.toolbar.addFromURL", systemImage: "link")
+                    }
+                    .accessibilityIdentifier("subscriptions.toolbar.addFromURL")
+
+                    Button {
+                        showingImporter = true
+                    } label: {
+                        Label("subscriptions.toolbar.importFromFile", systemImage: "icloud.and.arrow.down")
+                    }
+                    .accessibilityIdentifier("subscriptions.toolbar.importFromFile")
                 } label: {
                     Image(systemName: "plus")
                 }
@@ -86,6 +102,13 @@ struct SubscriptionsView: View {
         }
         .sheet(isPresented: $showingAdd) {
             AddSubscriptionSheet(error: $error)
+        }
+        .fileImporter(
+            isPresented: $showingImporter,
+            allowedContentTypes: yamlContentTypes(),
+            allowsMultipleSelection: false,
+        ) { result in
+            handleImport(result)
         }
         .sheet(item: $editing) { profile in
             NavigationStack {
@@ -97,6 +120,57 @@ struct SubscriptionsView: View {
         } message: {
             Text(error ?? "")
         }
+    }
+
+    /// File picker accepts YAML proper plus `.txt` and unspecified data —
+    /// iCloud Drive routinely serves Clash configs uploaded from desktops
+    /// where the OS tagged them as `public.plain-text` or just `public.data`,
+    /// not `public.yaml`. The actual YAML check happens inside addLocal's
+    /// normalize step, so widening the accept list here is safe.
+    private func yamlContentTypes() -> [UTType] {
+        var types: [UTType] = [.yaml, .plainText, .text, .data]
+        if let yml = UTType(filenameExtension: "yml") { types.append(yml) }
+        return types
+    }
+
+    private func handleImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case let .success(urls):
+            guard let url = urls.first else { return }
+            Task {
+                do {
+                    let yaml = try await readSecurityScoped(url)
+                    let suggestedName = url.deletingPathExtension().lastPathComponent
+                    let name = suggestedName.isEmpty ? "Imported" : suggestedName
+                    _ = try await service.addLocal(name: name, yamlContent: yaml)
+                } catch {
+                    self.error = error.localizedDescription
+                }
+            }
+        case let .failure(err):
+            error = err.localizedDescription
+        }
+    }
+
+    /// iCloud Drive / Files picker hands back a URL that requires a
+    /// security-scoped resource access pairing before the sandbox lets us
+    /// read it. The picker URL is single-shot — we copy the bytes into a
+    /// String and let the scope expire.
+    private func readSecurityScoped(_ url: URL) async throws -> String {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+        let data = try Data(contentsOf: url)
+        guard let yaml = String(data: data, encoding: .utf8) else {
+            throw NSError(
+                domain: "SubscriptionsView",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: NSLocalizedString(
+                    "subscriptions.import.invalidEncoding",
+                    comment: "Shown when an imported file isn't UTF-8 text",
+                )],
+            )
+        }
+        return yaml
     }
 }
 

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -49,7 +49,7 @@ use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
 use tracing::{info, trace, warn};
 
 use netstack_smoltcp::{udp::UdpMsg, AnyIpPktFrame, StackBuilder, TcpStream as NetstackTcpStream};
@@ -145,6 +145,30 @@ pub fn accept_cap() -> usize {
 const TCP_IDLE_SECS: u64 = 30;
 const TCP_IDLE_SWEEP_INTERVAL_SECS: u64 = 10;
 const UDP_BURST_CAP: usize = 512;
+
+// In-TUN UDP/53 handler fan-out cap. Each UDP/53 packet spawns an async
+// task that may block on a real DNS round-trip (forward_dns_to_upstream
+// for non-A/AAAA, mihomo's resolver for A/AAAA). Without a cap, a DNS
+// storm (Safari HTTPS/SVCB probes, mDNS-style fan-out, malicious flood)
+// produces unbounded `tokio::spawn` calls each holding the inbound IP
+// frame plus its upstream socket. 256 is sized to match the UDP burst
+// cap above — DNS is conceptually a slice of UDP, not a separate budget.
+const DNS_BURST_CAP: usize = 256;
+static DNS_CAP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
+
+// Per-DNS-task wall-clock cap. Belt-and-suspenders for DNS_BURST_CAP: the
+// cap bounds concurrent tasks but only a timeout bounds individual task
+// lifetime, and 256 stuck tasks against a hung upstream would otherwise
+// permanently exhaust the cap. 5s covers the worst legitimate iOS
+// resolver round-trip (cold DNS-over-HTTPS in a captive-portal scenario)
+// while bounding the lockout window.
+const DNS_TASK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+// Throttle slot for the silent-egress-drop log. The egress path drops
+// outbound frames non-blockingly when egress_rx is saturated (Swift-side
+// writePackets is slow); without a log the user sees a throughput cliff
+// with no on-device signal. Throttled via warn_capped to once per second.
+static EGRESS_DROP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
 
 // Emergency watchdog: when registry size crosses the threshold, abort
 // *every* flow in the table. Was 3600 s / 1024 flows — the on-device
@@ -356,6 +380,7 @@ async fn run_tun2socks(
     let (egress_tx, mut egress_rx) = mpsc::channel::<Vec<u8>>(1024);
 
     let udp_sem = Arc::new(Semaphore::new(UDP_BURST_CAP));
+    let dns_sem = Arc::new(Semaphore::new(DNS_BURST_CAP));
     let tcp_accept_sem = Arc::new(Semaphore::new(accept_cap()));
 
     let runner_handle = tokio::spawn(async move {
@@ -381,7 +406,14 @@ async fn run_tun2socks(
                 }
                 pkt = stack.next() => {
                     match pkt {
-                        Some(Ok(frame)) => { let _ = egress_tx_stack.try_send(frame); }
+                        Some(Ok(frame)) => {
+                            if egress_tx_stack.try_send(frame).is_err() {
+                                warn_capped(
+                                    &EGRESS_DROP_LOG_LAST_MS,
+                                    "tun2socks: egress queue saturated, dropping outbound frame (Swift writePackets backpressure)",
+                                );
+                            }
+                        }
                         Some(Err(e)) => {
                             logging::bridge_log(&format!("stack recv error: {}", e));
                             break;
@@ -529,8 +561,7 @@ async fn run_tun2socks(
             let reply_tx = udp_reply_tx_accept.clone();
             let readers = reply_readers_accept.clone();
             tokio::spawn(async move {
-                let _permit = permit;
-                dispatch_udp(payload, src, dst, reply_tx, readers).await;
+                dispatch_udp(payload, src, dst, reply_tx, readers, permit).await;
             });
         }
     });
@@ -556,13 +587,25 @@ async fn run_tun2socks(
         // destination IP isn't a real host on the inside, and we'd just
         // create an orphan session.
         if parse_udp_packet(&ip_data).is_some_and(|p| p.dst_port == 53) {
+            let permit = match dns_sem.clone().try_acquire_owned() {
+                Ok(p) => p,
+                Err(_) => {
+                    warn_capped(
+                        &DNS_CAP_LOG_LAST_MS,
+                        "tun2socks: DNS burst cap reached, dropping query",
+                    );
+                    continue;
+                }
+            };
             let request = ip_data.clone();
             let egress = egress_tx.clone();
             tokio::spawn(async move {
-                let Some(parsed) = parse_udp_packet(&request) else {
-                    return;
-                };
-                let qtype = parse_dns_qtype(parsed.payload);
+                let _permit = permit;
+                let work = async {
+                    let Some(parsed) = parse_udp_packet(&request) else {
+                        return;
+                    };
+                    let qtype = parse_dns_qtype(parsed.payload);
 
                 let response_payload = if matches!(qtype, Some(1) | Some(28)) {
                     let Some(tunnel) = crate::engine::tunnel() else {
@@ -597,10 +640,14 @@ async fn run_tun2socks(
                         }
                     }
                 };
-                let Some(reply_pkt) = build_udp_reply(&request, &response_payload) else {
-                    return;
+                    let Some(reply_pkt) = build_udp_reply(&request, &response_payload) else {
+                        return;
+                    };
+                    let _ = egress.send(reply_pkt).await;
                 };
-                let _ = egress.send(reply_pkt).await;
+                if tokio::time::timeout(DNS_TASK_TIMEOUT, work).await.is_err() {
+                    trace!("tun2socks: DNS task exceeded {:?}, aborting", DNS_TASK_TIMEOUT);
+                }
             });
             continue;
         }
@@ -829,6 +876,7 @@ async fn dispatch_udp(
     dst: SocketAddr,
     reply_tx: mpsc::Sender<UdpMsg>,
     reply_readers: Arc<Mutex<HashSet<(SocketAddr, SocketAddr)>>>,
+    permit: OwnedSemaphorePermit,
 ) {
     let Some(tunnel) = crate::engine::tunnel() else {
         logging::bridge_log("tun2socks: engine not running, dropping UDP datagram");
@@ -857,11 +905,20 @@ async fn dispatch_udp(
     //   2. `pre_resolve` — re-resolves the host (if any) through the engine
     //      resolver and re-populates `dst_ip` with the real upstream IP.
     //
-    // Both calls are idempotent — handle_udp invokes them again internally
-    // and they short-circuit on the already-populated metadata. The
-    // round-trip is unavoidable on this side because we need the resolved
-    // SocketAddr to key the reply-reader registry.
+    // Release the UDP burst-cap permit before pre_resolve. The permit's
+    // purpose is to bound the concurrent count of UDP *dispatch* tasks
+    // (handle_udp + NAT-insert work), not to gate DNS resolution. Holding
+    // it across pre_resolve means a slow upstream DNS shrinks the
+    // effective cap in proportion to the resolve latency — under a partial
+    // upstream outage the cap exhausts and new datagrams get silently
+    // dropped even though no real dispatch work is in flight.
+    //
+    // Both pre_* calls are idempotent — handle_udp invokes them again
+    // internally and they short-circuit on the already-populated metadata.
+    // The round-trip is unavoidable on this side because we need the
+    // resolved SocketAddr to key the reply-reader registry.
     tunnel.inner().pre_handle_metadata(&mut metadata);
+    drop(permit);
     tunnel.inner().pre_resolve(&mut metadata).await;
     let Some(resolved_ip) = metadata.dst_ip else {
         // Resolution failed — handle_udp will also bail, nothing to dispatch.


### PR DESCRIPTION
## Summary

### tun2socks backpressure audit
Three audit-driven fixes in `core/rust/mihomo-ios-ffi/src/tun2socks.rs`:
- **DNS handler bounded** at `DNS_BURST_CAP=256` + per-task 5s timeout. Previously every UDP/53 packet did an unbounded `tokio::spawn`; under a DNS storm this allocated unbounded tasks each holding the IP frame plus a potentially-blocking upstream resolve.
- **UDP burst-cap permit released before `pre_resolve.await`** in `dispatch_udp`. The permit now only covers the real `handle_udp` dispatch work, not the DNS round-trip — a slow upstream DNS no longer shrinks the effective cap.
- **Silent egress drops now surfaced in oslog** via `warn_capped` (1/s). The try_send into egress_tx_stack stays non-blocking (the stack driver can't await without freezing), but the previously-invisible drops on Swift writePackets backpressure are now diagnosable.

### iCloud / Files import
The Subscriptions toolbar `+` is now a menu: "Add from URL" / "Import from iCloud Drive…". The new path uses `.fileImporter`, reads under `startAccessingSecurityScopedResource`, normalizes the YAML through the existing pipeline, and stores a Profile with empty `url`. URL-less profiles hide the refresh button.

## Path B attestation
- [x] `swiftformat --lint .` — 0 violations
- [x] `swiftlint --strict` — 0 violations
- [x] `xcodebuild test -scheme meow-ios -only-testing:MeowTests` — all passed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 findings
- [x] `cargo test --lib` in core/rust/mihomo-ios-ffi — 30 passed
- [x] Build 2026051609 installed on device and uploaded to TestFlight; iCloud import flow exercised, backpressure changes running in the background.

## Test plan
- [ ] DNS-heavy load (Safari fresh-start fan-out) — watch oslog for `DNS burst cap reached` / `DNS task exceeded`; both should be rare under normal load.
- [ ] Flaky-proxy scenario where Swift writePackets stalls — watch oslog for `egress queue saturated`.
- [ ] Subscriptions → `+` → "Import from iCloud Drive…" → pick a YAML from iCloud Drive. Profile appears with the file basename, no refresh button on the row.
- [ ] Refresh on a URL-based profile still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)