### PR TITLE
chore(deps): bump meow-rs to v0.11.0

### DIFF
--- a/core/rust/geosite-mrs-builder/Cargo.toml
+++ b/core/rust/geosite-mrs-builder/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
-meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "fa176e9fffc3fb54ae6b8a3f1725fef963530885" }
+meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
 
 # `.mrs` writing pulls zstd via meow-rules; no extra dep needed here.

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -267,7 +267,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte_string"
@@ -1384,6 +1384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1534,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
@@ -1630,8 +1639,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "axum",
  "base64",
@@ -1662,8 +1671,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1684,8 +1693,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1717,8 +1726,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1777,8 +1786,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "async-trait",
  "base64",
@@ -1804,8 +1813,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1821,8 +1830,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "async-trait",
  "base64",
@@ -1847,16 +1856,16 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "meow-tunnel"
-version = "0.9.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fde44860e1ab4d0f4880cca59abd11030ee5542d#fde44860e1ab4d0f4880cca59abd11030ee5542d"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3476,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3489,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3499,9 +3508,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3509,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3522,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3565,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -61,12 +61,9 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# Currently on a post-rename `rev =` pin to pick up the crate-name rename
-# (madeye/meow-rs commit 105eacfe7f) plus subsequent fixes, including the
-# in-engine geodata startup-fetch added at 9048f370d6 and the
-# proxy-routed internal_http downloader at 97b1efd435. Restore to a tag
-# once a v0.8.x release is cut.
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "fde44860e1ab4d0f4880cca59abd11030ee5542d" }
+# Pinned to v0.11.0 tag. Includes BloomMap→TrieMap domain matching,
+# geosite Plain/Regex support, and lazy RegexSet (53→38 MB footprint).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -74,11 +71,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "fde44860e1ab4d
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "fde44860e1ab4d0f4880cca59abd11030ee5542d", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "fde44860e1ab4d0f4880cca59abd11030ee5542d" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "fde44860e1ab4d0f4880cca59abd11030ee5542d" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "fde44860e1ab4d0f4880cca59abd11030ee5542d" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "fde44860e1ab4d0f4880cca59abd11030ee5542d" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that
 # accept bytes past our advertised window edge trigger a panic in


### PR DESCRIPTION
## Summary
- Bump meow-rs from fde44860 (v0.9.0) to v0.11.0 tag (f5dd5707)
- BloomMap→TrieMap domain matching, geosite Plain/Regex support, lazy RegexSet (53→38 MB), per-query heap alloc elimination, upstream mihomo config compat fix

## Test plan
- [x] `scripts/build-rust.sh` — XCFramework built for device + simulator
- [x] Ad Hoc IPA exported and installed on device via `devicectl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)