### PR TITLE
docs(investigation): geoip download TLS handshake failure

### DIFF
--- a/docs/INVESTIGATION-2026-05-19-geoip-download-tls-failure.md
+++ b/docs/INVESTIGATION-2026-05-19-geoip-download-tls-failure.md
@@ -1,0 +1,355 @@
+# Geoip download fails with TLS error — bootstrap-tunnel chicken-and-egg, second variant
+
+**Date:** 2026-05-19
+**Investigator:** Claude Opus 4.7 driven by max.c.lv@gmail.com
+**Tool chain:** Source-only audit of `claude/investigate-and-document-fHUtC`
+against current `main`. A single user screenshot was the trigger; no new
+device reproduction was run.
+
+## TL;DR
+
+Symptom (operator-reported screenshot, zh-Hans device on 5G cellular):
+
+* Status badge `未连接` (Not connected).
+* Error banner:
+  * Title: `无法启动隧道`.
+  * Detail: `Failed to download geoip: TLS 错误导致安全连接失败`.
+* Traffic counters show `入站 14 / 出站 12` — tens of bytes flowed before
+  the failure; consistent with the bootstrap tunnel briefly coming up and
+  being torn back down.
+
+The string assembles to **`Failure.downloadFailed(name: "geoip",
+underlying: URLError(.secureConnectionFailed))`** raised by
+`GeoAssetService.download` (`App/Sources/Services/GeoAssetService.swift:94-96`).
+`Failure.errorDescription` interpolates `underlying.localizedDescription`
+(`App/Sources/Services/GeoAssetService.swift:26-28`), and on a zh-Hans
+device CFNetwork renders `NSURLErrorSecureConnectionFailed` (`-1200`,
+`kCFErrorDomainCFNetwork`) as exactly `TLS 错误导致安全连接失败`.
+Neither half of the string lives in
+`App/Resources/zh-Hans.lproj/Localizable.strings` — the banner title
+`无法启动隧道` is the only app-side string here
+(`App/Resources/zh-Hans.lproj/Localizable.strings:62`).
+
+**The download path runs THROUGH a minimal bootstrap tunnel**, not direct.
+`VpnManager.bootstrapGeoDownload` (`App/Sources/Services/VpnManager.swift:91-114`)
+writes a `MinimalConfigBuilder` config containing only the user profile's
+first proxy plus a `MATCH,<first-proxy>` rule
+(`MeowShared/Sources/MeowModels/MinimalConfigBuilder.swift:26-41`), starts
+the tunnel, waits for `NEVPNStatus = .connected`, then issues the
+`URLSession` download. So the TLS handshake that fails happens **inside**
+the tunnel, dispatched through the first proxy, not from the bare iOS
+network stack to `cdn.jsdelivr.net` directly.
+
+This is the **second variant** of the geoip-download chicken-and-egg. The
+first variant — `请求超时` (timeout) caused by jsDelivr being unreachable
+direct from mainland China — was fixed in `dd12fe6 feat(geo): bootstrap
+geo download via first proxy` (2026-05-17). That commit moved the request
+through the proxy and resolved the timeout class. The TLS class is left
+unaddressed: a `URLError(.secureConnectionFailed)` raised mid-proxy
+manifests identically to a direct-connection TLS failure, and the
+bootstrap proxy path widens the surface for it rather than narrowing it.
+
+## How the error string is assembled
+
+Two halves, two origins:
+
+1. **`无法启动隧道`** — app-side, localized.
+   * Key: `home.error.tunnelFailed.title`
+     (`App/Resources/zh-Hans.lproj/Localizable.strings:62`).
+   * Displayed by the home error banner over the `lastError` body.
+
+2. **`Failed to download geoip: TLS 错误导致安全连接失败`** — body, two
+   sub-parts joined by `: `:
+   * Static prefix `Failed to download geoip` from
+     `Failure.errorDescription` in `GeoAssetService`:
+
+     ```swift
+     case let .downloadFailed(name, underlying):
+         "Failed to download \(name): \(underlying.localizedDescription)"
+     ```
+
+     (`App/Sources/Services/GeoAssetService.swift:26-28`)
+     The `name` is whichever key in the effective config's `geox-url`
+     block failed first — here `"geoip"`, which under the default block is
+     `https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb`
+     (`MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift:30`).
+   * Suffix `TLS 错误导致安全连接失败` is the system zh-Hans rendering of
+     `NSURLErrorSecureConnectionFailed` (`-1200`,
+     `kCFErrorDomainCFNetwork`). This is **not** in the app's strings
+     file — `grep -i 'tls\|安全\|secure'` against
+     `App/Resources/zh-Hans.lproj/Localizable.strings` returns nothing.
+     The English equivalent CFNetwork ships is "An SSL error has occurred
+     and a secure connection to the server cannot be made."
+
+The `Failure.httpStatus` case (non-2xx HTTP) is **not** in play here —
+that branch returns a `Failed to download geoip (HTTP <code>)`-shaped
+string with parentheses, not the `: TLS 错误…` shape we see.
+
+## Code path that produced this banner
+
+The bootstrap-tunnel dance is the only path that reaches the URLSession
+download today. There is no direct-from-cell fallback. The full sequence
+the screenshot captured:
+
+1. User taps the red `连接` button.
+   `HomeView` calls `VpnManager.connect()`
+   (`App/Sources/Services/VpnManager.swift:64`).
+2. `connect()` clears `lastError`, sets `stage = .preparing`
+   (`App/Sources/Services/VpnManager.swift:65-68`).
+3. `GeoAssetService.allFilesPresent()` returns `false` — at least one of
+   `geoip.metadb`, `country.mmdb`, `geosite.dat`,
+   `GeoLite2-ASN.mmdb` is missing from
+   `AppGroup.mihomoConfigDir`
+   (`App/Sources/Services/GeoAssetService.swift:38-47`).
+4. `bootstrapGeoDownload(manager:)` runs
+   (`App/Sources/Services/VpnManager.swift:91-114`):
+   * Reads source YAML from `AppGroup.configURL`.
+   * Builds the minimal config — only the first proxy in `proxies:`
+     and `rules: [MATCH,<first-proxy-name>]`
+     (`MeowShared/Sources/MeowModels/MinimalConfigBuilder.swift:34-40`).
+   * Writes minimal YAML over `configURL` (with a `defer`-scoped
+     best-effort restore on every exit path,
+     `App/Sources/Services/VpnManager.swift:96-101`).
+   * `manager.connection.startVPNTunnel()` and
+     `waitForStatus(.connected, timeout: 30)`
+     (`App/Sources/Services/VpnManager.swift:103-104`). This is when the
+     14/12 in/out byte counters in the screenshot started ticking —
+     mihomo-rust booted, the TUN attached, the first proxy was dialed.
+   * `GeoAssetService.ensureFiles(prefs:)` iterates the effective
+     `geox-url` block and downloads each missing file via an ephemeral
+     `URLSession` (60 s request / 180 s resource timeout,
+     `App/Sources/Services/GeoAssetService.swift:81-87`). Per-URL
+     packets are routed through the iOS routing table → into the TUN we
+     just brought up → into mihomo-rust → MATCH → first proxy →
+     upstream → `cdn.jsdelivr.net`.
+5. On `geoip` (the first key iterated, in dictionary order over
+   `defaultGeoXURL` — order matters for which file's name appears in
+   the message), `session.download(from:)` throws
+   `URLError(.secureConnectionFailed)`.
+6. `GeoAssetService` re-throws `Failure.downloadFailed(name: "geoip",
+   underlying: <the URLError>)`
+   (`App/Sources/Services/GeoAssetService.swift:94-96`).
+7. `bootstrapGeoDownload`'s `do/catch`
+   (`App/Sources/Services/VpnManager.swift:105-111`) calls
+   `manager.connection.stopVPNTunnel()` and waits up to 10 s for
+   `.disconnected`, then re-throws.
+8. `connect()`'s outer catch
+   (`App/Sources/Services/VpnManager.swift:74-77`) sets
+   `lastError = error.localizedDescription` and `stage = .error`.
+9. The `.preparing → .stopped` collapse normally swallowed by
+   `applyConnectionStatus` (`App/Sources/Services/VpnManager.swift:210`,
+   intentional to not flash "Stopped" mid-bootstrap) does **not** apply
+   here because the failure path explicitly assigns `stage = .error`.
+   `HomeView` then renders `lastError` in the orange banner and the
+   primary card flips to `未连接`.
+10. The `defer` from step 4 restores the source YAML to `configURL`, so
+    the next connect attempt will re-run the bootstrap from the same
+    starting state. There is no progress made — the bootstrap is
+    all-or-nothing.
+
+## Why `URLError(.secureConnectionFailed)` specifically
+
+`-1200` is iOS's "the TLS handshake didn't produce a verified, usable
+session" bucket. CFNetwork raises it for, among other things:
+
+* Server hello whose certificate chain doesn't validate against the
+  iOS trust store (expired leaf, missing intermediate, hostname
+  mismatch, untrusted root).
+* TLS protocol-level failure during the handshake (alert from
+  peer, unexpected close, no compatible cipher, malformed record).
+* SNI / ALPN negotiation that the OS rejects.
+* Some middlebox-injected RST mid-handshake.
+
+It is **not** the same as `-1202` (`.serverCertificateUntrusted`),
+`-1203` (`.serverCertificateHasUnknownRoot`), or `-1204`
+(`.serverCertificateNotYetValid`) — those carry more specific reasons.
+The fact that the kernel chose the generic `-1200` rules out a
+cert-chain-specific cause we could pinpoint without packet capture.
+
+Because the request rides the tunnel, the TLS handshake observed by
+URLSession is between **the iOS device and `cdn.jsdelivr.net`** —
+mihomo-rust just forwards encrypted bytes through the first proxy. The
+proxy can't "fail" the TLS handshake itself (it has no key for jsDelivr),
+but it can:
+
+* Drop or corrupt handshake records → URLSession sees an unexpected
+  close → `-1200`.
+* Connect to the wrong upstream (e.g., a captive portal at the cellular
+  carrier transparently rewrote DNS for `cdn.jsdelivr.net` before the
+  proxy dialed) → certificate served doesn't match `*.jsdelivr.net` →
+  `-1200`.
+* Be reached over a hop that's doing TLS interception → cert presented
+  to URLSession is the interceptor's, not pinned-trusted by iOS →
+  `-1200`. (No certificate pinning is configured in
+  `GeoAssetService.download`; iOS system trust store is the sole
+  authority.)
+
+The screenshot's 5G cellular context is the highest-prior hypothesis: a
+cellular operator middlebox (or upstream-of-proxy network) interfering
+with the jsDelivr handshake. The bytes-flowed counters (14/12) say the
+proxy did dial something — but they don't say it dialed the right
+endpoint, and we have no log of what error mihomo-rust internally
+recorded (the MATCH path doesn't surface dial-level errors to the app;
+URLSession sees only the eventual handshake outcome).
+
+## What this rules in and out
+
+Ruled **in**:
+
+* Bootstrap tunnel reached `.connected` (otherwise we'd have failed at
+  `waitForStatus`, surfacing `URLError(.timedOut)` not
+  `.secureConnectionFailed`).
+* TUN routing did funnel the request — there were packets
+  (`入站 14 / 出站 12`).
+* TLS handshake to `cdn.jsdelivr.net` was attempted and rejected by
+  iOS, not by the proxy. The proxy can't synthesize a `-1200` for the
+  app; the OS makes that determination on bytes it received.
+
+Ruled **out**:
+
+* App-side TLS pinning / custom validation: there is none.
+  `URLSessionConfiguration.ephemeral` with no `URLSessionDelegate`
+  means iOS system trust store and nothing else
+  (`App/Sources/Services/GeoAssetService.swift:81-87`).
+* HTTP-level failure (404 / 5xx / certificate explicitly untrusted):
+  those would route through `Failure.httpStatus` or one of the more
+  specific `URLError` codes, producing a different banner shape.
+* Bundled-geoip regression: there is no bundled `geoip.metadb` anymore
+  (`e442d7b feat(geo): lazy-download GeoIP/ASN databases on connect`
+  removed it). Every fresh install hits this path.
+* Engine-side download (mihomo-rust honoring `geox-url` itself):
+  it does **not**. `GeoAssetService` comment is explicit —
+  "mihomo-rust does NOT itself honor `geox-url` for lazy fetching"
+  (`App/Sources/Services/GeoAssetService.swift:8-10`). The app stages
+  files; the engine reads them off disk. So this failure can't be
+  attributed to anything in `core/rust/mihomo-ios-ffi/`.
+
+Not yet determinable without more data:
+
+* Whether the user's first proxy itself is degraded (e.g., the
+  TLS-tunneled VLESS endpoint is up enough for the dial to succeed
+  but is forwarding garbage). Repro with a known-good first proxy
+  on the same network would disambiguate.
+* Whether jsDelivr is the unhappy endpoint, vs. the cellular
+  carrier intercepting it. A simultaneous direct-from-Wi-Fi test
+  would disambiguate.
+
+## Default geox-url block (the URLs being attempted)
+
+From `MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift:29-34`,
+injected when the user's profile doesn't ship `geox-url`:
+
+```yaml
+geox-url:
+  geoip:   https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb
+  mmdb:    https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/country.mmdb
+  geosite: https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat
+  asn:     https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb
+```
+
+All four point at `cdn.jsdelivr.net`, a single SAN
+(`*.jsdelivr.net` + apex) on Fastly/Cloudflare-fronted infrastructure.
+Single-CDN exposure means a single endpoint problem (cert renewal hiccup,
+CDN regional incident, ISP-level interception of that specific host)
+takes the entire bootstrap down for everyone — there is no mirror.
+
+The user *can* override `geox-url` in their profile YAML, but no current
+UX surfaces this; an end user hitting this banner has no obvious path
+out other than retrying on a different network.
+
+## Surrounding context — why this matters more than a transient
+
+The bootstrap-tunnel fix `dd12fe6` is one week old. Before it, the
+direct-from-cell path was the failure mode and users saw a timeout
+banner; the fix turned that into "we have a tunnel for the geoip fetch,
+which should make this near-perfect." The TLS variant says the new path
+is not actually perfect — it's narrower than direct, but it inherits a
+new dependency on **whatever the first proxy does to TLS to jsDelivr**.
+Operators who never saw `请求超时` before may now see
+`TLS 错误导致安全连接失败` instead, with no path to recover other than
+restarting the app on a different network.
+
+The blast radius is **first connect on every install**. Once any of the
+four files lands on disk, `allFilesPresent` becomes a fast path
+(`App/Sources/Services/GeoAssetService.swift:38-47` — non-zero file size
+is the only check, no HEAD revalidation), and the bootstrap is never
+re-entered until the user manually deletes the files or reinstalls. So
+the failure is bursty and onboarding-shaped, not steady-state. That
+matches the screenshot: a fresh-install or post-reinstall user trying
+to come up for the first time.
+
+## Suggested next steps (not implemented in this pass)
+
+Listed in order of "smallest change first," not necessarily preferred
+order. Each carries a separate tradeoff; the right pick depends on
+whether we want to **avoid** the failure, **recover** from it, or
+**explain** it better.
+
+1. **Multi-mirror fallback in `GeoAssetService.download`**. Try jsDelivr
+   first, then a list of alternates (`raw.githubusercontent.com`,
+   `ghproxy.com`, `fastly.jsdelivr.net` direct, `gcore.jsdelivr.net`
+   etc.) on any `URLError` whose `code` is in
+   `{.secureConnectionFailed, .cannotConnectToHost, .timedOut,
+   .networkConnectionLost, .notConnectedToInternet}`. Cheapest user-
+   visible improvement; the alternates list could ship as a constant on
+   `EffectiveConfigWriter` alongside `defaultGeoXURL`.
+
+2. **Bundle the four files in-app** and use `GeoAssetService` only to
+   refresh stale ones. Removes the entire chicken-and-egg from
+   first-connect — the bootstrap tunnel is no longer needed at all.
+   Costs ~5–6 MB of IPA (the four files together) and reintroduces
+   what `e442d7b` deliberately removed; revisiting that decision is a
+   separate conversation. The "fresh install on cellular" UX is the
+   strongest argument for this.
+
+3. **Pluggable bootstrap proxy**. The current first-proxy choice is
+   "whatever's first in the YAML." If a user's first proxy is a
+   slow/degraded shadowsocks node, that's what gets stuck handling the
+   jsDelivr handshake. Letting the user pin a known-good bootstrap
+   proxy (or auto-selecting based on latency) would harden the path.
+   Larger change; touches UI.
+
+4. **Surface the specific URLError code in the banner.** Today the
+   user gets the OS-localized blurb. Adding the URLError code (`-1200`)
+   plus the URL host (`cdn.jsdelivr.net`) to the banner would make
+   user-reported screenshots immediately actionable instead of
+   requiring this whole investigation each time. Cheap, fully app-side,
+   doesn't change failure rate but reduces investigation cost.
+
+5. **Bridge mihomo-rust's dial-level error to URLSession's view.**
+   When the first proxy fails its upstream dial mid-TLS, the app today
+   sees only `URLError(.secureConnectionFailed)`. If we exposed a
+   shared-store breadcrumb (`SharedStore.readState()`) from mihomo-rust
+   for "last dial outcome on the bootstrap config," the
+   `bootstrapGeoDownload` catch path could include it in the rethrown
+   error and the banner would say something like "proxy dial failed:
+   <reason>" instead of a generic TLS message. Larger change, touches
+   FFI; useful diagnostic improvement, not a fix.
+
+## File reference
+
+```
+App/Sources/Services/VpnManager.swift:64-114        — connect() + bootstrapGeoDownload()
+App/Sources/Services/GeoAssetService.swift          — entire file is in scope
+  :20-32                                              Failure enum + errorDescription
+  :38-47                                              allFilesPresent() fast path
+  :54-66                                              ensureFiles()
+  :79-110                                             download() + URLSession config
+MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift:29-34  — defaultGeoXURL
+MeowShared/Sources/MeowModels/MinimalConfigBuilder.swift         — bootstrap config
+MeowShared/Sources/MeowModels/VpnState.swift:3-16                — VpnStage enum
+App/Resources/zh-Hans.lproj/Localizable.strings:62               — banner title
+```
+
+Relevant commits:
+
+```
+dd12fe6  feat(geo): bootstrap geo download via first proxy   (2026-05-17)
+e442d7b  feat(geo): lazy-download GeoIP/ASN databases on connect
+6c8cf36  feat(mihomo): enable boring-tls feature for ECH support  (adjacent, not causal)
+```
+
+No GitHub issue currently filed for this specific banner. `gh search`
+across `madeye/meow-ios` for `geoip OR jsdelivr OR "无法启动隧道" OR
+"Failed to download" OR TLS` returned only #112 (YAML import format,
+unrelated).

--- a/docs/adr/ADR-005-geoip-download-via-in-process-proxy.md
+++ b/docs/adr/ADR-005-geoip-download-via-in-process-proxy.md
@@ -1,0 +1,462 @@
+# ADR-005: Download geoip via in-process mihomo proxy, not via a bootstrap tunnel
+
+- **Status:** Proposed
+- **Date:** 2026-05-19
+- **Author:** Claude Opus 4.7 driven by max.c.lv@gmail.com
+- **Builds on:** `INVESTIGATION-2026-05-19-geoip-download-tls-failure.md`
+- **Supersedes (if accepted):** the bootstrap-tunnel approach in commit
+  `dd12fe6 feat(geo): bootstrap geo download via first proxy`
+  (2026-05-17), specifically `VpnManager.bootstrapGeoDownload`
+  (`App/Sources/Services/VpnManager.swift:91-114`).
+
+## Context
+
+The current first-connect path for any install missing geoip/geosite/
+mmdb/asn does the following dance, per
+`App/Sources/Services/VpnManager.swift:64-114`:
+
+1. Build a minimal config (first proxy + `MATCH,<first-proxy>`).
+2. Overwrite the real config with the minimal one.
+3. Call `NETunnelProviderManager.connection.startVPNTunnel()`.
+4. Poll for `NEVPNStatus = .connected` (up to 30 s).
+5. `GeoAssetService.ensureFiles` → `URLSession.download` for each
+   `geox-url` — the TUN routes those requests through mihomo through
+   the first proxy.
+6. `stopVPNTunnel()`, wait for `.disconnected` (up to 10 s).
+7. Restore the real config (via `defer`).
+8. Call `startVPNTunnel()` again with the real config.
+
+This works most of the time, but the operator-facing failure mode is
+now `URLError(.secureConnectionFailed)` (CFNetwork `-1200`) surfacing as
+`Failed to download geoip: TLS 错误导致安全连接失败` — investigated in
+`docs/INVESTIGATION-2026-05-19-geoip-download-tls-failure.md`. The
+TLS handshake observed by URLSession is between the device and
+`cdn.jsdelivr.net`; the proxy carries encrypted bytes, but any
+middlebox or proxy-side disturbance manifests at the URLSession layer
+as a generic `-1200`. The user is left with no recovery path other
+than retrying on a different network.
+
+The dance also has structural costs we'd prefer to remove regardless
+of the TLS class of failure:
+
+* **State juggling** — `configURL` is overwritten with the minimal YAML
+  and restored only via `defer`. If the app is killed between the
+  overwrite and the restore, the user's profile is wedged on the
+  minimal config until they reselect the profile.
+* **Two NE state transitions per first connect** —
+  `.disconnected → .connecting → .connected → .disconnecting →
+  .disconnected → .connecting → .connected`. Each is observable to
+  iOS NetworkExtension housekeeping, and the badge flicker contract
+  inside `applyConnectionStatus` had to grow special-case handling
+  (`App/Sources/Services/VpnManager.swift:210`) just to avoid showing
+  "Stopped" mid-bootstrap.
+* **Up-to-40 s of "Preparing…"** in the worst case (30 s
+  `waitForStatus(.connected)` + the download + 10 s
+  `waitForStatus(.disconnected)`).
+
+## Goal
+
+Download the four geo files through a proxy from the user's config
+**without** starting `NEPacketTunnelProvider`, by running a minimal
+mihomo engine in the App process as a local HTTP/SOCKS5 listener and
+pointing `URLSession` at it.
+
+## Non-goals
+
+* **Replacing the TLS stack.** This design keeps URLSession (and thus
+  iOS Security framework) as the TLS endpoint. Some `-1200` cases will
+  still happen — they are different cases (no longer "the bootstrap
+  proxy hop disturbed the handshake"). Routing TLS through Rust
+  (rustls / boring-tls) is a separable concern; see "Future work
+  not in scope" below.
+* **Bundling geo files in the IPA.** That's an alternative way to
+  remove the chicken-and-egg entirely, with its own size and freshness
+  tradeoffs. Out of scope here.
+* **First-proxy auto-selection.** "First proxy in the YAML" remains the
+  bootstrap-proxy selection policy. Improving that is a separable
+  follow-up.
+
+## Why this is feasible — what the FFI already exposes
+
+`MeowCore/include/mihomo_core.h` cleanly separates engine startup
+from TUN startup:
+
+```c
+int  meow_engine_start(const char *config_path);
+void meow_engine_stop(void);
+int  meow_engine_is_running(void);
+int  meow_tun_start(void *ctx, MeowWritePacket write_cb);
+void meow_tun_stop(void);
+```
+
+`meow_engine_start` brings up:
+
+* The mixed-port listener (HTTP + SOCKS5 on the same port, default
+  `7890`), per
+  `MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift:22`.
+* The external-controller REST API (`127.0.0.1:9090`), per
+  `EffectiveConfigWriter.swift:23`.
+* The proxy graph (groups, providers, rules).
+* The DNS subsystem the engine uses internally.
+
+It does **not** require `meow_tun_start` to be called. The
+PacketTunnel extension calls both in sequence; the App can call only
+the first.
+
+Critically, the App target **already links `MihomoCore.xcframework`**
+(`project.yml:110`, mirror of `project.yml:226` for PacketTunnel) and
+the App already calls FFI symbols today
+(`App/Sources/Services/SubscriptionConverter.swift`,
+`App/Sources/Views/UserDiagnosticsView.swift`,
+`App/Sources/AppModel.swift:37`). Starting the engine in-process is
+within the existing capability surface; no new dependency, no IPA-size
+delta.
+
+## Approaches considered
+
+### A. In-process mihomo engine, no TUN (RECOMMENDED)
+
+App process starts a minimal mihomo engine, points URLSession at
+`127.0.0.1:7890` via `connectionProxyDictionary`, downloads through it,
+stops the engine, then asks `NETunnelProviderManager` to start the
+real tunnel with the real config.
+
+### B. Reuse the bootstrap tunnel, add multi-mirror fallback
+
+Keep `bootstrapGeoDownload` exactly as is, but in `GeoAssetService`
+on any `URLError` in
+`{.secureConnectionFailed, .cannotConnectToHost, .timedOut, .networkConnectionLost}`,
+retry against a mirror list (`raw.githubusercontent.com`,
+`ghproxy.com`, `gcore.jsdelivr.net`).
+
+Cheap. Fixes some `-1200` cases (those caused by jsDelivr-specific
+incidents). Does not address the structural costs above. Considered
+complementary, not a replacement.
+
+### C. Engine-side download (new FFI)
+
+Add `meow_engine_fetch_url(url, proxy_name, out_path)`. mihomo-rust
+opens an `mihomo-proxy` adapter for `proxy_name`, sends the HTTP
+request using its own TLS stack (boring-tls), writes the body to
+`out_path`.
+
+Bypasses iOS URLSession entirely. Largest change — new FFI surface,
+need to handle streaming-to-disk, error propagation, cancellation.
+Defers the recommended approach by a release. Considered for the next
+iteration if URLSession-over-loopback proves insufficient.
+
+### D. Status quo + better banner diagnostics only
+
+Surface the `URLError.code` and the failing host in the banner. Doesn't
+fix the failure, just makes user-reported screenshots actionable in
+one shot instead of requiring the investigation pipeline. Cheap; not
+mutually exclusive with anything above.
+
+## Decision: pursue Approach A
+
+In-process engine, no TUN, loopback HTTP/SOCKS5 listener, URLSession
+proxy dictionary. Approach B's mirror fallback layers cleanly on top
+and should land in the same change. Approaches C and D are explicitly
+out of scope here but documented so the next iteration has a starting
+point.
+
+## Detailed design
+
+### New service: `BootstrapEngine`
+
+A small Swift class in `App/Sources/Services/BootstrapEngine.swift`
+(new file) responsible for the engine lifetime. Shape:
+
+```swift
+@MainActor
+final class BootstrapEngine {
+    enum Failure: LocalizedError {
+        case engineStartFailed(String)
+        case noProxies
+        case alreadyRunning
+    }
+
+    /// Bring up an engine-only (no TUN) mihomo against `minimalConfig`,
+    /// confirmed listening on 127.0.0.1:<port>. Returns the port so
+    /// callers can point URLSession at it. Idempotent: returns the
+    /// existing port if already running.
+    func start() async throws -> Int
+
+    /// Stop the engine and release ports. Safe to call when not running.
+    func stop() async
+
+    /// True iff the engine is currently up in-process.
+    var isRunning: Bool { get }
+}
+```
+
+Internals:
+
+* Build the minimal YAML via `MinimalConfigBuilder.build(...)` (already
+  exists, no change). The minimal config doesn't reference geox-url,
+  rule-providers, or DNS — exactly what we want.
+* Pick a bootstrap port. Two options:
+  * **Same `7890`** — risks colliding with another instance if the
+    PacketTunnel extension is running. By design, bootstrap only
+    runs when the tunnel is NOT up, so the conflict window is
+    closed. But on iOS app extensions, the extension process can
+    linger briefly after stop. Add an explicit pre-check via a
+    `bind()` probe; fail fast with a clear error if 7890 is held.
+  * **Random ephemeral port** — patch the minimal YAML to set
+    `mixed-port: <chosen>`, returned to the caller. More robust.
+    Cost: one extra patch step in MinimalConfigBuilder, plus
+    `EffectiveConfigWriter.defaultMixedPort` (currently 7890) loses
+    its "single source of truth" guarantee for bootstrap. **Pick
+    this — random ephemeral**. Rationale: the bootstrap engine is
+    transient; the PacketTunnel extension's engine still uses 7890
+    long-term. Decoupling them removes a class of port-conflict
+    bugs we can't easily diagnose remotely.
+* Write the minimal YAML to a **separate** path
+  (`AppGroup.bootstrapConfigDir/minimal.yaml`), not over
+  `AppGroup.configURL`. This eliminates the `defer`-based restore
+  fragility — the user's real config is never touched.
+* `minimal.yaml.withCString { meow_engine_start($0) }`.
+* On success, return the chosen port. The engine binds
+  `127.0.0.1:<port>` (verified by a one-shot reachability probe
+  `meow_engine_test_proxy_http("http://127.0.0.1:9090/", 500, ...)`
+  — same cold-connect readiness pattern
+  `AppModel.replaySelectedProxies` already uses
+  (`App/Sources/AppModel.swift:81-91`); applied to the local
+  listener instead of the REST API).
+* `stop()` calls `meow_engine_stop()`; mihomo-rust releases the port
+  synchronously on its side, but BSD socket TIME_WAIT can hold the
+  port for up to ~30 s. Random-port choice neutralizes this.
+
+### Rewiring `GeoAssetService.download`
+
+Add a `URL` for the proxy, plumbed in by the caller:
+
+```swift
+static func ensureFiles(prefs: Preferences, throughProxy proxy: URL?) async throws { ... }
+
+private static func download(name: String, from source: URL, to destination: URL, throughProxy proxy: URL?) async throws {
+    let config = URLSessionConfiguration.ephemeral
+    config.timeoutIntervalForRequest = 60
+    config.timeoutIntervalForResource = 180
+    config.waitsForConnectivity = false
+    if let proxy {
+        config.connectionProxyDictionary = [
+            kCFNetworkProxiesHTTPEnable as String:  true,
+            kCFNetworkProxiesHTTPProxy  as String:  proxy.host ?? "127.0.0.1",
+            kCFNetworkProxiesHTTPPort   as String:  proxy.port ?? 7890,
+            kCFNetworkProxiesHTTPSEnable as String: true,
+            kCFNetworkProxiesHTTPSProxy  as String: proxy.host ?? "127.0.0.1",
+            kCFNetworkProxiesHTTPSPort   as String: proxy.port ?? 7890,
+        ]
+    }
+    // ... rest unchanged
+}
+```
+
+Notes:
+
+* `kCFNetworkProxiesHTTPSProxy` instructs URLSession to use the HTTP
+  proxy's `CONNECT` method for HTTPS — exactly what we want. iOS has
+  supported this since iOS 10; no entitlement or ATS exception needed
+  beyond what the app already has.
+* The proxy URL is `URL(string: "http://127.0.0.1:<port>")`; the
+  port comes from `BootstrapEngine.start()`.
+* If `proxy == nil` (the path used by future direct-mode reuse),
+  behavior is identical to today's `GeoAssetService.download` —
+  we don't break existing callers or tests.
+
+### New `VpnManager.connect()` flow
+
+Replacement for `bootstrapGeoDownload` (delete that method entirely,
+along with `MinimalConfigBuilder` callsite migrating from
+`bootstrapGeoDownload` to `BootstrapEngine`):
+
+```swift
+func connect() async {
+    lastError = nil
+    if manager == nil { await refresh() }
+    guard let manager else { return }
+    stage = .preparing
+    do {
+        if !GeoAssetService.allFilesPresent() {
+            let port = try await bootstrapEngine.start()
+            defer { Task { await bootstrapEngine.stop() } }
+            let proxy = URL(string: "http://127.0.0.1:\(port)")!
+            try await GeoAssetService.ensureFiles(
+                prefs: Preferences.load(from: AppGroup.defaults),
+                throughProxy: proxy,
+            )
+        }
+        try manager.connection.startVPNTunnel()
+    } catch {
+        lastError = error.localizedDescription
+        stage = .error
+    }
+}
+```
+
+The `.preparing` badge window now covers:
+
+* `bootstrapEngine.start()` — sub-second on device (cold engine init
+  is dominated by config parse + rule compile, both fast for the
+  minimal config which has zero rules other than `MATCH`).
+* The actual download — bound by the user's first proxy's throughput.
+* `bootstrapEngine.stop()` — synchronous on the FFI side.
+
+Total replaces the old 30 s + download + 10 s with just the download
+itself plus a few-hundred-ms boot. **Worst-case "Preparing…" drops by
+~40 s.**
+
+### Multi-mirror fallback (Approach B layered in)
+
+Inside `GeoAssetService.download`, on `URLError` whose code is in
+`{.secureConnectionFailed, .cannotConnectToHost, .timedOut,
+.networkConnectionLost}`, walk a per-asset mirror list. Default mirror
+table (a sibling of `EffectiveConfigWriter.defaultGeoXURL`):
+
+```swift
+static let geoXMirrors: [String: [String]] = [
+    "geoip": [
+        "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb",
+        "https://gcore.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb",
+        "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/geoip.metadb",
+        "https://ghproxy.com/https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/geoip.metadb",
+    ],
+    // ... similar for mmdb / geosite / asn
+]
+```
+
+Iterate in order, stop on first 2xx. The mirror list is overridable
+the same way `geox-url` is — if the user's profile ships a custom
+`geox-url`, mirrors are not used (we don't second-guess user intent).
+
+This is independent of Approach A and would be valuable on its own,
+but ships in the same PR to keep the user-visible recovery story
+coherent.
+
+## API / file surface
+
+New:
+
+```
+App/Sources/Services/BootstrapEngine.swift        — new file (~120 lines)
+MeowShared/Sources/MeowModels/AppGroup.swift      — add bootstrapConfigDir
+MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+    — add geoXMirrors constant
+MeowShared/Sources/MeowModels/MinimalConfigBuilder.swift
+    — overload build(...) to accept a port override
+```
+
+Modified:
+
+```
+App/Sources/Services/GeoAssetService.swift        — add throughProxy:, mirror walk
+App/Sources/Services/VpnManager.swift             — connect() rewrite, delete bootstrapGeoDownload + waitForStatus
+```
+
+Deleted:
+
+```
+App/Sources/Services/VpnManager.swift:bootstrapGeoDownload(manager:)
+App/Sources/Services/VpnManager.swift:waitForStatus(manager:target:timeout:)
+App/Sources/Services/VpnManager.swift:applyConnectionStatus's
+    .preparing → .stopped suppression branch (no longer needed,
+    we never bring the tunnel up during bootstrap)
+```
+
+No new FFI, no entitlement changes, no Info.plist changes, no
+ATS exceptions. `NSAllowsLocalNetworking: true` is already set on the
+app (`project.yml`, `NSAppTransportSecurity` block), which is what
+permits the loopback HTTP proxy in the first place.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Engine init in App process bloats cold-start. | `meow_engine_start` is only called inside `connect()`, never at launch. Cold start is unaffected. |
+| App-process engine collides with PacketTunnel extension's engine on 9090 / 7890. | Random ephemeral mixed-port; the external-controller port (9090) is not actually queried during bootstrap, but we should also randomize it to be safe. Alternative: skip the `external-controller` line entirely in the minimal config — the engine doesn't need a REST API if no caller is using it. **Prefer skipping.** |
+| `URLSession.connectionProxyDictionary` is ignored on iOS in some configurations. | Documented as supported since iOS 10 for HTTP and HTTPS-via-CONNECT. We can validate during dev with an iPhone 16 Pro simulator + Charles intercepting the loopback hop. Listed in test plan. |
+| The user's profile's first proxy is the bootstrap proxy — same chicken-as-current. | Acknowledged. First-proxy degradation still fails. Multi-mirror fallback addresses the case where the proxy is fine but jsDelivr isn't; first-proxy reliability is a separate ADR. |
+| In-process engine holds memory the app didn't need before. | Minimal config has zero rule-providers and zero geox-url, so the engine's in-memory footprint is dominated by the one proxy adapter. Expected: low single-digit MB. Need to measure. |
+| Port held in TIME_WAIT after `meow_engine_stop`. | Random port per bootstrap; no impact on subsequent runs. |
+| `meow_engine_start` returns before the socket is fully bound. | The cold-connect readiness probe pattern from `AppModel.replaySelectedProxies` (`App/Sources/AppModel.swift:81-91`) is the proven mitigation — 100 ms × up-to-10 retries against the loopback listener. |
+| ATS rejects HTTPS-via-HTTP-proxy on loopback. | `NSAllowsLocalNetworking: true` is already in `project.yml`; this is exactly the case it's for. Adding `NSExceptionDomains` is not needed because the destination is `cdn.jsdelivr.net` (publicly HTTPS-capable), not a non-TLS host. |
+| Engine startup logs leak to the app's stderr / device console. | mihomo-rust logging is gated by `log-level: warning` in the minimal config (`MinimalConfigBuilder.swift:37`); accept the warnings, they're useful for diagnostics. |
+| User force-quits app mid-bootstrap. | Engine is in-process — dies with the app. No external cleanup needed. Contrast with the current bootstrap-tunnel approach where a force-quit between `configURL` overwrite and `defer`-restore leaves a wedged config. |
+
+## Test plan
+
+* **Unit:** `BootstrapEngineTests` covering start-twice (idempotent),
+  stop-when-not-running (no-op), start-fails-when-port-held
+  (synthetic — bind 127.0.0.1:7890 in the test then attempt to
+  start; this only applies if we don't go with random-port).
+* **Unit:** `GeoAssetServiceTests` extended with a fake URLSession
+  scenario that returns `URLError(.secureConnectionFailed)` on URL #1,
+  succeeds on URL #2 — verifies mirror walk picks the right asset and
+  writes atomically.
+* **Integration (`MeowIntegrationTests`):** start `BootstrapEngine` against
+  a real minimal config pointing at a single test-proxy, fetch a
+  small fixture via `URLSession.connectionProxyDictionary`, verify
+  bytes match. Skip on CI if a test proxy isn't available; mark as
+  `#if INTEGRATION`.
+* **Manual on-device (per CLAUDE.md QA path):** iPhone 16 Pro on
+  iOS 26, fresh install, real subscription. Confirm:
+  * First connect succeeds within ~5 s of "Preparing…" (vs current
+    ~30 s+).
+  * `configURL` on disk is never overwritten with the minimal
+    config (compare before/after `connect()`).
+  * `NEVPNStatus` only transitions once
+    (`.disconnected → .connecting → .connected`), not twice.
+  * Force-quitting the app mid-download leaves the user's profile
+    intact.
+* **Manual failure paths:**
+  * Cellular with first-proxy intentionally pointed at a bad endpoint
+    → engine starts, download fails, mirror walk fails, error banner
+    says "Failed to download geoip" with a more specific URLError
+    code (Approach D layered in — see below).
+  * Cellular with first-proxy fine but jsDelivr blocked → mirror walk
+    catches it on the second mirror.
+
+## Rollout
+
+Single PR, no feature flag. Justification:
+
+* The change is bounded to first-connect when geo files are missing.
+* Subsequent connects on the same install never enter this path
+  (`allFilesPresent()` fast path,
+  `App/Sources/Services/GeoAssetService.swift:38-47`).
+* Rollback is straightforward: revert the PR; existing-install users
+  with geo files on disk are unaffected.
+* No schema, no on-disk format change, no shared-store / IPC
+  contract change.
+
+## Future work not in scope
+
+* **Engine-side TLS for geo downloads (Approach C).** If
+  URLSession-over-loopback proves to still hit `-1200` for reasons
+  outside our control (e.g., iOS Security framework strictness on
+  some jsDelivr-served chains), revisit with a `meow_engine_fetch_url`
+  FFI that uses mihomo's TLS stack.
+* **Bundling geo files in the IPA.** Removes the chicken-and-egg
+  entirely; ~5–6 MB IPA cost. Deserves its own ADR weighing IPA size
+  vs onboarding reliability.
+* **Banner diagnostics (Approach D).** Cheap and orthogonal; should
+  land regardless of which path we pick, but is out of scope here
+  to keep this ADR focused.
+* **Pluggable bootstrap-proxy selection.** "First proxy" is a sharp
+  edge if the user's first proxy is degraded. Auto-select fastest /
+  let user pin a bootstrap proxy. Out of scope.
+
+## References
+
+* `INVESTIGATION-2026-05-19-geoip-download-tls-failure.md` — symptom
+  walkthrough and ruling.
+* `dd12fe6 feat(geo): bootstrap geo download via first proxy` — the
+  approach this ADR proposes to supersede.
+* `e442d7b feat(geo): lazy-download GeoIP/ASN databases on connect`
+  — the commit that removed bundled geo assets, creating the
+  chicken-and-egg in the first place.
+* `App/Sources/AppModel.swift:81-91` — cold-connect readiness probe
+  pattern, reused here for "is the loopback listener up yet."
+* `MeowCore/include/mihomo_core.h` — FFI surface that already
+  supports engine-without-TUN.


### PR DESCRIPTION
User-reported banner "无法启动隧道 / Failed to download geoip: TLS
错误导致安全连接失败" traced end-to-end. The detail half is iOS's
zh-Hans rendering of NSURLErrorSecureConnectionFailed (-1200) thrown
from GeoAssetService.download against cdn.jsdelivr.net.

Key finding: the download now rides the dd12fe6 bootstrap tunnel
(minimal config, first proxy + MATCH) rather than a direct dial, so the
failing TLS handshake is between iOS and jsDelivr through the user's
first proxy. This is the second variant of the chicken-and-egg the
bootstrap fix was meant to solve — timeout class is gone, TLS class
remains and is widened by the proxy-mediated path.

Doc covers the full call chain with file:line references, what the
14/12 traffic counters in the screenshot imply, what -1200 rules in /
out, why proxy-mediated TLS is the most likely contributor on 5G
cellular, and five candidate mitigations (multi-mirror fallback,
bundling, pluggable bootstrap proxy, banner diagnostics, FFI
breadcrumbs) with tradeoffs — not implemented in this pass.