### PR TITLE
chore(deps): bump meow-rs to 14ad7d50 for reduce-heap-allocs

### DIFF
--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
@@ -267,7 +267,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -757,7 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1384,15 +1384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "axum",
  "base64",
@@ -1672,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1694,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1727,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1787,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "async-trait",
  "base64",
@@ -1815,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1832,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "async-trait",
  "base64",
@@ -1858,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "smallvec",
 ]
@@ -1866,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "meow-tunnel"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=3031b1389f0af14f24ace7e97647eb67c916ed26#3031b1389f0af14f24ace7e97647eb67c916ed26"
+source = "git+https://github.com/madeye/meow-rs?rev=14ad7d50146c648009a4e99d4428960301e8349b#14ad7d50146c648009a4e99d4428960301e8349b"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1934,7 +1925,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2205,7 +2196,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2472,7 +2463,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2919,7 +2910,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3656,7 +3647,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -61,8 +61,8 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 3031b138 — memleak-ech-tls-tunnel fix (PR #148).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
+# HEAD: 14ad7d50 — reduce-heap-allocs (PR #149).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "14ad7d50146c648009a4e99d4428960301e8349b" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -70,11 +70,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af1
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "3031b1389f0af14f24ace7e97647eb67c916ed26" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "14ad7d50146c648009a4e99d4428960301e8349b", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "14ad7d50146c648009a4e99d4428960301e8349b" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "14ad7d50146c648009a4e99d4428960301e8349b" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "14ad7d50146c648009a4e99d4428960301e8349b" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "14ad7d50146c648009a4e99d4428960301e8349b" }
 # Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
 # ("tcp: Reject bytes outside the receive window"). Without it, peers that
 # accept bytes past our advertised window edge trigger a panic in


### PR DESCRIPTION
## Summary
- Bump meow-rs from `3031b138` to `14ad7d50` (PR #149: reduce-heap-allocs)

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 errors
- [x] `cargo test --lib` — 38/38 pass
- [x] `scripts/build-rust.sh` — both iOS targets build clean
- [x] `xcodebuild archive` — release archive succeeds
- [x] Installed on device via ios-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)