### PR TITLE
fix(ffi): drop geodata_fetch startup spawn — OOMs the 50 MB NE budget

### DIFF
--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -490,7 +490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
@@ -503,18 +502,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -770,7 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1664,31 +1651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "meow-app"
-version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
-dependencies = [
- "anyhow",
- "clap",
- "dashmap 6.2.1",
- "libc",
- "meow-api",
- "meow-common",
- "meow-config",
- "meow-dns",
- "meow-listener",
- "meow-proxy",
- "meow-rules",
- "meow-tunnel",
- "parking_lot",
- "rustls",
- "serde_yaml",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "meow-common"
 version = "0.8.0"
 source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
@@ -1783,7 +1745,6 @@ dependencies = [
  "lwip",
  "maxminddb",
  "meow-api",
- "meow-app",
  "meow-common",
  "meow-config",
  "meow-dns",
@@ -1801,20 +1762,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
-]
-
-[[package]]
-name = "meow-listener"
-version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
-dependencies = [
- "base64",
- "libc",
- "meow-common",
- "meow-trie",
- "meow-tunnel",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1963,7 +1910,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2234,7 +2181,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2501,7 +2448,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2948,7 +2895,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3676,7 +3623,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -79,13 +79,6 @@ meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd
 meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
 meow-api = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
 meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
-# `meow-app` is the upstream binary crate; we depend on it solely for
-# `geodata_fetch::run_on_startup`, which upstream extracted at commit
-# 27f9d79bf3 for downstream FFI callers like us. `default-features = false`
-# avoids dragging in the listener / dns-server / protocol bundles meant for
-# the `meow` binary build.
-meow-app = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc", default-features = false }
-
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that
 # accept bytes past our advertised window edge trigger a panic in

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -292,24 +292,21 @@ pub fn start(config_path: &str) -> Result<()> {
     tunnel.update_proxies(cfg.proxies);
     let stats = tunnel.statistics().clone();
 
-    // Kick off a background task that downloads any missing GeoIP / ASN /
-    // geosite DB on first boot. Routes the fetch through the first user
-    // proxy via `internal_http::first_named_proxy`, so we don't need an
-    // app-side BootstrapEngine + GeoAssetService detour to reach the
-    // jsDelivr / GitHub release URLs from behind the GFW.
-    let geodata = cfg.geodata.clone();
-    let fetch_tunnel = tunnel.clone();
-    let fetch_raw_config = Arc::clone(&raw_config);
-    let fetch_resolver = Arc::clone(&resolver);
-    crate::get_runtime().spawn(async move {
-        meow_app::geodata_fetch::run_on_startup(
-            geodata,
-            fetch_tunnel,
-            fetch_raw_config,
-            fetch_resolver,
-        )
-        .await;
-    });
+    // No `meow_app::geodata_fetch::run_on_startup` spawn here: the iOS app
+    // bundles Country.mmdb, GeoLite2-ASN.mmdb, and geosite.mrs in
+    // App/Resources/GeoData and `GeoAssetStager` stages them into
+    // `AppGroup.meowConfigDir` at app launch, so every DB the rule loader
+    // and resolver want is already on disk before the engine starts. The
+    // upstream fetcher checks `meow_config::default_geosite_path()`
+    // (`geosite.dat`) — which never exists in our layout, since we ship
+    // `geosite.mrs` — and would otherwise spawn `reqwest`/`hyper`/
+    // `tokio-rustls`/`aws-lc-rs` plus buffer a multi-MB download body in
+    // process, blowing past the 50 MB NE jetsam cap within ~0.6 s of
+    // launch (per-process-limit kill, observed via `idevicesyslog`).
+    //
+    // If a future build ever stops bundling one of the DBs, the FFI must
+    // re-introduce a fetch — but in a memory-bounded form (streamed to
+    // disk, no full-body buffer) suitable for the NE budget.
 
     // `ApiServer::new` grew from 5 to 9 parameters to serve the new
     // `/providers/*`, `/rules`, `/listeners`, and `/logs` routes. Build the


### PR DESCRIPTION
## Summary
- Removes the `meow_app::geodata_fetch::run_on_startup` spawn from `engine::start` (added in PR #178).
- That spawn was the root cause of the on-device "connects then drops" symptom on the build merged in #179: PacketTunnel exceeded the 50 MB NE jetsam cap within ~0.6 s of every launch.
- Drops the `meow-app` and `meow-listener` crates from the dep graph (no other FFI user).

## Why the fetch OOMs the extension
The upstream helper checks `meow_config::default_geosite_path()` which returns `geosite.dat`. We ship `geosite.mrs` (bundled via `App/Resources/GeoData`, staged into `AppGroup.meowConfigDir` by `GeoAssetStager`). The fetcher sees `geosite.dat` missing and unconditionally fires `reqwest + hyper + tokio-rustls + aws-lc-rs` while buffering the multi-MB body, pushing PacketTunnel's RSS past 50 MB.

Captured via `idevicesyslog` over USB (Wi-Fi syslog can't survive the VPN routing change):

```
kernel: memorystatus: PacketTunnel [80272] exceeded mem limit: ActiveHard 50 MB (fatal)
kernel: killing process 80272 [PacketTunnel] in high band FOREGROUND (100) - memorystatus_available_pages: 182197
ReportSystemMemory: Process PacketTunnel [80272] killed by jetsam reason per-process-limit
```

System RAM was plenty free; the kill is the per-process NE cap. NEAgent relaunched the extension at ~20 s gaps, each new pid (80272 → 80274 → 80275) hit the same wall.

The rule loader is unaffected — `default_geosite_candidates()` (in `meow-rules/src/geosite.rs`) lists `geosite.mrs` *before* `geosite.dat`, so rules compile fine against the bundled `.mrs`.

## Why removing the spawn is safe
`GeoAssetStager` (PR #178) unconditionally copies `Country.mmdb`, `GeoLite2-ASN.mmdb`, and `geosite.mrs` from the app bundle into `AppGroup.meowConfigDir` at app launch (`AppModel.start()`), so the engine always sees every DB it needs already on disk. There's nothing for the runtime fetcher to fill in.

If a future build ever stops bundling one of the DBs, the FFI must reintroduce a fetch — but in a memory-bounded form (streamed to disk, no full-body buffer) suitable for the NE budget. A comment in `engine.rs` notes the constraint.

## Path B attestation
- [x] `swiftformat --lint .` → `0/88 files require formatting, 27 files skipped.`
- [x] `swiftlint --strict` → `Found 0 violations, 0 serious in 79 files.`
- [x] `xcodebuild test ... -only-testing:MeowTests -only-testing:MeowIntegrationTests` → `** TEST SUCCEEDED **`
- [x] `(cd core/rust/meow-ios-ffi && cargo fmt --all -- --check)` → clean
- [x] `(cd core/rust/meow-ios-ffi && cargo clippy --all-targets -- -D warnings)` → 0 errors
- [x] `(cd core/rust/meow-ios-ffi && cargo test --lib)` → 38 passed
- [x] `scripts/build-rust.sh` → `MeowCore.xcframework` written
- [x] `git diff origin/main...HEAD --stat` reviewed — 3 files (Cargo.toml, Cargo.lock, engine.rs), no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)