### PR TITLE
chore(release): bump build number to 2026052003

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026052002</string>
+	<string>2026052003</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2026052002</string>
+	<string>2026052003</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026052002"
+        CFBundleVersion: "2026052003"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026052002"
+        CFBundleVersion: "2026052003"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
Pure \`CFBundleVersion\` bump for the next TestFlight upload. No Swift/Rust/script logic touched.

## Diff

- \`project.yml\`: \`CFBundleVersion: "2026052002"\` → \`"2026052003"\` (App + PacketTunnel targets).
- \`App/Info.plist\` / \`PacketTunnel/Info.plist\`: regenerated by \`scripts/generate-xcodeproj.sh\`.

## Path B local-CI attestation

- [x] \`swiftformat --lint .\` — 0 violations.
- [x] \`swiftlint --strict\` — 0 violations.
- [x] \`cargo test --lib\` in \`core/rust/mihomo-ios-ffi/\` — 38 passed (run on main tip 89f7258, identical to this branch's source).
- [x] \`xcodebuild test … -only-testing:MeowTests\` (iPhone 17 / iOS 26.4) — 126 tests / 24 suites green on main tip 89f7258; this branch adds only Info.plist version-string bumps and changes no compiled or testable code.
- [x] \`git diff origin/main...HEAD --stat\` reviewed — 3 files (2 Info.plist + project.yml), version strings only.

\`.github/workflows/*.yml\` not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)