### PR TITLE
fix: YAML editor cancel button now dismisses (#181)

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -143,10 +143,10 @@
 "yamlEditor.nav.title" = "Edit Config";
 "yamlEditor.empty.title" = "Empty config";
 "yamlEditor.empty.description" = "Paste a Clash YAML config to start editing.";
-"yamlEditor.button.revert" = "Revert";
+"yamlEditor.button.cancel" = "Cancel";
 "yamlEditor.button.save" = "Save";
 "yamlEditor.button.saving" = "Saving…";
-"yamlEditor.a11y.revert" = "Revert to last saved config";
+"yamlEditor.a11y.cancel" = "Discard changes and close editor";
 "yamlEditor.a11y.save" = "Save config";
 "yamlEditor.error.invalid" = "Invalid config";
 
@@ -165,6 +165,7 @@
 "settings.logLevel.silent" = "Silent";
 "settings.section.diagnostics" = "Diagnostics";
 "settings.label.diagnostics" = "Diagnostics";
+"settings.label.exportLogs" = "Export Logs";
 "settings.section.about" = "About";
 "settings.about.version" = "Version";
 "settings.about.memory" = "Memory";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -149,10 +149,10 @@
 "yamlEditor.nav.title" = "编辑配置";
 "yamlEditor.empty.title" = "配置为空";
 "yamlEditor.empty.description" = "粘贴 Clash YAML 配置以开始编辑。";
-"yamlEditor.button.revert" = "撤销";
+"yamlEditor.button.cancel" = "取消";
 "yamlEditor.button.save" = "保存";
 "yamlEditor.button.saving" = "保存中…";
-"yamlEditor.a11y.revert" = "还原到上次保存的配置";
+"yamlEditor.a11y.cancel" = "放弃更改并关闭编辑器";
 "yamlEditor.a11y.save" = "保存配置";
 "yamlEditor.error.invalid" = "配置无效";
 
@@ -171,6 +171,7 @@
 "settings.logLevel.silent" = "静默";
 "settings.section.diagnostics" = "诊断";
 "settings.label.diagnostics" = "诊断";
+"settings.label.exportLogs" = "导出日志";
 "settings.section.about" = "关于";
 "settings.about.version" = "版本";
 "settings.about.memory" = "内存";

--- a/App/Sources/Views/YamlEditorView.swift
+++ b/App/Sources/Views/YamlEditorView.swift
@@ -30,9 +30,9 @@ struct YamlEditorView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("yamlEditor.button.revert") { text = profile.yamlBackup }
-                        .accessibilityLabel("yamlEditor.a11y.revert")
-                        .accessibilityIdentifier("yamlEditor.revertButton")
+                    Button("yamlEditor.button.cancel") { dismiss() }
+                        .accessibilityLabel("yamlEditor.a11y.cancel")
+                        .accessibilityIdentifier("yamlEditor.cancelButton")
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(


### PR DESCRIPTION
## Summary
- Change the YAML editor's cancel-position toolbar button from "Revert" (restore backup text, stay in editor) to "Cancel" (dismiss without saving)
- Users previously had no way to leave the editor without saving

Closes #181

## Test plan
- [x] `swiftformat --lint .` — 0 issues
- [x] `swiftlint --strict` — 0 violations
- [x] `xcodebuild archive` — release archive succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)