### PR TITLE
docs(landing): swap TestFlight CTA for Firebase App Distribution

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -471,17 +471,11 @@
         </div>
 
         <div class="cta-row">
-          <a class="cta" href="https://testflight.apple.com/join/nnDAn7ZH">
-            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.12-1.14.461-2.31 1.177-3.08.804-.84 2.142-1.46 2.987-1.57zM21.5 17.236c-.554 1.286-.82 1.86-1.532 2.998-.992 1.585-2.394 3.56-4.13 3.575-1.546.014-1.945-1.005-4.043-.99-2.099.014-2.541 1.005-4.087.99-1.737-.015-3.063-1.81-4.054-3.395C.866 15.927 1.176 11.7 2.927 9.43 4.158 7.83 6.075 6.89 7.876 6.89c1.83 0 2.98.99 4.498.99 1.475 0 2.371-.991 4.485-.991 1.6 0 3.296.873 4.503 2.382-3.957 2.165-3.318 7.821.138 7.965z"/>
-            </svg>
-            Join the public beta
-          </a>
-          <a class="cta-alt" href="https://appdistribution.firebase.dev/i/85546f1795ab613a">
+          <a class="cta" href="https://appdistribution.firebase.dev/i/85546f1795ab613a">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M3.89 15.27 6.24 0l3.16 5.93-2.65 4.93Zm.04 1.78L12 22.51l8.23-5.47-2.31-1.45L12 19.65l-5.93-3.99-2.14 1.39Zm14.39-2.83-3.4-13.7-3.43 6.43L20.6 17.5l-2.28-3.28Zm-9.66-7.65 2.95 5.49 2.96-5.55-2.96-5.55Z"/>
             </svg>
-            Firebase Ad Hoc
+            Join the beta
           </a>
           <a class="cta-secondary" href="https://github.com/madeye/meow-ios">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -494,11 +488,11 @@
           Requires iOS 17 or later · Bring your own Mihomo / Clash subscription
         </p>
         <p class="req-detail">
-          <strong>TestFlight</strong> is the recommended channel — install Apple's
-          TestFlight app, tap the link, done. <strong>Firebase Ad Hoc</strong>
-          installs directly through Safari (no TestFlight app, no 90-day rebuild
-          for installed devices); it requires a one-time device registration and
-          is capped at ~100 active devices.
+          Distributed via <strong>Firebase App Distribution</strong> — installs
+          directly through Safari, no TestFlight app required. Tap the link on
+          your iPhone, accept the invite, install the configuration profile
+          once, and future builds appear automatically. Capped at ~100 active
+          devices per build cycle.
         </p>
 
         <h2>What it does</h2>
@@ -585,8 +579,7 @@
           </p>
           <p>
             Please report issues via
-            <a href="https://github.com/madeye/meow-ios/issues">GitHub Issues</a>
-            or the in-app TestFlight feedback button.
+            <a href="https://github.com/madeye/meow-ios/issues">GitHub Issues</a>.
           </p>
         </div>
 


### PR DESCRIPTION
Internal beta channel moved from TestFlight to Firebase App Distribution — the Ad Hoc path lets us iterate without per-build Apple beta review and lands as a direct Safari install instead of needing the TestFlight app.

Changes:
- Existing Firebase CTA promoted from secondary to primary. Removed the now-redundant duplicate Firebase Ad Hoc button.
- Updated the prose under the CTA to describe the Firebase install flow (Safari-direct, one-time device registration, ~100-device cap per build cycle).
- Dropped the "in-app TestFlight feedback button" mention from the Reporting copy.

Docs-only — Path A bypass applies (no code paths touched, only `docs/index.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)