### PR TITLE
chore(release): bump build number to 2026052004

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026052003</string>
+	<string>2026052004</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2026052003</string>
+	<string>2026052004</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026052003"
+        CFBundleVersion: "2026052004"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.1.4"
-        CFBundleVersion: "2026052003"
+        CFBundleVersion: "2026052004"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
2026052003 was rejected by App Store Connect (\`Redundant Binary Upload\`, error code 90189) — the build number already existed server-side from a prior session, so the upload couldn't proceed. Bumping to 2026052004 to land the same source.

## Path B attestation

- [x] \`swiftformat --lint .\` — 0 violations.
- [x] \`swiftlint --strict\` — 0 violations.
- [x] \`cargo test --lib\` in \`core/rust/mihomo-ios-ffi/\` — 38 passed (on main tip fe838b9, identical to this branch's source).
- [x] \`xcodebuild test … -only-testing:MeowTests\` (iPhone 17 / iOS 26.4) — 126 / 24 suites green on main tip fe838b9; this branch only bumps Info.plist version strings.
- [x] \`git diff origin/main...HEAD --stat\` — 3 files, version strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)