### PR TITLE
feat: enable iCloud backup for downloaded config and database

### DIFF
--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -57,6 +57,7 @@ final class AppModel {
             }
         }
         try? FileManager.default.createDirectory(at: AppGroup.meowConfigDir, withIntermediateDirectories: true)
+        AppGroup.configureBackup()
         GeoAssetStager.stageIfNeeded()
         await vpnManager.refresh()
         ipcBridge.start()

--- a/App/Sources/AppModelContainer.swift
+++ b/App/Sources/AppModelContainer.swift
@@ -33,6 +33,10 @@ enum AppModelContainer {
             .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
             .appending(path: "meow")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        var dirURL = dir
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = false
+        try? dirURL.setResourceValues(values)
         return dir.appending(path: "meow.sqlite")
     }
 }

--- a/MeowShared/Sources/MeowModels/AppGroup.swift
+++ b/MeowShared/Sources/MeowModels/AppGroup.swift
@@ -39,6 +39,25 @@ public enum AppGroup {
         containerURL.appending(path: "meow", directoryHint: .isDirectory)
     }
 
+    /// Mark the user's downloaded config and engine data directory as
+    /// iCloud-backup-eligible, and exclude transient files that are
+    /// regenerated on every tunnel start.
+    public static func configureBackup() {
+        setBackupExclusion(containerURL, excluded: false)
+        setBackupExclusion(configURL, excluded: false)
+        setBackupExclusion(meowConfigDir, excluded: false)
+        setBackupExclusion(effectiveConfigURL, excluded: true)
+        setBackupExclusion(stateURL, excluded: true)
+        setBackupExclusion(trafficURL, excluded: true)
+    }
+
+    private static func setBackupExclusion(_ url: URL, excluded: Bool) {
+        var u = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = excluded
+        try? u.setResourceValues(values)
+    }
+
     /// UserDefaults suite shared between app and extension. Force-unwrap is
     /// safe once entitlements are wired — missing suite indicates a config bug
     /// that should fail loudly.


### PR DESCRIPTION
## Summary
- Explicitly mark App Group container (`config.yaml`, `meow/` engine dir) and SwiftData store as iCloud-backup-eligible via `isExcludedFromBackup = false`
- Exclude transient files regenerated on every tunnel start (`effective-config.yaml`, `state.json`, `traffic.json`)
- Called during app bootstrap after config directory creation

## Test plan
- [x] `swiftformat --lint .` — 0 issues
- [x] `swiftlint --strict` — 0 violations
- [x] `xcodebuild archive` — release archive succeeds
- [x] Installed on device via ios-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)