### PR TITLE
feat(geo,build): implement ADR-004 dev-convenience + ADR-005 in-process bootstrap engine

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -37,8 +37,6 @@
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -56,10 +54,6 @@
 		<key>UIColorName</key>
 		<string>LaunchBackground</string>
 	</dict>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/App/Sources/Services/BootstrapEngine.swift
+++ b/App/Sources/Services/BootstrapEngine.swift
@@ -1,0 +1,176 @@
+import Darwin
+import Foundation
+import MeowModels
+import Network
+import os
+
+/// In-process mihomo engine used to fetch GeoIP/ASN databases through the
+/// user's first proxy without bringing `NEPacketTunnelProvider` up. Replaces
+/// the bootstrap-tunnel detour formerly in `VpnManager.bootstrapGeoDownload`
+/// — see `docs/adr/ADR-005-geoip-download-via-in-process-proxy.md`.
+///
+/// Lifecycle:
+///   1. `start()` picks a random ephemeral mixed-port, writes a minimal YAML
+///      to `AppGroup.bootstrapConfigDir/minimal.yaml`, calls
+///      `meow_engine_start`, and probes the loopback listener for readiness.
+///   2. Caller points `URLSession.connectionProxyDictionary` at
+///      `127.0.0.1:<port>` and downloads.
+///   3. `stop()` calls `meow_engine_stop`. The bootstrap engine is transient;
+///      its port dies with the process and won't collide with the long-lived
+///      PacketTunnel extension engine on 7890.
+@MainActor
+final class BootstrapEngine {
+    enum Failure: LocalizedError {
+        case engineStartFailed(String)
+        case noPortAvailable
+        case listenerNotReady
+
+        var errorDescription: String? {
+            switch self {
+            case let .engineStartFailed(message):
+                "Failed to start bootstrap engine: \(message)"
+            case .noPortAvailable:
+                "Bootstrap engine could not reserve a loopback port."
+            case .listenerNotReady:
+                "Bootstrap engine started but loopback listener never came up."
+            }
+        }
+    }
+
+    private nonisolated static let log = Logger(subsystem: "io.github.madeye.meow", category: "bootstrap-engine")
+
+    private var runningPort: Int?
+
+    var isRunning: Bool {
+        runningPort != nil
+    }
+
+    /// Bring up the engine-only mihomo against a minimal config and return the
+    /// loopback port URLSession should route through. Idempotent: returns the
+    /// existing port if already started.
+    func start() async throws -> Int {
+        if let port = runningPort { return port }
+
+        let sourceYAML = try String(contentsOf: AppGroup.configURL, encoding: .utf8)
+        let port = try Self.reserveEphemeralPort()
+        let minimalYAML = try MinimalConfigBuilder.build(sourceYAML: sourceYAML, mixedPort: port)
+
+        try FileManager.default.createDirectory(
+            at: AppGroup.bootstrapConfigDir,
+            withIntermediateDirectories: true,
+        )
+        let configPath = AppGroup.bootstrapConfigDir.appending(path: "minimal.yaml")
+        try minimalYAML.write(to: configPath, atomically: true, encoding: .utf8)
+
+        let rc = configPath.path.withCString { meow_engine_start($0) }
+        guard rc == 0 else {
+            let msg = meow_core_last_error().map { String(cString: $0) } ?? "rc=\(rc)"
+            throw Failure.engineStartFailed(msg)
+        }
+
+        try await waitForListener(port: port)
+        runningPort = port
+        Self.log.notice("bootstrap engine up on 127.0.0.1:\(port, privacy: .public)")
+        return port
+    }
+
+    func stop() async {
+        guard runningPort != nil else { return }
+        meow_engine_stop()
+        runningPort = nil
+        Self.log.notice("bootstrap engine stopped")
+    }
+
+    // MARK: - Private
+
+    /// Bind a transient socket on `127.0.0.1:0`, read back the OS-assigned
+    /// port, then close it. Subject to a TOCTOU race against a concurrent
+    /// binder, but the window is microseconds and the only realistic
+    /// competitor (PacketTunnel extension engine) targets fixed 7890. If the
+    /// kernel never honors our hand-off, `waitForListener` catches it.
+    private static func reserveEphemeralPort() throws -> Int {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw Failure.noPortAvailable }
+        defer { close(fd) }
+
+        var yes: Int32 = 1
+        _ = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                bind(fd, sa, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else { throw Failure.noPortAvailable }
+
+        var bound = sockaddr_in()
+        var boundLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &bound) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                getsockname(fd, sa, &boundLen)
+            }
+        }
+        guard nameResult == 0 else { throw Failure.noPortAvailable }
+        return Int(UInt16(bigEndian: bound.sin_port))
+    }
+
+    /// Same cold-connect readiness pattern as `AppModel.replaySelectedProxies`
+    /// — 100 ms × up to 10 — but targeted at the loopback listener instead of
+    /// the REST API. `meow_engine_start` returns before the mixed-port
+    /// listener completes its bind, so a synchronous fall-through would lose
+    /// the first URLSession connect.
+    private func waitForListener(port: Int) async throws {
+        for _ in 0 ..< 10 {
+            if await Self.canConnect(toPort: port) { return }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        throw Failure.listenerNotReady
+    }
+
+    private static func canConnect(toPort port: Int) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            let connection = NWConnection(
+                host: "127.0.0.1",
+                port: NWEndpoint.Port(integerLiteral: UInt16(port)),
+                using: .tcp,
+            )
+            let resumer = ResultBox()
+            connection.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    if resumer.takeOnce() {
+                        continuation.resume(returning: true)
+                    }
+                    connection.cancel()
+                case let .failed(error):
+                    log.debug("listener probe failed: \(error.localizedDescription, privacy: .public)")
+                    if resumer.takeOnce() {
+                        continuation.resume(returning: false)
+                    }
+                    connection.cancel()
+                default:
+                    break
+                }
+            }
+            connection.start(queue: .global(qos: .userInitiated))
+        }
+    }
+
+    private final class ResultBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var done = false
+        func takeOnce() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            if done { return false }
+            done = true
+            return true
+        }
+    }
+}

--- a/App/Sources/Services/GeoAssetService.swift
+++ b/App/Sources/Services/GeoAssetService.swift
@@ -51,18 +51,85 @@ enum GeoAssetService {
     /// works before the extension has ever written `effective-config.yaml`.
     /// Falls back to `defaultGeoXURL` when no source config exists yet
     /// (Settings → "Connect (no profile required)" debug path).
-    static func ensureFiles(prefs: Preferences) async throws {
+    ///
+    /// `throughProxy` (when non-nil) routes the HTTPS download through a
+    /// loopback proxy via `URLSession.connectionProxyDictionary`. Used by the
+    /// in-process `BootstrapEngine`; see ADR-005.
+    static func ensureFiles(prefs: Preferences, throughProxy proxy: URL? = nil) async throws {
         let urls = geoXURLs(prefs: prefs)
         guard !urls.isEmpty else { return }
 
         try FileManager.default.createDirectory(at: AppGroup.mihomoConfigDir, withIntermediateDirectories: true)
 
+        let userOverridesGeoXURL = userProfileHasGeoXURL()
+
         for (name, sourceURL) in urls {
             let destination = AppGroup.mihomoConfigDir.appending(path: sourceURL.lastPathComponent)
             let size = (try? FileManager.default.attributesOfItem(atPath: destination.path)[.size] as? Int) ?? 0
             if size > 0 { continue }
-            try await download(name: name, from: sourceURL, to: destination)
+
+            let mirrors: [URL] = if userOverridesGeoXURL {
+                [sourceURL]
+            } else {
+                (EffectiveConfigWriter.geoXMirrors[name] ?? [sourceURL.absoluteString]).compactMap(URL.init(string:))
+            }
+            try await downloadWithMirrors(name: name, mirrors: mirrors, to: destination, throughProxy: proxy)
         }
+    }
+
+    private static func userProfileHasGeoXURL() -> Bool {
+        let source = (try? String(contentsOf: AppGroup.configURL, encoding: .utf8)) ?? ""
+        let parsed = (try? Yams.load(yaml: source)) as? [String: Any]
+        return parsed?["geox-url"] != nil
+    }
+
+    /// Recoverable URLError categories — connection-class failures we want to
+    /// retry against the next mirror. Anything else (cancel, bad URL, server
+    /// 5xx) propagates immediately.
+    private static let mirrorRetryableCodes: Set<URLError.Code> = [
+        .secureConnectionFailed,
+        .cannotConnectToHost,
+        .timedOut,
+        .networkConnectionLost,
+        .notConnectedToInternet,
+        .dnsLookupFailed,
+    ]
+
+    private static func downloadWithMirrors(
+        name: String,
+        mirrors: [URL],
+        to destination: URL,
+        throughProxy proxy: URL?,
+    ) async throws {
+        var lastError: Error?
+        for (index, source) in mirrors.enumerated() {
+            do {
+                try await download(name: name, from: source, to: destination, throughProxy: proxy)
+                if index > 0 {
+                    log.notice("downloaded \(name, privacy: .public) from mirror #\(index, privacy: .public)")
+                }
+                return
+            } catch let Failure.downloadFailed(_, underlying) where shouldRetry(underlying) {
+                lastError = Failure.downloadFailed(name: name, underlying: underlying)
+                continue
+            } catch let httpError as Failure {
+                if case .httpStatus = httpError {
+                    lastError = httpError
+                    continue
+                }
+                throw httpError
+            } catch {
+                throw error
+            }
+        }
+        throw lastError ?? Failure.downloadFailed(name: name, underlying: URLError(.unknown))
+    }
+
+    private static func shouldRetry(_ error: Error) -> Bool {
+        if let urlError = error as? URLError, mirrorRetryableCodes.contains(urlError.code) {
+            return true
+        }
+        return false
     }
 
     private static func geoXURLs(prefs: Preferences) -> [(name: String, url: URL)] {
@@ -76,13 +143,34 @@ enum GeoAssetService {
         }
     }
 
-    private static func download(name: String, from source: URL, to destination: URL) async throws {
+    private static func download(
+        name: String,
+        from source: URL,
+        to destination: URL,
+        throughProxy proxy: URL? = nil,
+    ) async throws {
         log.info("downloading \(name, privacy: .public) from \(source.absoluteString, privacy: .public)")
         let session: URLSession = {
             let config = URLSessionConfiguration.ephemeral
             config.timeoutIntervalForRequest = 60
             config.timeoutIntervalForResource = 180
             config.waitsForConnectivity = false
+            if let proxy, let host = proxy.host, let port = proxy.port {
+                // iOS has supported HTTPS-via-HTTP-proxy (CONNECT) since iOS 10.
+                // The `HTTPSEnable/HTTPSProxy/HTTPSPort` keys are macOS-only in
+                // SDK headers but are honored at runtime via untyped CFNetwork
+                // string keys — the documented iOS workaround.
+                // `NSAllowsLocalNetworking: true` in project.yml permits the
+                // loopback hop.
+                config.connectionProxyDictionary = [
+                    kCFNetworkProxiesHTTPEnable as String: true,
+                    kCFNetworkProxiesHTTPProxy as String: host,
+                    kCFNetworkProxiesHTTPPort as String: port,
+                    "HTTPSEnable": true,
+                    "HTTPSProxy": host,
+                    "HTTPSPort": port,
+                ]
+            }
             return URLSession(configuration: config)
         }()
         defer { session.invalidateAndCancel() }

--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -26,6 +26,7 @@ final class VpnManager {
     }
 
     private var manager: NETunnelProviderManager?
+    private let bootstrapEngine = BootstrapEngine()
     // nonisolated(unsafe): written only from attach() on MainActor, read from
     // deinit (which is nonisolated). NotificationCenter.removeObserver is
     // thread-safe, so a torn read here is harmless.
@@ -54,13 +55,14 @@ final class VpnManager {
     }
 
     /// Kick off a connect. Caller should have already written the selected
-    /// profile YAML into the App Group container. Re-enables on-demand if
-    /// `disconnect` previously turned it off.
+    /// profile YAML into the App Group container.
     ///
-    /// Stages any missing GeoIP/ASN databases (`GeoAssetService.ensureFiles`)
-    /// before issuing `startVPNTunnel`. The badge surfaces this window as
-    /// `.preparing` so the UI doesn't lie about being "Connected" while the
-    /// engine would actually fail to start on a missing MMDB.
+    /// When GeoIP/ASN files are missing, runs an in-process mihomo engine
+    /// (no TUN) so URLSession can download through the user's first proxy
+    /// over `127.0.0.1:<port>` — see ADR-005. The `.preparing` badge covers
+    /// the engine boot + download window; `startVPNTunnel` only fires once
+    /// the files are on disk, so the tunnel only transitions
+    /// `.disconnected → .connecting → .connected` once.
     func connect() async {
         lastError = nil
         if manager == nil { await refresh() }
@@ -68,63 +70,24 @@ final class VpnManager {
         stage = .preparing
         do {
             if !GeoAssetService.allFilesPresent() {
-                try await bootstrapGeoDownload(manager: manager)
+                let port = try await bootstrapEngine.start()
+                do {
+                    let proxy = URL(string: "http://127.0.0.1:\(port)")
+                    try await GeoAssetService.ensureFiles(
+                        prefs: Preferences.load(from: AppGroup.defaults),
+                        throughProxy: proxy,
+                    )
+                } catch {
+                    await bootstrapEngine.stop()
+                    throw error
+                }
+                await bootstrapEngine.stop()
             }
             try manager.connection.startVPNTunnel()
         } catch {
             lastError = error.localizedDescription
             stage = .error
         }
-    }
-
-    /// Two-step bootstrap when the GeoIP/ASN databases aren't on disk yet:
-    ///
-    ///   1. Swap `configURL` for a `MinimalConfigBuilder` config that uses
-    ///      only the first proxy from the user profile + a `MATCH` rule.
-    ///   2. Start the tunnel, wait for `.connected`, and download the geo
-    ///      files via URLSession — the app's traffic is routed through the
-    ///      tunnel's TUN, so jsDelivr is reached *through* the proxy.
-    ///   3. Stop the tunnel, wait for `.disconnected`, restore the original
-    ///      `configURL`.
-    ///
-    /// The caller then issues `startVPNTunnel` against the restored config.
-    private func bootstrapGeoDownload(manager: NETunnelProviderManager) async throws {
-        let sourceYAML = try String(contentsOf: AppGroup.configURL, encoding: .utf8)
-        let minimal = try MinimalConfigBuilder.build(sourceYAML: sourceYAML)
-
-        try minimal.write(to: AppGroup.configURL, atomically: true, encoding: .utf8)
-        defer {
-            // Best-effort restore. If a crash happens between here and the
-            // restore line below, the user's next profile reselect will
-            // re-stamp the real config.
-            try? sourceYAML.write(to: AppGroup.configURL, atomically: true, encoding: .utf8)
-        }
-
-        try manager.connection.startVPNTunnel()
-        try await waitForStatus(manager: manager, target: .connected, timeout: 30)
-        do {
-            try await GeoAssetService.ensureFiles(prefs: Preferences.load(from: AppGroup.defaults))
-        } catch {
-            manager.connection.stopVPNTunnel()
-            try? await waitForStatus(manager: manager, target: .disconnected, timeout: 10)
-            throw error
-        }
-        manager.connection.stopVPNTunnel()
-        try await waitForStatus(manager: manager, target: .disconnected, timeout: 10)
-    }
-
-    private func waitForStatus(
-        manager: NETunnelProviderManager,
-        target: NEVPNStatus,
-        timeout: TimeInterval,
-    ) async throws {
-        if manager.connection.status == target { return }
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            try await Task.sleep(for: .milliseconds(200))
-            if manager.connection.status == target { return }
-        }
-        throw URLError(.timedOut)
     }
 
     /// Disable on-demand first, then tear down the tunnel. iOS reclaims the NE
@@ -203,11 +166,6 @@ final class VpnManager {
     func applyConnectionStatus(_ status: NEVPNStatus) {
         let previous = stage
         let next = map(status)
-        // Hold `.preparing` until NE actually moves off `.disconnected` —
-        // otherwise the observer fire mid-`connect()` (cold attach edge,
-        // on-demand bounce) would flash the badge back to "Stopped" while
-        // the geo-asset download is still in flight.
-        if previous == .preparing, next == .stopped { return }
         stage = next
         if next == .connected, previous != .connected {
             onConnected?()

--- a/MeowShared/Sources/MeowModels/AppGroup.swift
+++ b/MeowShared/Sources/MeowModels/AppGroup.swift
@@ -39,6 +39,13 @@ public enum AppGroup {
         containerURL.appending(path: "mihomo", directoryHint: .isDirectory)
     }
 
+    /// Scratch directory for the app-process bootstrap engine's transient
+    /// minimal YAML. Kept separate from `configURL` so a crash mid-bootstrap
+    /// can never leave the user's real profile wedged on the minimal config.
+    public static var bootstrapConfigDir: URL {
+        containerURL.appending(path: "bootstrap", directoryHint: .isDirectory)
+    }
+
     /// UserDefaults suite shared between app and extension. Force-unwrap is
     /// safe once entitlements are wired — missing suite indicates a config bug
     /// that should fail loudly.

--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -33,6 +33,38 @@ public enum EffectiveConfigWriter {
         "asn": "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb",
     ]
 
+    /// Per-asset mirror lists walked when the primary `defaultGeoXURL` host
+    /// fails with a recoverable URLError. Order matters — primary first, then
+    /// jsDelivr alternates, then raw GitHub, then a GH-proxy fallback. If the
+    /// user's profile ships its own `geox-url:`, mirrors are NOT consulted —
+    /// the user's intent wins.
+    public static let geoXMirrors: [String: [String]] = [
+        "geoip": [
+            "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb",
+            "https://gcore.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb",
+            "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/geoip.metadb",
+            "https://ghproxy.com/https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/geoip.metadb",
+        ],
+        "mmdb": [
+            "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/country.mmdb",
+            "https://gcore.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/country.mmdb",
+            "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/country.mmdb",
+            "https://ghproxy.com/https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/country.mmdb",
+        ],
+        "geosite": [
+            "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat",
+            "https://gcore.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat",
+            "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/geosite.dat",
+            "https://ghproxy.com/https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/geosite.dat",
+        ],
+        "asn": [
+            "https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb",
+            "https://gcore.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb",
+            "https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/GeoLite2-ASN.mmdb",
+            "https://ghproxy.com/https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/release/GeoLite2-ASN.mmdb",
+        ],
+    ]
+
     public static func write(
         sourceYAML: String,
         to destination: URL,

--- a/MeowShared/Sources/MeowModels/MinimalConfigBuilder.swift
+++ b/MeowShared/Sources/MeowModels/MinimalConfigBuilder.swift
@@ -24,6 +24,14 @@ public enum MinimalConfigBuilder {
     }
 
     public static func build(sourceYAML: String) throws -> String {
+        try build(sourceYAML: sourceYAML, mixedPort: nil)
+    }
+
+    /// Bootstrap-friendly overload: when `mixedPort` is non-nil, that port
+    /// replaces the default and the `external-controller` line is omitted —
+    /// the bootstrap engine doesn't need a REST API and skipping it avoids
+    /// 9090 collisions with a lingering PacketTunnel extension engine.
+    public static func build(sourceYAML: String, mixedPort: Int?) throws -> String {
         let loaded = try Yams.load(yaml: sourceYAML)
         let root = (loaded as? [String: Any]) ?? [:]
         let proxies = (root["proxies"] as? [[String: Any]]) ?? []
@@ -31,13 +39,15 @@ public enum MinimalConfigBuilder {
             throw BuildError.noProxies
         }
 
-        let minimal: [String: Any] = [
-            "mixed-port": EffectiveConfigWriter.defaultMixedPort,
-            "external-controller": EffectiveConfigWriter.defaultExternalController,
+        var minimal: [String: Any] = [
+            "mixed-port": mixedPort ?? EffectiveConfigWriter.defaultMixedPort,
             "log-level": "warning",
             "proxies": [first],
             "rules": ["MATCH,\(name)"],
         ]
+        if mixedPort == nil {
+            minimal["external-controller"] = EffectiveConfigWriter.defaultExternalController
+        }
         return try Yams.dump(object: minimal, sortKeys: true)
     }
 }

--- a/docs/adr/ADR-005-geoip-download-via-in-process-proxy.md
+++ b/docs/adr/ADR-005-geoip-download-via-in-process-proxy.md
@@ -1,7 +1,7 @@
 # ADR-005: Download geoip via in-process mihomo proxy, not via a bootstrap tunnel
 
-- **Status:** Proposed
-- **Date:** 2026-05-19
+- **Status:** Accepted
+- **Date:** 2026-05-19 (proposed), 2026-05-20 (accepted)
 - **Author:** Claude Opus 4.7 driven by max.c.lv@gmail.com
 - **Builds on:** `INVESTIGATION-2026-05-19-geoip-download-tls-failure.md`
 - **Supersedes (if accepted):** the bootstrap-tunnel approach in commit

--- a/project.yml
+++ b/project.yml
@@ -48,13 +48,10 @@ targets:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.4"
         CFBundleVersion: "2026051901"
-        LSRequiresIPhoneOS: true
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
           UIColorName: LaunchBackground
-        UIRequiredDeviceCapabilities:
-          - arm64
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
         UISupportedInterfaceOrientations~ipad:
@@ -86,6 +83,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: io.github.madeye.meow
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: YES
+        SUPPORTED_PLATFORMS: "iphoneos iphonesimulator macosx"
         CODE_SIGN_ENTITLEMENTS: App/App.entitlements
         SWIFT_OBJC_BRIDGING_HEADER: App/Sources/BridgingHeader.h
         GENERATE_INFOPLIST_FILE: NO


### PR DESCRIPTION
## Summary

Implements both ADRs in `docs/adr/`:

- **ADR-004 (dev-convenience):** widen the meow-ios target so the iOSAppOnMac destination is selectable from Xcode's UI for non-NE work. Removes `LSRequiresIPhoneOS`, drops `UIRequiredDeviceCapabilities: arm64`, adds `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD=YES`, widens `SUPPORTED_PLATFORMS` to include `macosx`. NE-touching paths still hit the macOS provider gap documented in the ADR — this is launch-from-Xcode-only convenience.
- **ADR-005 (geoip via in-process proxy):** replaces the bootstrap-tunnel detour with a new `BootstrapEngine` that runs mihomo's engine (no TUN) in the app process on a random ephemeral loopback port, served to `URLSession.connectionProxyDictionary`. `GeoAssetService` gains `throughProxy:` and a per-asset mirror walk (jsDelivr / gcore / raw.gh / ghproxy). `MinimalConfigBuilder` gains a port override and omits `external-controller` for bootstrap to avoid 9090 collisions with the PacketTunnel extension engine. `VpnManager.bootstrapGeoDownload` + `waitForStatus` + the `.preparing→.stopped` suppression branch all deleted. Promotes ADR-005 status to Accepted.

Net effect of ADR-005: NE only transitions `.disconnected → .connecting → .connected` once; the user's `configURL` is never overwritten; worst-case "Preparing…" drops by ~40 s.

## Path B attestation (code PR)

- [x] `swiftformat --lint .` at repo root → 0 violations
- [x] `swiftlint --strict` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' -only-testing:MeowTests` → 129 tests pass (iPhone 16 Pro sim unavailable on host; 17 Pro on iOS 26.4 is the closest available iOS 26 simulator)
- [x] `xcodebuild test ... -only-testing:MeowIntegrationTests` → 26 tests pass
- [x] `git diff origin/main...HEAD --stat` reviewed — only ADR-targeted Swift, project.yml, generated Info.plist, and ADR markdown

No FFI changes, no Rust changes, no workflow files touched → Path B applies.

## Test plan

- [x] Local lint (swiftformat --lint, swiftlint --strict)
- [x] Local MeowTests (129 pass on iPhone 17 Pro iOS 26.4)
- [x] Local MeowIntegrationTests (26 pass on iPhone 17 Pro iOS 26.4)
- [ ] Manual on-device first-connect (per ADR-005 test plan): fresh install + real subscription, verify "Preparing…" stays sub-5s, `configURL` is never overwritten, NE only transitions once, force-quit mid-download leaves profile intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)