### PR TITLE
fix: DIRECT-rule TCP 断流 (dial watchdog + UDP first-reply + MTU/MSS clamp)

### DIFF
--- a/MeowCore/include/mihomo_core.h
+++ b/MeowCore/include/mihomo_core.h
@@ -240,6 +240,55 @@ int meow_tun_set_accept_cap(int cap);
 int meow_tun_accept_cap(void);
 
 /**
+ * Set the per-flow dial deadline, in milliseconds. Bounds the time
+ * `dispatch_tcp` waits for the relay's first byte of progress on the
+ * netstack stream before declaring the dial hung and dropping the
+ * future. See docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md
+ * for context.
+ *
+ * Default 10000 ms. Pass `0` to disable the watchdog (relies on the
+ * 30 s idle sweeper to reap stuck flows). Negative values are rejected.
+ *
+ * Takes effect on the next flow accepted; does not abort in-flight
+ * flows mid-wait.
+ *
+ * Returns 0 on success, -1 on invalid input.
+ */
+int meow_tun_set_dial_deadline_ms(int ms);
+
+/**
+ * Read the currently-configured per-flow dial deadline, in
+ * milliseconds. `0` means the watchdog is disabled.
+ */
+int meow_tun_dial_deadline_ms(void);
+
+/**
+ * Set the per-UDP-session first-reply deadline, in milliseconds. The
+ * symmetric counterpart to `meow_tun_set_dial_deadline_ms` for the UDP
+ * path — UDP doesn't connect, but iOS auto-bypass can silently drop
+ * the outbound sendto when the scoped-routing cache is stale, leaving
+ * the reply reader parked on `read_packet` forever. Bounding the
+ * *first* reply lets us evict a dead session so the next app datagram
+ * dispatches a fresh socket against a refreshed iOS route.
+ *
+ * Default 10000 ms. Pass `0` to disable the deadline (legacy unbounded
+ * behaviour — relies on mihomo's NAT-table TTL to reap idle sessions).
+ * Negative values are rejected.
+ *
+ * Takes effect on the next UDP session whose reply reader spawns;
+ * existing readers keep their captured deadline.
+ *
+ * Returns 0 on success, -1 on invalid input.
+ */
+int meow_tun_set_udp_first_reply_deadline_ms(int ms);
+
+/**
+ * Read the currently-configured UDP first-reply deadline, in
+ * milliseconds. `0` means the deadline is disabled.
+ */
+int meow_tun_udp_first_reply_deadline_ms(void);
+
+/**
  * Resident memory size of the FFI's containing process, in bytes. Same
  * number macOS jetsam compares against the 50 MiB PacketTunnel cap, so
  * Swift can poll this to chart the on-device RSS curve during a stress

--- a/PacketTunnel/Sources/MWTunnelSettings.m
+++ b/PacketTunnel/Sources/MWTunnelSettings.m
@@ -26,7 +26,22 @@
     NEDNSSettings *dns = [[NEDNSSettings alloc] initWithServers:@[@"172.19.0.2"]];
     settings.DNSSettings = dns;
 
-    settings.MTU = @1500;
+    // Conservative MSS clamp for PMTU black-holes on the upstream side.
+    // The app's TCP stack derives MSS from this MTU (1400 - 40 = 1360),
+    // so all payloads entering the TUN are ≤1360 bytes. When mihomo
+    // re-emits them on a real upstream socket, the kernel's outbound
+    // segment fits inside even pathological path MTUs (1428 on some
+    // cellular carriers, 1380 on iCloud Private Relay-style paths, etc.)
+    // without needing PMTUD — which routinely black-holes on CN routes
+    // where ICMP Fragmentation Needed is filtered.
+    //
+    // 1400 matches the conservative default used by Surge / Quantumult X
+    // / Loon. The ~6% throughput overhead on Wi-Fi paths that didn't
+    // need the clamp is the price for not relying on PMTUD.
+    //
+    // Follow-up: dynamic clamping via NWPathMonitor + getifaddrs/
+    // SIOCGIFMTU on the primary interface — see investigation doc.
+    settings.MTU = @1400;
     return settings;
 }
 

--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -1616,7 +1616,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "mihomo-api"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 dependencies = [
  "axum",
  "base64",
@@ -1647,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "mihomo-common"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "mihomo-config"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "mihomo-dns"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 dependencies = [
  "dashmap 6.1.0",
  "futures",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "mihomo-proxy"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 dependencies = [
  "async-trait",
  "base64",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "mihomo-rules"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1796,7 +1796,7 @@ dependencies = [
 [[package]]
 name = "mihomo-transport"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 dependencies = [
  "async-trait",
  "base64",
@@ -1821,12 +1821,12 @@ dependencies = [
 [[package]]
 name = "mihomo-trie"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 
 [[package]]
 name = "mihomo-tunnel"
 version = "0.7.6"
-source = "git+https://github.com/madeye/mihomo-rust?tag=v0.7.6#835b1bc160d6dbb75e91cc9d3cef37073c8b3d4b"
+source = "git+https://github.com/madeye/mihomo-rust?rev=0b98528739cde500a9bf92858f95bdf2cff92c7f#0b98528739cde500a9bf92858f95bdf2cff92c7f"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",

--- a/core/rust/mihomo-ios-ffi/Cargo.lock
+++ b/core/rust/mihomo-ios-ffi/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "netstack-smoltcp"
 version = "0.2.1"
-source = "git+https://github.com/madeye/netstack-smoltcp?branch=feat%2Faggressive-recycle#e2069235d8f0f649d7f4979ce21250526145d86b"
+source = "git+https://github.com/madeye/netstack-smoltcp?branch=feat%2Faggressive-recycle#16e87596e6e537c99017cdc772416ef2c479a091"
 dependencies = [
  "etherparse",
  "futures",
@@ -1905,7 +1905,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2446,7 +2446,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2807,7 +2807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2911,7 +2911,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3627,7 +3627,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -57,10 +57,16 @@ urlencoding = "2"
 # tun2socks
 netstack-smoltcp = "0.2"
 
-# Embedded mihomo-rust engine. Pinned to a release tag; bump deliberately
-# rather than tracking main. Each crate is a workspace member of
-# madeye/mihomo-rust.
-mihomo-common = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.6" }
+# Embedded mihomo-rust engine. Pinned to a release tag normally; bump
+# deliberately rather than tracking main. Each crate is a workspace
+# member of madeye/mihomo-rust.
+#
+# Currently on a post-v0.7.6 `rev =` pin to pick up
+# `DirectAdapter::with_connect_timeout` (madeye/mihomo-rust#86), which
+# bounds `TcpStream::connect` to address the DIRECT-rule TCP hang
+# documented in docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md.
+# Restore to a tag once a v0.7.7+ release is cut.
+mihomo-common = { git = "https://github.com/madeye/mihomo-rust", rev = "0b98528739cde500a9bf92858f95bdf2cff92c7f" }
 # `boring-tls` activates BoringSSL-backed TLS in mihomo-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -68,11 +74,11 @@ mihomo-common = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.6" 
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-mihomo-config = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.6", features = ["boring-tls"] }
-mihomo-dns = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.6" }
-mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.6" }
-mihomo-api = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.6" }
-mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", tag = "v0.7.6" }
+mihomo-config = { git = "https://github.com/madeye/mihomo-rust", rev = "0b98528739cde500a9bf92858f95bdf2cff92c7f", features = ["boring-tls"] }
+mihomo-dns = { git = "https://github.com/madeye/mihomo-rust", rev = "0b98528739cde500a9bf92858f95bdf2cff92c7f" }
+mihomo-tunnel = { git = "https://github.com/madeye/mihomo-rust", rev = "0b98528739cde500a9bf92858f95bdf2cff92c7f" }
+mihomo-api = { git = "https://github.com/madeye/mihomo-rust", rev = "0b98528739cde500a9bf92858f95bdf2cff92c7f" }
+mihomo-proxy = { git = "https://github.com/madeye/mihomo-rust", rev = "0b98528739cde500a9bf92858f95bdf2cff92c7f" }
 
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that

--- a/core/rust/mihomo-ios-ffi/Cargo.toml
+++ b/core/rust/mihomo-ios-ffi/Cargo.toml
@@ -104,6 +104,12 @@ cbindgen = "0.28"
 # fixture MMDB directly and prove the env-derived path resolves correctly.
 tempfile = "3"
 maxminddb = "0.27"
+# `test-util` enables `#[tokio::test(start_paused = true)]`, which gives
+# the dial-watchdog regression tests virtual time. Without it the tests
+# would either block on real wall-clock sleeps (slow CI) or shrink their
+# budgets so far they'd flake under load. Dev-only — production builds
+# don't pull `test-util` so the time skew never reaches a real device.
+tokio = { version = "1", features = ["test-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 
 [profile.release]
 # Shrink binary for the 50MB extension budget. mihomo-rust adds significant

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -671,6 +671,39 @@ pub extern "C" fn meow_tun_dial_deadline_ms() -> c_int {
     tun2socks::dial_deadline_ms() as c_int
 }
 
+/// Set the per-UDP-session first-reply deadline, in milliseconds. The
+/// symmetric counterpart to `meow_tun_set_dial_deadline_ms` for the UDP
+/// path — UDP doesn't connect, but iOS auto-bypass can silently drop
+/// the outbound sendto when the scoped-routing cache is stale, leaving
+/// the reply reader parked on `read_packet` forever. Bounding the
+/// *first* reply lets us evict a dead session so the next app datagram
+/// dispatches a fresh socket against a refreshed iOS route.
+///
+/// Default 10000 ms. Pass `0` to disable the deadline (legacy unbounded
+/// behaviour — relies on mihomo's NAT-table TTL to reap idle sessions).
+/// Negative values are rejected.
+///
+/// Takes effect on the next UDP session whose reply reader spawns;
+/// existing readers keep their captured deadline.
+///
+/// Returns 0 on success, -1 on invalid input.
+#[no_mangle]
+pub extern "C" fn meow_tun_set_udp_first_reply_deadline_ms(ms: c_int) -> c_int {
+    if ms < 0 {
+        set_error("udp first-reply deadline must be >= 0".into());
+        return -1;
+    }
+    tun2socks::set_udp_first_reply_deadline_ms(ms as u64);
+    0
+}
+
+/// Read the currently-configured UDP first-reply deadline, in
+/// milliseconds. `0` means the deadline is disabled.
+#[no_mangle]
+pub extern "C" fn meow_tun_udp_first_reply_deadline_ms() -> c_int {
+    tun2socks::udp_first_reply_deadline_ms() as c_int
+}
+
 /// Resident memory size of the FFI's containing process, in bytes. Same
 /// number macOS jetsam compares against the 50 MiB PacketTunnel cap, so
 /// Swift can poll this to chart the on-device RSS curve during a stress

--- a/core/rust/mihomo-ios-ffi/src/lib.rs
+++ b/core/rust/mihomo-ios-ffi/src/lib.rs
@@ -641,6 +641,36 @@ pub extern "C" fn meow_tun_accept_cap() -> c_int {
     tun2socks::accept_cap() as c_int
 }
 
+/// Set the per-flow dial deadline, in milliseconds. Bounds the time
+/// `dispatch_tcp` waits for the relay's first byte of progress on the
+/// netstack stream before declaring the dial hung and dropping the
+/// future. See docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md
+/// for context.
+///
+/// Default 10000 ms. Pass `0` to disable the watchdog (relies on the
+/// 30 s idle sweeper to reap stuck flows). Negative values are rejected.
+///
+/// Takes effect on the next flow accepted; does not abort in-flight
+/// flows mid-wait.
+///
+/// Returns 0 on success, -1 on invalid input.
+#[no_mangle]
+pub extern "C" fn meow_tun_set_dial_deadline_ms(ms: c_int) -> c_int {
+    if ms < 0 {
+        set_error("dial deadline must be >= 0".into());
+        return -1;
+    }
+    tun2socks::set_dial_deadline_ms(ms as u64);
+    0
+}
+
+/// Read the currently-configured per-flow dial deadline, in
+/// milliseconds. `0` means the watchdog is disabled.
+#[no_mangle]
+pub extern "C" fn meow_tun_dial_deadline_ms() -> c_int {
+    tun2socks::dial_deadline_ms() as c_int
+}
+
 /// Resident memory size of the FFI's containing process, in bytes. Same
 /// number macOS jetsam compares against the 50 MiB PacketTunnel cap, so
 /// Swift can poll this to chart the on-device RSS curve during a stress

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -171,6 +171,40 @@ pub fn dial_deadline_ms() -> u64 {
     DIAL_DEADLINE_MS.load(Ordering::Relaxed)
 }
 
+// Per-UDP-session first-reply deadline. The symmetric counterpart to
+// DIAL_DEADLINE_MS for the UDP path. UDP doesn't connect, so there's no
+// `TcpStream::connect` hang to bound — but iOS auto-bypass can silently
+// drop the outbound sendto when the kernel's scoped-routing cache is
+// stale, in which case the upstream never sees the datagram and the
+// reply reader sits forever on `session.conn.read_packet`. With this
+// deadline, a session that produces zero replies within the budget is
+// evicted from `nat_table` + `reply_readers`, so the next app datagram
+// dispatches a fresh socket against (hopefully) a refreshed iOS route.
+//
+// 10 s default to match TCP's `DIAL_DEADLINE_MS`. The cost for legit
+// no-reply UDP traffic (fire-and-forget telemetry, mDNS) is a
+// dispatch + bind churn every 10 s — negligible relative to even a
+// single round-trip's allocation cost. Tunable at runtime via
+// [`set_udp_first_reply_deadline_ms`] / `meow_tun_set_udp_first_reply_deadline_ms`;
+// set to 0 to opt out.
+const UDP_FIRST_REPLY_DEADLINE_MS_DEFAULT: u64 = 10_000;
+static UDP_FIRST_REPLY_DEADLINE_MS: AtomicU64 =
+    AtomicU64::new(UDP_FIRST_REPLY_DEADLINE_MS_DEFAULT);
+
+/// Set the per-UDP-session first-reply deadline, in milliseconds. `0`
+/// disables the deadline (legacy unbounded behaviour). Returns true
+/// unconditionally.
+pub fn set_udp_first_reply_deadline_ms(ms: u64) -> bool {
+    UDP_FIRST_REPLY_DEADLINE_MS.store(ms, Ordering::Relaxed);
+    true
+}
+
+/// Read the currently-configured UDP first-reply deadline, in
+/// milliseconds. `0` means the watchdog is disabled.
+pub fn udp_first_reply_deadline_ms() -> u64 {
+    UDP_FIRST_REPLY_DEADLINE_MS.load(Ordering::Relaxed)
+}
+
 // Sweep window. Tightened from 90 / 30 s to 30 / 10 s: dead-flow state
 // holds for at most one sweep interval past the idle deadline, so the
 // post-burst tail (~50 s in the 10-min stress run) is what we're trying
@@ -1145,9 +1179,39 @@ fn spawn_udp_reply_reader(
         // 1500-MTU tun without fragmentation; oversized datagrams are
         // truncated at the read, which matches the on-wire reality.
         let mut buf = vec![0u8; 4 * 1024];
+        // First-reply deadline: see UDP_FIRST_REPLY_DEADLINE_MS docs.
+        // Only the *first* read is bounded — once a reply has come back
+        // we know the route is alive and we don't want to evict an
+        // active session on quiet idle periods (long-poll, NAT keepalive).
+        let first_reply_deadline_ms = UDP_FIRST_REPLY_DEADLINE_MS.load(Ordering::Relaxed);
+        let mut had_first_reply = false;
         loop {
-            match session.conn.read_packet(&mut buf).await {
+            let read = if !had_first_reply && first_reply_deadline_ms > 0 {
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(first_reply_deadline_ms),
+                    session.conn.read_packet(&mut buf),
+                )
+                .await
+                {
+                    Ok(res) => res,
+                    Err(_) => {
+                        warn!(
+                            "UDP first-reply deadline exceeded for {:?} after {} ms; evicting session",
+                            key, first_reply_deadline_ms,
+                        );
+                        logging::bridge_log(&format!(
+                            "tun2socks: UDP first-reply-deadline {:?} ({} ms)",
+                            key, first_reply_deadline_ms,
+                        ));
+                        break;
+                    }
+                }
+            } else {
+                session.conn.read_packet(&mut buf).await
+            };
+            match read {
                 Ok((n, _from)) => {
+                    had_first_reply = true;
                     // Reply injection: the IP frame handed back to the app
                     // must look like it came FROM the external peer (app_dst)
                     // TO the app (app_src). netstack's Sink builds the header
@@ -1874,5 +1938,19 @@ mod tests {
         // Restore so other parallel tests that may sample the knob see the
         // configured default.
         set_dial_deadline_ms(prev);
+    }
+
+    #[test]
+    fn udp_first_reply_deadline_ms_roundtrip_and_zero_disables() {
+        let prev = udp_first_reply_deadline_ms();
+        assert!(set_udp_first_reply_deadline_ms(4_200));
+        assert_eq!(udp_first_reply_deadline_ms(), 4_200);
+        assert!(set_udp_first_reply_deadline_ms(0));
+        assert_eq!(
+            udp_first_reply_deadline_ms(),
+            0,
+            "0 must be accepted to opt out"
+        );
+        set_udp_first_reply_deadline_ms(prev);
     }
 }

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -425,6 +425,10 @@ async fn run_tun2socks(
 ) -> io::Result<()> {
     logging::bridge_log("tun2socks: building netstack-smoltcp stack");
 
+    // MTU is hardcoded inside the fork at 1500 (see madeye/netstack-smoltcp
+    // `fix/ios-mtu-1500`) to match `NEPacketTunnelNetworkSettings.MTU`
+    // (`MWTunnelSettings.m`). The builder doesn't expose `mtu()` so we
+    // rely on the device-level default.
     let (mut stack, tcp_runner, udp_socket, tcp_listener) = StackBuilder::default()
         .enable_tcp(true)
         .enable_udp(true)

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -137,6 +137,40 @@ pub fn accept_cap() -> usize {
     TCP_ACCEPT_CAP.load(Ordering::Relaxed)
 }
 
+// Per-flow dial deadline. Bounds the time `dispatch_tcp` waits for the
+// relay's first byte of progress on the netstack stream before declaring
+// the dial hung and dropping the future. See
+// docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md for the
+// failure mode: `DirectAdapter::dial_tcp` awaits `TcpStream::connect`
+// with no timeout, and an iOS reachability-cache / scoped-routing
+// transient can leave the connect hanging until the 30 s idle sweeper
+// reaps the flow. With the deadline, the app sees a RST in
+// `DIAL_DEADLINE_MS` ms instead of 30 s, the `tcp_accept_sem` permit is
+// released promptly, and `ConnectionGuard`'s Drop runs the mihomo
+// session cleanup on the discarded future.
+//
+// 10 s default: safely above cold cellular handshakes against distant
+// CN PoPs (~5-8 s observed) and below Mobile Safari's ~12 s
+// request-timeout floor, so the app's own retry loop kicks in.
+// Tunable at runtime via [`set_dial_deadline_ms`] /
+// `meow_tun_set_dial_deadline_ms` — set to 0 to disable the watchdog.
+const DIAL_DEADLINE_MS_DEFAULT: u64 = 10_000;
+static DIAL_DEADLINE_MS: AtomicU64 = AtomicU64::new(DIAL_DEADLINE_MS_DEFAULT);
+
+/// Set the per-flow dial deadline, in milliseconds. `0` disables the
+/// deadline (no watchdog — flows that hang in `dial_tcp` will only be
+/// reaped by the 30 s idle sweeper). Returns true unconditionally.
+pub fn set_dial_deadline_ms(ms: u64) -> bool {
+    DIAL_DEADLINE_MS.store(ms, Ordering::Relaxed);
+    true
+}
+
+/// Read the currently-configured dial deadline, in milliseconds. `0`
+/// means the watchdog is disabled.
+pub fn dial_deadline_ms() -> u64 {
+    DIAL_DEADLINE_MS.load(Ordering::Relaxed)
+}
+
 // Sweep window. Tightened from 90 / 30 s to 30 / 10 s: dead-flow state
 // holds for at most one sweep interval past the idle deadline, so the
 // post-burst tail (~50 s in the 10-min stress run) is what we're trying
@@ -740,6 +774,17 @@ async fn dispatch_tcp(
         ..Default::default()
     };
 
+    // Snapshot the FlowState's accept-time stamp before the relay future
+    // even runs. `IdleTracking::touch` rewrites `last_active_ms` on the
+    // first successful poll, which only happens after
+    // `mihomo_tunnel::tcp::handle_tcp` → `pre_handle_metadata` →
+    // `pre_resolve` → `proxy.dial_tcp` returns and `copy_bidirectional_buf`
+    // starts reading. So "`last_active_ms` is still equal to the snapshot"
+    // is a precise proxy for "the dial hasn't completed yet."
+    let accepted_at_ms = state.last_active_ms.load(Ordering::Relaxed);
+    let dial_deadline = DIAL_DEADLINE_MS.load(Ordering::Relaxed);
+    let watchdog_state = state.clone();
+
     let local_eof = Arc::new(Notify::new());
     let conn: Box<dyn ProxyConn> = Box::new(IdleTracking {
         inner: NetstackConn(stream),
@@ -768,6 +813,47 @@ async fn dispatch_tcp(
     // `ConnectionGuard` is RAII and runs on the dropped future.
     let fut = mihomo_tunnel::tcp::handle_tcp(tunnel.inner(), conn, metadata);
     tokio::pin!(fut);
+
+    // Dial-deadline watchdog (see DIAL_DEADLINE_MS docs above). `0` opts
+    // out entirely. Otherwise the watchdog polls FlowState every 500 ms;
+    // once the relay starts (`last_active_ms` advances past
+    // `accepted_at_ms`), the watchdog parks forever and the relay future
+    // owns the lifetime. If the deadline expires with no progress, the
+    // watchdog resolves, the `select!` arm fires, and dropping `fut` runs
+    // `ConnectionGuard::Drop` (mihomo session cleanup) and releases the
+    // `tcp_accept_sem` permit through the spawned task's exit.
+    let dial_watchdog = {
+        let state = watchdog_state;
+        async move {
+            if dial_deadline == 0 {
+                std::future::pending::<()>().await;
+                return;
+            }
+            let deadline =
+                tokio::time::Instant::now() + std::time::Duration::from_millis(dial_deadline);
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                if state.last_active_ms.load(Ordering::Relaxed) > accepted_at_ms {
+                    // Relay started — dial succeeded. Park; the relay
+                    // future now controls the task's lifetime.
+                    std::future::pending::<()>().await;
+                    return;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    // Final re-check to close the tick-to-deadline race:
+                    // touch() could have fired in the sleep wake-up
+                    // between the load above and the deadline check.
+                    if state.last_active_ms.load(Ordering::Relaxed) > accepted_at_ms {
+                        std::future::pending::<()>().await;
+                        return;
+                    }
+                    return;
+                }
+            }
+        }
+    };
+    tokio::pin!(dial_watchdog);
+
     tokio::select! {
         biased;
         _ = &mut fut => {}
@@ -781,6 +867,18 @@ async fn dispatch_tcp(
                 std::time::Duration::from_millis(250),
                 &mut fut,
             ).await;
+        }
+        _ = &mut dial_watchdog => {
+            warn!(
+                "tun2socks: dial deadline exceeded for {} -> {} after {} ms; dropping flow",
+                src, dst, dial_deadline,
+            );
+            logging::bridge_log(&format!(
+                "tun2socks: TCP dial-deadline {} -> {} ({} ms)",
+                src, dst, dial_deadline,
+            ));
+            // Drop `fut` on exit → mihomo `ConnectionGuard` cleanup runs,
+            // accept_sem permit released via the spawned task's exit.
         }
     }
 }
@@ -1638,5 +1736,19 @@ mod tests {
         assert!(flows.is_empty(), "registry should be empty after close-all");
 
         flows.clear();
+    }
+
+    #[test]
+    fn dial_deadline_ms_roundtrip_and_zero_disables() {
+        let prev = dial_deadline_ms();
+        // Default initial value matches the documented threshold.
+        // (Other tests don't touch this knob, so the first read sees it.)
+        assert!(set_dial_deadline_ms(7_500));
+        assert_eq!(dial_deadline_ms(), 7_500);
+        assert!(set_dial_deadline_ms(0));
+        assert_eq!(dial_deadline_ms(), 0, "0 must be accepted to opt out");
+        // Restore so other parallel tests that may sample the knob see the
+        // configured default.
+        set_dial_deadline_ms(prev);
     }
 }

--- a/core/rust/mihomo-ios-ffi/src/tun2socks.rs
+++ b/core/rust/mihomo-ios-ffi/src/tun2socks.rs
@@ -814,44 +814,9 @@ async fn dispatch_tcp(
     let fut = mihomo_tunnel::tcp::handle_tcp(tunnel.inner(), conn, metadata);
     tokio::pin!(fut);
 
-    // Dial-deadline watchdog (see DIAL_DEADLINE_MS docs above). `0` opts
-    // out entirely. Otherwise the watchdog polls FlowState every 500 ms;
-    // once the relay starts (`last_active_ms` advances past
-    // `accepted_at_ms`), the watchdog parks forever and the relay future
-    // owns the lifetime. If the deadline expires with no progress, the
-    // watchdog resolves, the `select!` arm fires, and dropping `fut` runs
-    // `ConnectionGuard::Drop` (mihomo session cleanup) and releases the
-    // `tcp_accept_sem` permit through the spawned task's exit.
-    let dial_watchdog = {
-        let state = watchdog_state;
-        async move {
-            if dial_deadline == 0 {
-                std::future::pending::<()>().await;
-                return;
-            }
-            let deadline =
-                tokio::time::Instant::now() + std::time::Duration::from_millis(dial_deadline);
-            loop {
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                if state.last_active_ms.load(Ordering::Relaxed) > accepted_at_ms {
-                    // Relay started — dial succeeded. Park; the relay
-                    // future now controls the task's lifetime.
-                    std::future::pending::<()>().await;
-                    return;
-                }
-                if tokio::time::Instant::now() >= deadline {
-                    // Final re-check to close the tick-to-deadline race:
-                    // touch() could have fired in the sleep wake-up
-                    // between the load above and the deadline check.
-                    if state.last_active_ms.load(Ordering::Relaxed) > accepted_at_ms {
-                        std::future::pending::<()>().await;
-                        return;
-                    }
-                    return;
-                }
-            }
-        }
-    };
+    // Dial-deadline watchdog (see DIAL_DEADLINE_MS docs above and
+    // `run_dial_watchdog` for the actual polling logic).
+    let dial_watchdog = run_dial_watchdog(watchdog_state, accepted_at_ms, dial_deadline);
     tokio::pin!(dial_watchdog);
 
     tokio::select! {
@@ -879,6 +844,57 @@ async fn dispatch_tcp(
             ));
             // Drop `fut` on exit → mihomo `ConnectionGuard` cleanup runs,
             // accept_sem permit released via the spawned task's exit.
+        }
+    }
+}
+
+/// Dial-deadline watchdog body. Resolves when the per-flow dial has been
+/// idle past the budget; parks forever once the relay starts so the
+/// `select!` arm in `dispatch_tcp` lets the relay future own the rest of
+/// the lifetime.
+///
+/// `dial_deadline_ms == 0` opts out (watchdog parks forever, behaviour
+/// matches the pre-fix pipeline that relied solely on the 30 s idle
+/// sweeper). Otherwise the watchdog ticks every 500 ms — fine grained
+/// enough to make sub-second `dial_deadline_ms` settings (used by tests)
+/// converge in <=2 ticks, coarse enough not to be a measurable wake-up
+/// cost under steady state.
+///
+/// Factored out of `dispatch_tcp` so unit tests can drive it without
+/// standing up the engine, netstack, and tcp-listener plumbing the
+/// real call site requires. See the `dial_watchdog_*` tests at the
+/// bottom of this file for the contract pinned in CI.
+async fn run_dial_watchdog(
+    state: Arc<FlowState>,
+    accepted_at_ms: u64,
+    dial_deadline_ms: u64,
+) {
+    if dial_deadline_ms == 0 {
+        std::future::pending::<()>().await;
+        return;
+    }
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(dial_deadline_ms);
+    loop {
+        // 500 ms is the longest a sub-second deadline can wait without
+        // overshooting the budget by more than one tick. Pick something
+        // smaller (say 100 ms) only if test flakiness from the 500 ms
+        // floor becomes a real issue.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        if state.last_active_ms.load(Ordering::Relaxed) > accepted_at_ms {
+            // Relay started — dial succeeded. Park; the relay future
+            // now controls the task's lifetime.
+            std::future::pending::<()>().await;
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            // Final re-check to close the tick-to-deadline race: touch()
+            // could have fired in the sleep wake-up between the load
+            // above and the deadline check.
+            if state.last_active_ms.load(Ordering::Relaxed) > accepted_at_ms {
+                std::future::pending::<()>().await;
+                return;
+            }
+            return;
         }
     }
 }
@@ -1736,6 +1752,114 @@ mod tests {
         assert!(flows.is_empty(), "registry should be empty after close-all");
 
         flows.clear();
+    }
+
+    /// Tier 3 regression harness — see
+    /// `docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md`.
+    ///
+    /// Models the failure mode that operators reported as 断流: the
+    /// upstream relay never starts (e.g. `DirectAdapter::dial_tcp`'s
+    /// underlying `TcpStream::connect` is hung on a TEST-NET-1
+    /// black-hole / iOS routing-cache transient), so
+    /// `IdleTracking::touch` never runs and `FlowState.last_active_ms`
+    /// stays frozen at its accept-time value. The watchdog must reap
+    /// the flow within the configured `dial_deadline_ms` budget rather
+    /// than waiting on the 30 s idle sweeper.
+    #[tokio::test(start_paused = true)]
+    async fn dial_watchdog_fires_when_relay_never_starts() {
+        let now = now_ms();
+        let state = Arc::new(FlowState {
+            last_active_ms: AtomicU64::new(now),
+        });
+
+        let started = tokio::time::Instant::now();
+        // Run with a 750 ms deadline (chosen above the 500 ms tick floor
+        // so we hit exactly one tick before the deadline check) and
+        // assert it resolves within a generous bound.
+        let outer = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            run_dial_watchdog(state.clone(), now, 750),
+        )
+        .await;
+
+        assert!(
+            outer.is_ok(),
+            "watchdog did not resolve within outer 3 s guard — regression"
+        );
+        let elapsed = started.elapsed();
+        // Sub-1500 ms upper bound: the watchdog should fire after at most
+        // ⌈750 / 500⌉ = 2 sleep ticks (1000 ms) plus the final re-check.
+        assert!(
+            elapsed < std::time::Duration::from_millis(1_500),
+            "watchdog took {:?}, expected <1.5 s with a 750 ms deadline",
+            elapsed
+        );
+        // The watchdog must not mutate `last_active_ms` — that's the
+        // relay's job. Pin the contract so a future refactor can't
+        // accidentally trample the field and mask a dial-hang regression.
+        assert_eq!(state.last_active_ms.load(Ordering::Relaxed), now);
+    }
+
+    /// Mirror of the above for the "dial succeeded normally" case: the
+    /// relay advances `last_active_ms` before the deadline expires, and
+    /// the watchdog must park forever (i.e. not return) so the relay
+    /// future owns the rest of the flow's lifetime. Drives the same
+    /// `select!`-arm semantics as `dispatch_tcp` without standing up
+    /// the netstack.
+    #[tokio::test(start_paused = true)]
+    async fn dial_watchdog_parks_when_relay_starts_in_time() {
+        let now = now_ms();
+        let state = Arc::new(FlowState {
+            last_active_ms: AtomicU64::new(now),
+        });
+
+        // Bump `last_active_ms` after 200 ms — simulates the first
+        // `IdleTracking::touch()` once the relay reads the app's first
+        // payload. The watchdog should observe the advance on its first
+        // 500 ms tick and park.
+        let state_for_bump = state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            state_for_bump
+                .last_active_ms
+                .store(now + 1, Ordering::Relaxed);
+        });
+
+        // 750 ms deadline; outer 2 s guard. If the watchdog mistakenly
+        // returns despite the bump, the outer timeout doesn't fire and
+        // `outer.is_err()` fails.
+        let outer = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            run_dial_watchdog(state, now, 750),
+        )
+        .await;
+        assert!(
+            outer.is_err(),
+            "watchdog returned despite the relay starting before the deadline — regression",
+        );
+    }
+
+    /// `dial_deadline_ms == 0` is the documented opt-out: the watchdog
+    /// must never fire, even if the relay never starts. Falls back to
+    /// the 30 s idle sweeper as the only line of defence.
+    #[tokio::test(start_paused = true)]
+    async fn dial_watchdog_zero_deadline_opts_out() {
+        let now = now_ms();
+        let state = Arc::new(FlowState {
+            last_active_ms: AtomicU64::new(now),
+        });
+
+        // 5 s outer guard with a 0 deadline: the watchdog should never
+        // resolve in that window.
+        let outer = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            run_dial_watchdog(state, now, 0),
+        )
+        .await;
+        assert!(
+            outer.is_err(),
+            "0-ms deadline must opt out of the watchdog (parked forever)",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Multi-pronged fix for the long-standing DIRECT-rule TCP 断流 reported by operators (3WHS completes, no upstream bytes flow, app sees a 30 s hang). Investigation in [docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md](../blob/main/docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md). The persistent failure mode after the original watchdog landed turned out to be **PMTU black-holing on the upstream side** — confirmed fixed by user testing on cellular.

## What's in this PR

### Tier 1 — FFI-side dial watchdog (`05b15e7`, `ed0253e`, `5765505`)
- New `run_dial_watchdog` in `dispatch_tcp` that snapshots `FlowState.last_active_ms` at accept and resolves if no relay progress is observed within `DIAL_DEADLINE_MS` (default 10 s, runtime-tunable via `meow_tun_set_dial_deadline_ms`).
- On expiry: drop the relay future → `ConnectionGuard::Drop` runs mihomo session cleanup → `tcp_accept_sem` permit released → app sees RST in 10 s instead of 30 s.
- 3 unit tests under virtual time (start_paused) pin the contract: fires-on-stall, parks-on-relay-start, 0-ms opts out.

### Tier 2 — Upstream `mihomo-rust` connect-timeout (`3d7328a`)
- Pin all six `mihomo-*` deps to `rev = 0b98528739...` to pick up [madeye/mihomo-rust#86](https://github.com/madeye/mihomo-rust/pull/86) (`DirectAdapter::with_connect_timeout`). API compiles in but not yet wired (YAML knob is a separate upstream PR).

### Tier 3 — UDP first-reply deadline (`1ed1d36`)
- Symmetric counterpart for QUIC/HTTP3: bounds the *first* `read_packet` in `spawn_udp_reply_reader` so a session whose outbound sendto was silently dropped by iOS auto-bypass gets evicted (default 10 s, tunable via `meow_tun_set_udp_first_reply_deadline_ms`, `0` opts out).

### MTU alignment (`e8d84c7`)
- Bump netstack-smoltcp fork from `e2069235` → `16e87596` (`madeye/netstack-smoltcp#fix/ios-mtu-1500`). Drops the stack's hardcoded MTU from 1504 ("1500+4 for VLAN") to **1500** for a raw-IP TUN.

### TUN MTU clamp to 1400 (`bec4d14`) — the actual 断流 fix
- `NEPacketTunnelNetworkSettings.MTU` was 1500 → **1400**. iOS app's TCP stack now advertises MSS=1360 at the SYN boundary. All payloads entering the TUN are small enough that mihomo's upstream socket emits segments fitting inside even pathological cellular path MTUs (1428, 1380, etc.) without relying on PMTUD — which routinely black-holes on CN routes where ICMP Frag-Needed is filtered.
- Same conservative default Surge / Quantumult X / Loon ship. ~6% throughput overhead on Wi-Fi paths that didn't need the clamp.
- Follow-up: dynamic clamping via `NWPathMonitor` + `getifaddrs/SIOCGIFMTU` to recover Wi-Fi overhead.

## Path B attestation (per CLAUDE.md)

- [x] **`swiftformat --lint .`** at repo root → **0 violations** (`SwiftFormat completed in 0.91s. 0/89 files require formatting`).
- [x] **`swiftlint --strict`** at repo root → **0 violations, 0 serious in 80 files**.
- [x] **`xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:MeowTests`** → **TEST SUCCEEDED**.
- [x] **Rust:** `cargo build --lib`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` in `core/rust/mihomo-ios-ffi/` → **35/35 pass, clippy clean**. `scripts/build-rust.sh` ran as part of `scripts/build-adhoc.sh` (used to build the verification IPA) → **clean release build**.
- [x] **`git diff origin/main...HEAD --stat`** verified — 6 files, all intended (FFI Rust + cbindgen header sync + tunnel-settings ObjC + dep manifests).

## Verification

User-confirmed fix on iPhone 17 Pro (iOS 26) against previously-flaky DIRECT-routed destinations. 断流 no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)