### PR TITLE
chore(deps): bump meow-rs + reduce heap allocations on hot paths

### DIFF
--- a/PacketTunnel/Sources/MWPacketWriter.m
+++ b/PacketTunnel/Sources/MWPacketWriter.m
@@ -1,9 +1,17 @@
 #import "MWPacketWriter.h"
 #import <stdatomic.h>
 
+static NSArray<NSNumber *> *sIPv4Proto;
+static NSArray<NSNumber *> *sIPv6Proto;
+
 @implementation MWPacketWriter {
     NEPacketTunnelFlow *_flow;
     _Atomic int64_t _egressPackets;
+}
+
++ (void)initialize {
+    sIPv4Proto = @[@(AF_INET)];
+    sIPv6Proto = @[@(AF_INET6)];
 }
 
 - (instancetype)initWithFlow:(NEPacketTunnelFlow *)flow {
@@ -18,8 +26,8 @@
 - (void)writeData:(const uint8_t *)data length:(NSUInteger)length {
     @autoreleasepool {
         NSData *packet = [NSData dataWithBytes:data length:length];
-        int32_t proto = ((length > 0 && (data[0] >> 4) == 6)) ? AF_INET6 : AF_INET;
-        [_flow writePackets:@[packet] withProtocols:@[@(proto)]];
+        NSArray<NSNumber *> *proto = (length > 0 && (data[0] >> 4) == 6) ? sIPv6Proto : sIPv4Proto;
+        [_flow writePackets:@[packet] withProtocols:proto];
         atomic_fetch_add_explicit(&_egressPackets, 1, memory_order_relaxed);
     }
 }

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "axum",
  "base64",
@@ -1672,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "async-trait",
  "base64",
@@ -1804,6 +1804,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shadowsocks",
+ "smol_str",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
@@ -1814,7 +1815,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1831,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "async-trait",
  "base64",
@@ -1857,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "smallvec",
 ]
@@ -1865,11 +1866,12 @@ dependencies = [
 [[package]]
 name = "meow-tunnel"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
 dependencies = [
  "arc-swap",
  "async-trait",
  "dashmap 6.2.1",
+ "itoa",
  "meow-common",
  "meow-dns",
  "meow-proxy",
@@ -1877,6 +1879,7 @@ dependencies = [
  "meow-trie",
  "parking_lot",
  "serde",
+ "smallvec",
  "smol_str",
  "tokio",
  "tracing",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -61,9 +61,8 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# Pinned to v0.11.0 tag. Includes BloomMap→TrieMap domain matching,
-# geosite Plain/Regex support, and lazy RegexSet (53→38 MB footprint).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
+# HEAD: 3031b138 — memleak-ech-tls-tunnel fix (PR #148).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -71,11 +70,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that
 # accept bytes past our advertised window edge trigger a panic in
@@ -85,8 +84,6 @@ meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a
 # pins smoltcp 0.12, so a 0.13 bump would also need to fork netstack-smoltcp.
 [patch.crates-io]
 smoltcp = { git = "https://github.com/madeye/smoltcp", branch = "fix/reject-bytes-outside-recv-win" }
-
-
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -367,11 +367,14 @@ pub unsafe extern "C" fn meow_engine_test_dns(
     let to = Duration::from_millis(timeout_ms.max(1) as u64);
     match get_runtime().block_on(diagnostics::test_dns(&tunnel, h, to)) {
         Ok(ips) => {
-            let joined = ips
-                .iter()
-                .map(|ip| ip.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
+            use std::fmt::Write;
+            let mut joined = String::new();
+            for (i, ip) in ips.iter().enumerate() {
+                if i > 0 {
+                    joined.push(',');
+                }
+                let _ = write!(joined, "{}", ip);
+            }
             write_out(joined.as_bytes(), out, out_cap)
         }
         Err(e) => {

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -290,10 +290,6 @@ fn evict_oldest_idle_tcp_flow() -> Option<u64> {
         "tun2socks: TCP cap reached, evicting longest-idle flow {} {} -> {}",
         id, rec.src, rec.dst
     );
-    logging::bridge_log(&format!(
-        "tun2socks: TCP cap-evict {} {} -> {}",
-        id, rec.src, rec.dst
-    ));
     Some(id)
 }
 
@@ -302,25 +298,16 @@ fn evict_oldest_idle_tcp_flow() -> Option<u64> {
 /// Exposed via FFI (`meow_tun_close_all_tcp_flows`) for emergency teardown.
 pub fn close_all_tcp_flows() -> usize {
     let flows = tcp_flows();
-    let mut closed: Vec<(u64, SocketAddr, SocketAddr)> = Vec::with_capacity(flows.len());
-    flows.retain(|&id, rec| {
+    let mut count = 0usize;
+    flows.retain(|_id, rec| {
         rec.abort.abort();
-        closed.push((id, rec.src, rec.dst));
+        count += 1;
         false
     });
-    if !closed.is_empty() {
-        warn!(
-            "tun2socks: registry watchdog closed {} TCP flows",
-            closed.len()
-        );
-        for (id, src, dst) in &closed {
-            logging::bridge_log(&format!(
-                "tun2socks: TCP watchdog-close {} {} -> {}",
-                id, src, dst
-            ));
-        }
+    if count > 0 {
+        warn!("tun2socks: registry watchdog closed {} TCP flows", count);
     }
-    closed.len()
+    count
 }
 
 fn warn_capped(slot: &AtomicU64, msg: &str) {
@@ -602,7 +589,7 @@ async fn run_tun2socks(
                     continue;
                 }
             };
-            let request = ip_data.clone();
+            let request = ip_data;
             let egress = egress_tx.clone();
             tokio::spawn(async move {
                 let _permit = permit;
@@ -809,12 +796,6 @@ async fn dispatch_tcp(
                 "tun2socks: dial deadline exceeded for {} -> {} after {} ms; dropping flow",
                 src, dst, dial_deadline,
             );
-            logging::bridge_log(&format!(
-                "tun2socks: TCP dial-deadline {} -> {} ({} ms)",
-                src, dst, dial_deadline,
-            ));
-            // Drop `fut` on exit → meow `ConnectionGuard` cleanup runs,
-            // accept_sem permit released via the spawned task's exit.
         }
     }
 }
@@ -1132,10 +1113,6 @@ fn spawn_udp_reply_reader(
                             "UDP first-reply deadline exceeded for {:?} after {} ms; evicting session",
                             key, first_reply_deadline_ms,
                         );
-                        logging::bridge_log(&format!(
-                            "tun2socks: UDP first-reply-deadline {:?} ({} ms)",
-                            key, first_reply_deadline_ms,
-                        ));
                         break;
                     }
                 }
@@ -1237,7 +1214,7 @@ pub(crate) async fn forward_dns_to_upstream(
         return None;
     }
     let query_id = u16::from_be_bytes([query[0], query[1]]);
-    let query_owned = query.to_vec();
+    let query_shared: Arc<[u8]> = Arc::from(query);
 
     type DnsForwardFut = Pin<Box<dyn std::future::Future<Output = Option<Vec<u8>>> + Send>>;
     let mut futs: Vec<DnsForwardFut> = Vec::with_capacity(upstreams.len());
@@ -1245,18 +1222,15 @@ pub(crate) async fn forward_dns_to_upstream(
         let Ok(addr) = upstream.parse::<SocketAddr>() else {
             continue;
         };
-        let q = query_owned.clone();
+        let q = query_shared.clone();
         futs.push(Box::pin(async move {
             let socket = tokio::net::UdpSocket::bind(("0.0.0.0", 0u16)).await.ok()?;
             socket.send_to(&q, addr).await.ok()?;
-            let mut buf = vec![0u8; 1500];
+            let mut buf = [0u8; 1500];
             let recv = tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await;
             let (n, _) = recv.ok()?.ok()?;
-            buf.truncate(n);
-            // RFC 1035 §4.1.1 — a reply's ID must match the query's ID;
-            // otherwise it's stray traffic on this ephemeral port.
-            if buf.len() >= 2 && u16::from_be_bytes([buf[0], buf[1]]) == query_id {
-                Some(buf)
+            if n >= 2 && u16::from_be_bytes([buf[0], buf[1]]) == query_id {
+                Some(buf[..n].to_vec())
             } else {
                 None
             }


### PR DESCRIPTION
## Summary
- Bump meow-rs to `3031b138` (PR #148: ECH TLS tunnel memleak fix)
- Eliminate per-packet/per-connection heap allocations on tun2socks hot paths (DNS move-not-clone, Arc<[u8]> for upstream fan-out, stack recv buffers, remove format!+bridge_log duplicates)
- Pre-allocate static NSNumber/NSArray singletons in MWPacketWriter to avoid boxing per egress packet

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 errors
- [x] `cargo test --lib` — 38/38 pass
- [x] `scripts/build-rust.sh` — both aarch64-apple-ios and aarch64-apple-ios-sim build clean
- [x] `xcodebuild archive` — release archive succeeds
- [x] Installed on device via ios-deploy, VPN tunnel functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)