### PR TITLE
release: 1.3.1 build 2026051901 (TestFlight)

### DIFF
--- a/metadata/testflight/whats_new/2026051901.txt
+++ b/metadata/testflight/whats_new/2026051901.txt
@@ -1,0 +1,54 @@
+Build 2026051901 (1.3.1)
+
+WHAT'S NEW
+• Fixes the long-standing DIRECT-rule TCP 断流 (3WHS completes, app
+  hangs ~30 s, then errors out). Investigation in
+  docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md.
+  Three-layer defence, all on by default:
+  – TUN MTU clamped to 1400. iOS app's TCP stack now advertises
+    MSS=1360 at the SYN boundary; all payloads entering the TUN
+    are small enough that mihomo's upstream socket emits segments
+    fitting inside even pathological cellular path MTUs (1428,
+    1380, etc.) without relying on PMTUD — which routinely
+    black-holes on CN routes where ICMP Frag-Needed is filtered.
+    Same conservative default as Surge / Quantumult X / Loon.
+    The actual fix in the user-reported reproduction.
+  – Per-flow dial-deadline watchdog in dispatch_tcp (default 10 s,
+    runtime-tunable). On expiry, drops the relay future so the app
+    sees a RST in 10 s instead of a 30 s black-hole hang; mihomo
+    session cleanup runs via ConnectionGuard's Drop.
+  – Per-UDP-session first-reply deadline (default 10 s). Bounds
+    only the *first* read_packet on a new UDP NAT entry, so a
+    session whose outbound sendto was silently dropped by iOS's
+    auto-bypass gets evicted and the next datagram dispatches a
+    fresh socket against a refreshed iOS route. Quiet-but-live
+    sessions (NAT keepalive, long-poll) are unaffected.
+
+• mihomo-rust pinned to a post-v0.7.6 rev to pick up
+  DirectAdapter::with_connect_timeout (madeye/mihomo-rust#86).
+  API compiles in but not yet wired through YAML — the FFI
+  watchdogs above are doing the work in this build.
+
+• netstack-smoltcp fork aligned to MTU=1500 (was 1504 with a
+  bogus "+4 for VLAN" allowance from upstream).
+
+KNOWN
+• Non-DNS UDP forwarding still pending (QUIC/HTTP3 degraded to TCP).
+• Path-change-driven dynamic MTU clamping (NWPathMonitor +
+  getifaddrs/SIOCGIFMTU) is deferred until we measure whether the
+  static 1400 clamp is leaving real Wi-Fi throughput on the table.
+
+FOR TESTERS
+• Specifically retry destinations that previously surfaced
+  "page hangs for ~30 s then errors" through DIRECT-routed flows.
+  If you still see 断流, please grab the log streamed from the
+  PacketTunnel subsystem (Console.app → predicate
+  `subsystem == "io.github.madeye.meow"`) and look for
+  `tun2socks: dial deadline exceeded` or
+  `tun2socks: UDP first-reply-deadline` lines — those tell us
+  which watchdog fired.
+• Cellular vs Wi-Fi: the MTU=1400 clamp is the same on both. If
+  Wi-Fi-side throughput regresses noticeably (the conservative
+  clamp can leave ~6% on the table on paths that didn't need it),
+  please report — that's the signal for prioritising the dynamic
+  NWPathMonitor work.

--- a/metadata/testflight/zh-Hans/whats_new/2026051901.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026051901.txt
@@ -1,0 +1,48 @@
+Build 2026051901 (1.3.1)
+
+新特性
+• 修复长期存在的 DIRECT 规则下 TCP 断流问题(三次握手已完成,
+  应用挂起约 30 秒后报错)。排查记录见
+  docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md。
+  默认开启三层防御:
+  – TUN MTU 收紧到 1400。iOS 应用 TCP 栈在 SYN 阶段宣告
+    MSS=1360,所有进入 TUN 的负载体积都足够小,mihomo 在物理
+    出栈套接字上发出的段能塞进即使是病态的蜂窝路径 MTU
+    (1428、1380 等),不再依赖 PMTUD —— 而国内常见路径上的
+    ICMP Frag-Needed 经常被过滤,导致 PMTUD 黑洞。这是
+    Surge / Quantumult X / Loon 的常用默认值。也是本次用户实测
+    生效的关键修复。
+  – dispatch_tcp 引入每流拨号超时看门狗(默认 10 秒,可运行时
+    调整)。超时即丢弃中继 future,应用 10 秒内收到 RST,而不是
+    黑洞挂起 30 秒;mihomo 会话状态通过 ConnectionGuard::Drop
+    完整清理。
+  – 每 UDP 会话首包回复超时(默认 10 秒)。只约束新 UDP NAT
+    条目上的*首次* read_packet —— 这样,如果 iOS auto-bypass
+    在路由缓存陈旧时悄悄丢弃了首个 sendto,被困住的会话会被
+    驱逐,下一个数据报会在更新过的 iOS 路由上重新拨号。已
+    在收过数据的活跃会话(NAT keepalive、长轮询)不受影响。
+
+• mihomo-rust 钉到 v0.7.6 之后的 rev,引入 DirectAdapter::
+  with_connect_timeout(madeye/mihomo-rust#86)。API 已经编译
+  进二进制,但 YAML 配置链路尚未打通 —— 本版的防御由上述
+  FFI 看门狗承担。
+
+• netstack-smoltcp fork MTU 对齐到 1500(原本 1504,带一份
+  上游错误的"+4 for VLAN"余量)。
+
+已知问题
+• 非 DNS UDP 转发仍未支持(QUIC/HTTP3 降级到 TCP)。
+• 基于路径变化的动态 MTU 钳制(NWPathMonitor + getifaddrs/
+  SIOCGIFMTU)暂不实现,先观察静态 1400 钳制是否影响实际
+  Wi-Fi 吞吐。
+
+测试关注点
+• 重点回测之前出现"页面挂起约 30 秒后报错"的 DIRECT 规则
+  目标。如果仍然出现断流,请抓取 PacketTunnel 子系统的日志
+  (Console.app → 谓词 `subsystem == "io.github.madeye.meow"`),
+  关注是否有 `tun2socks: dial deadline exceeded` 或
+  `tun2socks: UDP first-reply-deadline` 行 —— 这能告诉我们
+  哪一层看门狗触发了。
+• 蜂窝 vs Wi-Fi:MTU=1400 钳制对两者一视同仁。如果 Wi-Fi
+  吞吐有明显回退(在不需要钳制的路径上,这个保守值可能损耗
+  约 6%),请回报,以决定是否优先落地动态 NWPathMonitor 方案。

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026051810"
+        CFBundleVersion: "2026051901"
         LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -194,7 +194,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026051810"
+        CFBundleVersion: "2026051901"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

TestFlight release ships the DIRECT-rule TCP 断流 fix landed in #159:

- **TUN MTU clamp to 1400** (`MWTunnelSettings.m`) — the actual user-reproduced fix. iOS app TCP advertises MSS=1360 at the SYN boundary; mihomo's upstream segments fit inside even pathological cellular path MTUs without relying on PMTUD.
- **Per-flow dial-deadline watchdog** in `dispatch_tcp` (default 10 s).
- **UDP first-reply deadline** in `spawn_udp_reply_reader` (default 10 s).
- netstack-smoltcp fork bumped to MTU=1500.
- mihomo-rust pinned to post-v0.7.6 rev with `DirectAdapter::with_connect_timeout` API compiled in.

User-confirmed on iPhone 17 Pro / iOS 26 against previously-flaky DIRECT-routed destinations.

## Path B attestation (per CLAUDE.md)

- [x] `swiftformat --lint .` → **0 violations** (`0/89 files require formatting`).
- [x] `swiftlint --strict` → **0 violations, 0 serious in 80 files**.
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:MeowTests` → **TEST SUCCEEDED**.
- [x] `git diff origin/main...HEAD --stat` verified — 3 files: `project.yml` build-number bump + two `metadata/testflight/whats_new/2026051901.txt` (en + zh-Hans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)