### PR TITLE
chore(deps): bump meow-rs to 8742d16f for shared ParserContext

### DIFF
--- a/core/rust/geosite-mrs-builder/Cargo.toml
+++ b/core/rust/geosite-mrs-builder/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
-meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
+meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
 
 # `.mrs` writing pulls zstd via meow-rules; no extra dep needed here.

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1621,7 +1621,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "meow-api"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
  "axum",
  "base64",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,8 +1708,9 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
+ "async-trait",
  "dashmap 6.2.1",
  "futures",
  "hickory-proto",
@@ -1767,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
  "async-trait",
  "base64",
@@ -1794,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1811,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
  "async-trait",
  "base64",
@@ -1836,15 +1837,16 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
+ "regex",
  "smallvec",
 ]
 
 [[package]]
 name = "meow-tunnel"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=a703135dd7be602cd7ff3bd1fe05981250b20ddc#a703135dd7be602cd7ff3bd1fe05981250b20ddc"
+source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -66,7 +66,7 @@ lwip = "0.3"
 # in-engine geodata startup-fetch added at 9048f370d6 and the
 # proxy-routed internal_http downloader at 97b1efd435. Restore to a tag
 # once a v0.8.x release is cut.
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -74,11 +74,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be60
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "a703135dd7be602cd7ff3bd1fe05981250b20ddc" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that
 # accept bytes past our advertised window edge trigger a panic in


### PR DESCRIPTION
## Summary
- Bumps `meow-rs` deps from `a703135d` → `8742d16f`.
- Picks up two upstream perf fixes for the rule loader's resident memory:
  - `4cfe5d36` — `perf(geosite): reduce config memory 99 MB → 2.3 MB via targeted loading + Bloom filters`
  - `8742d16f` — `perf(config): build ParserContext once, share across all passes`

## Why this matters for iOS
Recent on-device PacketTunnel extensions were jetsam-killed inside the 50 MB NE memory cap when loading complex configs with many `GEOIP,*` / `GEOSITE,*` rules. The cap kill manifested as the "connects then drops" UX.

Tart-VM `meow-utun` RSS measurements against the same complex YAML that OOM'd on iOS:

| meow-rs rev | RSS | Note |
|---|---|---|
| `a703135d` | 262 MB | per-rule re-reads of Country.mmdb + per-rule DomainTrie blow-up |
| `4cfe5d36` | 65 MB | geosite Bloom-filter + targeted loading shipped |
| `8742d16f` | (expected ~42 MB based on upstream's –36%) | ParserContext shared across all passes |

Upstream's own bench in the `8742d16f` commit message: `77 MB → 49 MB`. Applied to our 65 MB baseline, the residual should fit under the 50 MB NE cap.

`geosite-mrs-builder` Cargo.toml is bumped to the same rev so the build-time generator stays in sync.

## Path B attestation
- [x] `swiftformat --lint .` → `0/88 files require formatting, 27 files skipped.`
- [x] `swiftlint --strict` → `Found 0 violations, 0 serious in 79 files.`
- [x] `xcodebuild test ... -only-testing:MeowTests -only-testing:MeowIntegrationTests` → `** TEST SUCCEEDED **`
- [x] `cargo fmt --all -- --check` → clean
- [x] `cargo clippy --all-targets -- -D warnings` → 0 errors
- [x] `cargo test --lib` → 38 passed
- [x] `scripts/build-rust.sh` → `MeowCore.xcframework` written
- [x] `git diff origin/main...HEAD --stat` reviewed — 3 files (Cargo.toml × 2 + Cargo.lock), no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)