### PR TITLE
chore(release): bump build number to 2026052401

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026052301"
+        CFBundleVersion: "2026052401"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026052301"
+        CFBundleVersion: "2026052401"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary
- Bump CFBundleVersion from 2026052301 → 2026052401

## Test plan
- Non-code change (project.yml only) — Path A bypass eligible

🤖 Generated with [Claude Code](https://claude.com/claude-code)