### PR TITLE
chore: pin mihomo-rust v0.7.4 + PacketTunnel 40 MB self-restart

### DIFF
--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -17,6 +17,13 @@ static const uint8_t kDiagTagUser       = 0x02;
 static const uint8_t kDiagTagMemory     = 0x03;
 static const uint8_t kProxyTagSelect    = 0x04;
 
+// Pre-emptive process restart threshold. iOS jetsam kills NE extensions
+// around 50 MB phys_footprint; we self-restart at 40 MB so the kill is
+// orderly (writes a state row, logs a reason) instead of a silent jetsam.
+// 10 MB headroom absorbs the burst between the check tick and exit().
+static const uint64_t kMemoryRestartThresholdBytes = 40ULL * 1024ULL * 1024ULL;
+static const uint64_t kMemoryWatchdogIntervalNsec  = 2ULL * NSEC_PER_SEC;
+
 static os_log_t gLog;
 
 @implementation PacketTunnelProvider {
@@ -25,6 +32,7 @@ static os_log_t gLog;
     nw_path_monitor_t   _pathMonitor;
     dispatch_queue_t    _pathQueue;
     dispatch_source_t   _pathDebounceTimer;
+    dispatch_source_t   _memoryWatchdog;
     BOOL                _havePath;
     BOOL                _lastSatisfied;
     nw_interface_type_t _lastInterfaceType;
@@ -76,6 +84,7 @@ static os_log_t gLog;
             self->_ipcListener = listener;
 
             [self startPathMonitor];
+            [self startMemoryWatchdog];
 
             [self writeState:@"connected" profileID:profileID errorMessage:nil];
             completionHandler(nil);
@@ -87,6 +96,7 @@ static os_log_t gLog;
            completionHandler:(void (^)(void))completionHandler {
     os_log_info(gLog, "stopTunnel reason=%ld", (long)reason);
     [self stopPathMonitor];
+    [self stopMemoryWatchdog];
     [_engine stop];
     _engine = nil;
     [_ipcListener stop];
@@ -378,6 +388,75 @@ static os_log_t gLog;
                 errorMessage:@"reconnect after network change failed"];
         }
     }];
+}
+
+// MARK: - Memory watchdog
+//
+// Polls TASK_VM_INFO.phys_footprint (the same byte iOS jetsam compares against
+// the NE memory limit) on a background queue. When the footprint crosses
+// kMemoryRestartThresholdBytes, the extension restarts itself by calling
+// exit(0): NE respawns the process on the next packet / on-demand probe, and
+// the cumulative memory leaks (slab fragmentation, retained per-flow state,
+// rustls session caches) reset to a fresh baseline. Without this, growth
+// continues past 50 MB and iOS jetsam-kills the extension — silent from the
+// app's point of view, with no state row or log line.
+
+- (void)startMemoryWatchdog {
+    dispatch_queue_t q = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0);
+    dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, q);
+    dispatch_source_set_timer(timer,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)kMemoryWatchdogIntervalNsec),
+        kMemoryWatchdogIntervalNsec,
+        100 * NSEC_PER_MSEC);
+
+    __weak __typeof__(self) weak = self;
+    dispatch_source_set_event_handler(timer, ^{
+        __strong __typeof__(weak) self = weak;
+        if (!self) return;
+        [self checkMemoryFootprint];
+    });
+    _memoryWatchdog = timer;
+    dispatch_resume(timer);
+}
+
+- (void)stopMemoryWatchdog {
+    if (_memoryWatchdog) {
+        dispatch_source_cancel(_memoryWatchdog);
+        _memoryWatchdog = nil;
+    }
+}
+
+- (void)checkMemoryFootprint {
+    task_vm_info_data_t info;
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t kr = task_info(mach_task_self(),
+                                 TASK_VM_INFO,
+                                 (task_info_t)&info,
+                                 &count);
+    if (kr != KERN_SUCCESS) return;
+
+    uint64_t footprint = info.phys_footprint;
+    if (footprint < kMemoryRestartThresholdBytes) return;
+
+    os_log_fault(gLog,
+        "memory: phys_footprint=%llu bytes >= threshold=%llu bytes — restarting process",
+        footprint, kMemoryRestartThresholdBytes);
+
+    // Persist an audit row so the app can surface "restarted due to memory"
+    // on the next status read instead of presenting an unexplained
+    // disconnect. Tag is intentionally distinct from user-initiated "error".
+    [self writeState:@"error"
+           profileID:nil
+        errorMessage:[NSString stringWithFormat:
+                      @"restarted: memory %llu MB exceeded %llu MB cap",
+                      footprint / (1024ULL * 1024ULL),
+                      kMemoryRestartThresholdBytes / (1024ULL * 1024ULL)]];
+
+    // exit(0) is the only way to truly drop accumulated allocations. NE
+    // respawns the extension on the next demand (on-demand probe, app
+    // re-toggle). cancelTunnelWithError: would tear down the session but
+    // keep this same dirtied process alive for the next start cycle.
+    exit(0);
 }
 
 @end

--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -138,12 +138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,16 +488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,15 +516,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1075,35 +1050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2",
- "hickory-proto",
- "http",
- "idna",
- "ipnet",
- "jni",
- "rand 0.10.1",
- "rustls",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tokio-rustls",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hickory-proto"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,65 +1060,12 @@ dependencies = [
  "ipnet",
  "jni",
  "once_cell",
- "prefix-trie",
  "rand 0.10.1",
  "ring",
- "serde",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipconfig",
- "ipnet",
- "jni",
- "moka",
- "ndk-context",
- "once_cell",
- "parking_lot",
- "rand 0.10.1",
- "resolv-conf",
- "rustls",
- "smallvec",
- "system-configuration",
- "thiserror 2.0.18",
- "tokio",
- "tokio-rustls",
- "tracing",
-]
-
-[[package]]
-name = "hickory-server"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipnet",
- "prefix-trie",
- "serde",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1429,26 +1322,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2 0.6.3",
- "widestring",
- "windows-registry",
- "windows-result 0.4.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ipnetwork"
@@ -1709,8 +1586,8 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "axum",
  "base64",
@@ -1740,8 +1617,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1761,14 +1638,13 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "hickory-proto",
- "hickory-resolver",
  "ipnet",
  "maxminddb",
  "mihomo-common",
@@ -1788,24 +1664,27 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "dashmap 6.1.0",
  "futures",
- "hickory-resolver",
- "hickory-server",
+ "hickory-proto",
  "ipnet",
  "lru",
  "maxminddb",
  "mihomo-common",
  "mihomo-trie",
  "parking_lot",
+ "rand 0.9.4",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1841,8 +1720,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "async-trait",
  "base64",
@@ -1868,8 +1747,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1884,8 +1763,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "async-trait",
  "base64",
@@ -1906,13 +1785,13 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -1950,29 +1829,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
-]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netstack-smoltcp"
@@ -2035,15 +1891,6 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "objc2"
@@ -2215,17 +2062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prefix-trie"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
 ]
 
 [[package]]
@@ -2539,12 +2375,6 @@ dependencies = [
  "web-sys",
  "webpki-roots 1.0.7",
 ]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -3055,33 +2885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3554,7 +3357,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3776,12 +3578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,7 +3626,7 @@ checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.1.2",
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -3863,41 +3659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -138,12 +138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,16 +466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,15 +494,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1030,35 +1005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2",
- "hickory-proto",
- "http",
- "idna",
- "ipnet",
- "jni",
- "rand 0.10.1",
- "rustls",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tokio-rustls",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hickory-proto"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,65 +1015,12 @@ dependencies = [
  "ipnet",
  "jni",
  "once_cell",
- "prefix-trie",
  "rand 0.10.1",
  "ring",
- "serde",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipconfig",
- "ipnet",
- "jni",
- "moka",
- "ndk-context",
- "once_cell",
- "parking_lot",
- "rand 0.10.1",
- "resolv-conf",
- "rustls",
- "smallvec",
- "system-configuration",
- "thiserror 2.0.18",
- "tokio",
- "tokio-rustls",
- "tracing",
-]
-
-[[package]]
-name = "hickory-server"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipnet",
- "prefix-trie",
- "serde",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1384,26 +1277,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2 0.6.3",
- "widestring",
- "windows-registry",
- "windows-result 0.4.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ipnetwork"
@@ -1661,8 +1538,8 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mihomo-api"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "axum",
  "base64",
@@ -1692,8 +1569,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-common"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1713,14 +1590,13 @@ dependencies = [
 
 [[package]]
 name = "mihomo-config"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "hickory-proto",
- "hickory-resolver",
  "ipnet",
  "maxminddb",
  "mihomo-common",
@@ -1740,24 +1616,27 @@ dependencies = [
 
 [[package]]
 name = "mihomo-dns"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "dashmap 6.1.0",
  "futures",
- "hickory-resolver",
- "hickory-server",
+ "hickory-proto",
  "ipnet",
  "lru",
  "maxminddb",
  "mihomo-common",
  "mihomo-trie",
  "parking_lot",
+ "rand 0.9.4",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1795,8 +1674,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-proxy"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "async-trait",
  "base64",
@@ -1822,8 +1701,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-rules"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1838,8 +1717,8 @@ dependencies = [
 
 [[package]]
 name = "mihomo-transport"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "async-trait",
  "base64",
@@ -1860,13 +1739,13 @@ dependencies = [
 
 [[package]]
 name = "mihomo-trie"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 
 [[package]]
 name = "mihomo-tunnel"
-version = "0.7.3"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.3#0f182f4b48c6593d476e22012dc941f766cd4359"
+version = "0.7.4"
+source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.4#7b406f8aa418bb339f63ac16daabb1c66cf05b58"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -1904,29 +1783,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
-]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netstack-smoltcp"
@@ -1977,15 +1833,6 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "once_cell"
@@ -2142,17 +1989,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prefix-trie"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
 ]
 
 [[package]]
@@ -2466,12 +2302,6 @@ dependencies = [
  "web-sys",
  "webpki-roots 1.0.7",
 ]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -2981,33 +2811,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,7 +3283,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3702,12 +3504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3756,7 +3552,7 @@ checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.1.2",
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -3789,41 +3585,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -60,12 +60,12 @@ netstack-smoltcp = "0.2"
 # Embedded mihomo-rust engine. Pinned to a release tag; bump deliberately
 # rather than tracking main. Each crate is a workspace member of
 # madeye/mihomo-rust.
-mihomo-common = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.3" }
-mihomo-config = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.3" }
-mihomo-dns = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.3" }
-mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.3" }
-mihomo-api = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.3" }
-mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.3" }
+mihomo-common = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.4" }
+mihomo-config = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.4" }
+mihomo-dns = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.4" }
+mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.4" }
+mihomo-api = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.4" }
+mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.4" }
 
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that


### PR DESCRIPTION
## Summary
- Bump `mihomo-{common,config,dns,tunnel,api,proxy}` from v0.7.3 → v0.7.4.
- Add a phys_footprint watchdog in `PacketTunnelProvider`: every 2 s on a background timer it samples `TASK_VM_INFO.phys_footprint`; at ≥40 MB it writes an error state row ("restarted: memory NN MB exceeded 40 MB cap") and calls `exit(0)` so NE respawns the extension with a fresh heap. 10 MB headroom below the ~50 MB iOS jetsam cap turns silent jetsam kills into orderly, audit-trailed restarts.

## Local verification
- `cd core/rust/mihomo-ios-ffi && cargo check --lib` → ok
- `cd core/rust/mihomo-ios-ffi && cargo test --lib` → 30 passed
- `scripts/build-rust.sh` → xcframework written
- `xcodebuild build -scheme meow-ios -destination 'id=…iPhone 17 26.2'` → BUILD SUCCEEDED
- `swiftformat --lint .` → 0 violations
- `swiftlint --strict` → 0 violations
- `scripts/build-adhoc.sh --skip-rust-build` → IPA exported and installed on physical iPhone 17 Pro

## Test plan
- [ ] CI green
- [ ] On-device: confirm tunnel comes back after intentional memory growth crosses 40 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)