### PR TITLE
release: sync Info.plist build number to 2026051901

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026051810</string>
+	<string>2026051901</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>2026051810</string>
+	<string>2026051901</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Catch-up to #160 — regenerated `App/Info.plist` and `PacketTunnel/Info.plist` build-number values were missed in the release commit. xcodegen produces these from `project.yml`; prior releases (cf. `a131691`) always carried the regenerated values alongside `project.yml`.

No behavioural change — `xcodebuild` reads the workspace where values are already updated. Brings the source of truth back in sync.

## Path B attestation

Same diff shape as a generated-artifact bump (two `CFBundleVersion` string changes). Lint + tests reused from #160 (project.yml-derived, identical workspace state):

- [x] `swiftformat --lint .` → 0 violations
- [x] `swiftlint --strict` → 0 violations, 0 serious
- [x] `xcodebuild test ... -only-testing:MeowTests` → TEST SUCCEEDED (run for #160 against this exact xcodegen output)
- [x] diff verified — 2 files (`App/Info.plist`, `PacketTunnel/Info.plist`), `CFBundleVersion` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)