### PR TITLE
chore(deps): bump meow-rs to fa176e9f for boring X509Store webpki roots

### DIFF
--- a/core/rust/geosite-mrs-builder/Cargo.toml
+++ b/core/rust/geosite-mrs-builder/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
-meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
+meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "fa176e9fffc3fb54ae6b8a3f1725fef963530885" }
 
 # `.mrs` writing pulls zstd via meow-rules; no extra dep needed here.

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -757,7 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1621,7 +1621,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 [[package]]
 name = "meow-api"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "axum",
  "base64",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "async-trait",
  "base64",
@@ -1795,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1812,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "async-trait",
  "base64",
@@ -1831,13 +1831,14 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite 0.24.0",
  "tracing",
+ "webpki-root-certs",
  "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "meow-trie"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "regex",
  "smallvec",
@@ -1846,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "meow-tunnel"
 version = "0.8.0"
-source = "git+https://github.com/madeye/meow-rs?rev=8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8#8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8"
+source = "git+https://github.com/madeye/meow-rs?rev=fa176e9fffc3fb54ae6b8a3f1725fef963530885#fa176e9fffc3fb54ae6b8a3f1725fef963530885"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1912,7 +1913,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2183,7 +2184,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2450,7 +2451,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2897,7 +2898,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3574,6 +3575,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,7 +3635,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -66,7 +66,7 @@ lwip = "0.3"
 # in-engine geodata startup-fetch added at 9048f370d6 and the
 # proxy-routed internal_http downloader at 97b1efd435. Restore to a tag
 # once a v0.8.x release is cut.
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "fa176e9fffc3fb54ae6b8a3f1725fef963530885" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -74,11 +74,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "8742d16fe3bbfb434d4cbc15e3edf2d6deb274d8" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "fa176e9fffc3fb54ae6b8a3f1725fef963530885", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "fa176e9fffc3fb54ae6b8a3f1725fef963530885" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "fa176e9fffc3fb54ae6b8a3f1725fef963530885" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "fa176e9fffc3fb54ae6b8a3f1725fef963530885" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "fa176e9fffc3fb54ae6b8a3f1725fef963530885" }
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that
 # accept bytes past our advertised window edge trigger a panic in


### PR DESCRIPTION
## Summary
- Bumps `meow-rs` deps from `8742d16f` → `fa176e9f`.
- Picks up `madeye/meow-rs#132` (`fix(transport): seed boring's X509Store with webpki-roots Mozilla CAs`).

## Why
On-device PacketTunnel was failing every ech-tls-tunnel dial with:
```
boring TLS handshake (ECH rejected; retry_configs=fe0dffffff): TLS handshake failed:
cert verification failed - unable to get local issuer certificate [CERTIFICATE_VERIFY_FAILED]
```

The "ECH rejected; retry_configs=fe0dffffff" framing is a misleading artifact — BoringSSL's internal state after a torn handshake, not a real server retry config. The actual cause was a tail revealed only inside the NE sandbox: the boring `SslConnector`'s `X509Store` was empty, because the only roots ever loaded were `TlsConfig.additional_roots` (which every shipping proxy leaves at default `Vec::new()`). On macOS host the same code path worked because boring-sys's vendored BoringSSL has a host-side fallback; inside the iOS NE sandbox there's no equivalent.

#132 seeds the X509Store from `webpki-root-certs` (the DER-only sibling of `webpki-roots`) so peer cert chains chase the Mozilla bundle that rustls already uses by default. User-supplied `additional_roots` are still appended afterwards and keep precedence.

Post-bump, on-device:
```
boring TLS handshake complete sni=tyo.maxlv.net ech_requested=true ech_accepted=true tls_version=TLSv1.3
```

## Path B attestation
- [x] `swiftformat --lint .` → `0/88 files require formatting, 27 files skipped.`
- [x] `swiftlint --strict` → `Found 0 violations, 0 serious in 79 files.`
- [x] `xcodebuild test ... -only-testing:MeowTests -only-testing:MeowIntegrationTests` → `** TEST SUCCEEDED **`
- [x] `cargo fmt --all -- --check` → clean
- [x] `cargo clippy --all-targets -- -D warnings` → 0 errors
- [x] `cargo test --lib` → 38 passed
- [x] `scripts/build-rust.sh` → `MeowCore.xcframework` written
- [x] `git diff origin/main...HEAD --stat` reviewed — 3 files (Cargo.toml × 2 + Cargo.lock), no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)