### PR TITLE
chore(release): bump build to 2026052002 (ASC rejected 2026052001)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026052001</string>
+	<string>2026052002</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2026052001</string>
+	<string>2026052002</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026052001"
+        CFBundleVersion: "2026052002"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026052001"
+        CFBundleVersion: "2026052002"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

ASC rejected the 2026052001 upload with code 90189 ("Redundant Binary Upload — You've already uploaded a build with build number '2026052001' for version number '1.1.4'"). One-tick bump to land the validate_config nested-runtime crash fix from #167 in TestFlight.

## Path B attestation

- Pure version-string bump (project.yml + regenerated Info.plists). No Swift, Rust, or workflow changes.
- swiftformat --lint . / swiftlint --strict: trivially pass — no source changes.
- MeowTests / cargo tests: unchanged from #167's green state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)