### PR TITLE
chore(deps): bump meow-rs to a703135d for ech-tls-tunnel fingerprint default

### DIFF
--- a/core/rust/geosite-mrs-builder/Cargo.toml
+++ b/core/rust/geosite-mrs-builder/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
-meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f" }
+meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
 
 # `.mrs` writing pulls zstd via meow-rules; no extra dep needed here.

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -770,7 +770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1634,7 +1634,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "meow-api"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "axum",
  "base64",
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "meow-app"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "anyhow",
  "clap",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1746,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "dashmap 6.2.1",
  "futures",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "base64",
  "libc",
@@ -1820,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "async-trait",
  "base64",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "async-trait",
  "base64",
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "smallvec",
 ]
@@ -1897,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "meow-tunnel"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f#27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f"
+source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1963,7 +1963,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2234,7 +2234,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2501,7 +2501,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2948,7 +2948,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3676,7 +3676,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -66,7 +66,7 @@ lwip = "0.3"
 # in-engine geodata startup-fetch added at 9048f370d6 and the
 # proxy-routed internal_http downloader at 97b1efd435. Restore to a tag
 # once a v0.8.x release is cut.
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -74,17 +74,17 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
 # `meow-app` is the upstream binary crate; we depend on it solely for
 # `geodata_fetch::run_on_startup`, which upstream extracted at commit
 # 27f9d79bf3 for downstream FFI callers like us. `default-features = false`
 # avoids dragging in the listener / dns-server / protocol bundles meant for
 # the `meow` binary build.
-meow-app = { git = "https://github.com/madeye/meow-rs", rev = "27f9d79bf31e7b23d1ccc98fbfe15ab16361ad9f", default-features = false }
+meow-app = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc", default-features = false }
 
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that


### PR DESCRIPTION
## Summary
- Bumps `meow-config` / `meow-proxy` / `meow-dns` / `meow-tunnel` / `meow-api` / `meow-common` / `meow-app` from `27f9d79b` to `a703135d`.
- The upstream commit (`feat(ech-tls-tunnel): honor fingerprint opt, default to chrome`) makes the SIP003 ech-tls-tunnel plugin parse `fingerprint=<value>` (also `client-fingerprint` / `client_fingerprint`) and default to `chrome` when the opt is absent.
- That flips the `meow-transport` TLS-backend tiebreaker to BoringSSL (uTLS-shaped Chrome ClientHello + real ECH). ECH-only servers — whose stealth gate RSTs any TLS hello missing the `0xfe0d` extension — now accept the dial.
- `core/rust/geosite-mrs-builder/Cargo.toml` pins the same rev for `meow-rules` so the build-time geosite.mrs generator stays in sync.

## End-to-end verification (Tart VM, macos-utun-harness)
Ran `MATCH,ech-sgp` config against the live ss + ech-tls-tunnel server through `meow-utun` inside the `meow-ios-dev` VM. Pre-bump: TCP-RST cascade at TLS handshake. Post-bump:
```
INFO meow_tunnel::tcp:    172.19.0.1:54267 → www.gstatic.com:443 match MATCH() using ech-sgp
INFO meow_transport::tls: boring TLS handshake complete sni=sgp.maxlv.net ech_requested=true ech_accepted=true tls_version=TLSv1.3
              → HTTP 204 in 3.6s
```

## Path B attestation
Per CLAUDE.md Path B (admin rebase-merge for code PRs). All checks ran locally on this branch's HEAD and passed:

- [x] `swiftformat --lint .` → `0/88 files require formatting, 27 files skipped.`
- [x] `swiftlint --strict` → `Found 0 violations, 0 serious in 79 files.`
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → `** TEST SUCCEEDED **`
- [x] `(cd core/rust/meow-ios-ffi && cargo fmt --all -- --check)` → clean
- [x] `(cd core/rust/meow-ios-ffi && cargo clippy --all-targets -- -D warnings)` → 0 errors
- [x] `(cd core/rust/meow-ios-ffi && cargo test --lib)` → 38 passed
- [x] `scripts/build-rust.sh` → `MeowCore.xcframework` written
- [x] `git diff origin/main...HEAD --stat` reviewed — 3 files (Cargo.toml × 2 + Cargo.lock), no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)