### PR TITLE
fix: NE sleep/wake lifecycle + full tun restart on network change

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.h
+++ b/PacketTunnel/Sources/MWTunnelEngine.h
@@ -13,6 +13,13 @@
 /// Stops engine, tun2socks, ingress loop, traffic pump.
 - (void)stop;
 
+/// Stop tun2socks + ingress loop, keep engine alive. Sheds per-flow
+/// memory so the NE survives jetsam during device sleep.
+- (void)suspendTun;
+
+/// Restart tun2socks + ingress loop after a prior `suspendTun`.
+- (void)resumeTun;
+
 @property (nonatomic, readonly) BOOL isEngineRunning;
 @property (nonatomic, readonly) BOOL tunStarted;
 

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -126,6 +126,37 @@ static const NSTimeInterval kReliefCooldownS  = 60.0;
     _writer = nil;
 }
 
+// MARK: - Suspend / resume tun2socks
+
+- (void)suspendTun {
+    if (!_tunStarted) return;
+
+    atomic_store_explicit(&_ingressRunning, NO, memory_order_relaxed);
+    [self stopTrafficPump];
+
+    meow_tun_stop();
+    _tunStarted = NO;
+
+    os_log_info(gLog, "engine: tun suspended (engine still running)");
+}
+
+- (void)resumeTun {
+    if (_tunStarted) return;
+    if (!_started) return;
+
+    int rc = meow_tun_start(_writerCtx, meowPacketWriterCB);
+    if (rc != 0) {
+        os_log_error(gLog, "engine: tun resume failed: %{public}@",
+                     [self lastRustError] ?: @"unknown");
+        return;
+    }
+    _tunStarted = YES;
+
+    [self startIngressLoop];
+    [self startTrafficPump];
+    os_log_info(gLog, "engine: tun resumed");
+}
+
 // MARK: - Engine state
 
 - (BOOL)isEngineRunning {

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -8,6 +8,7 @@
 #import "meow_core.h"
 #import <os/log.h>
 #import <mach/mach.h>
+#import <malloc/malloc.h>
 @import Network;
 
 // keep in sync with MeowShared/Sources/MeowIPC/DiagnosticsIPC.swift and
@@ -93,6 +94,18 @@ static os_log_t gLog;
     _ipcListener = nil;
     [self writeState:@"stopped" profileID:nil errorMessage:nil];
     completionHandler();
+}
+
+- (void)sleepWithCompletionHandler:(void (^)(void))completionHandler {
+    os_log_info(gLog, "sleep: suspending tun to shed memory before device sleep");
+    [_engine suspendTun];
+    malloc_zone_pressure_relief(NULL, 0);
+    completionHandler();
+}
+
+- (void)wake {
+    os_log_info(gLog, "wake: resuming tun");
+    [_engine resumeTun];
 }
 
 // MARK: - App messages
@@ -367,22 +380,18 @@ static os_log_t gLog;
 - (void)triggerReconnect {
     if (!_engine) return;
 
-    // Light-touch network-change handling: keep the VPN connected, keep
-    // the TUN and engine running, and just abort every in-flight TCP
-    // flow in tun2socks. Meow-tunnel's `ConnectionGuard` drops the
-    // matching `Statistics.connections` entry on each task cancel, so
-    // its state stays in sync with our flow registry. The next packet
-    // from the app for any pre-flip flow opens a fresh dispatch and
-    // dials over the new uplink. Previously we toggled `reasserting`
-    // (which iOS surfaces as a "connecting" UI flicker) and restarted
-    // the entire engine — heavy, and unnecessary now that we have a
-    // targeted way to drop stale flows.
-    //
-    // UDP is intentionally not touched: it's connectionless from the
-    // app's perspective, meow's NAT entries time out on their own,
-    // and dropping them mid-flip would clobber in-flight DNS replies.
-    int32_t aborted = meow_tun_close_all_tcp_flows();
-    os_log_info(gLog, "path: closed %d TCP flows on network change", aborted);
+    // Full tun2socks restart on network change: the gVisor netstack and
+    // per-flow state (TCP connections, UDP NAT table, dispatch futures)
+    // all bind to the pre-flip network path. Aborting individual TCP
+    // flows was insufficient — the engine's upstream connections stayed
+    // stale and accumulated retry state, eventually crashing the NE
+    // ~14 minutes after a Wi-Fi reachability flip (see meow-tunnel log
+    // 2026-05-27 crash #1). A clean stop+start gives the netstack a
+    // fresh path with zero carryover. The engine (mihomo) stays alive
+    // so proxy groups, routing rules, and the REST API persist.
+    os_log_info(gLog, "path: restarting tun2socks on network change");
+    [_engine suspendTun];
+    [_engine resumeTun];
 }
 
 @end

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -572,6 +572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1631,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
  "axum",
  "base64",
@@ -1663,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1685,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1718,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1778,14 +1787,20 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
+ "aes",
+ "aes-gcm",
  "async-trait",
  "base64",
  "bytes",
+ "chacha20poly1305",
+ "crc32fast",
  "futures",
  "hex",
+ "hmac",
  "libc",
+ "md-5",
  "meow-common",
  "meow-dns",
  "meow-transport",
@@ -1806,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1823,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
  "async-trait",
  "base64",
@@ -1849,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
  "smallvec",
 ]
@@ -1857,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "meow-tunnel"
 version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f531fb630e2d5ddc3a286378c5dbb33f7335eaea#f531fb630e2d5ddc3a286378c5dbb33f7335eaea"
+source = "git+https://github.com/madeye/meow-rs?rev=ac97e1b387fb2762e74090f8636fe0273792a828#ac97e1b387fb2762e74090f8636fe0273792a828"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1925,7 +1940,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2196,7 +2211,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2463,7 +2478,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2910,7 +2925,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3647,7 +3662,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4125,8 +4140,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "smoltcp"
-version = "0.12.0"
-source = "git+https://github.com/madeye/smoltcp?branch=fix%2Freject-bytes-outside-recv-win#d986300eee4bed07c033744359e192a60211b23a"

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -61,8 +61,8 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: f531fb63 — boring session cache leak fix (PR #150).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f531fb630e2d5ddc3a286378c5dbb33f7335eaea" }
+# HEAD: ac97e1b3
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "ac97e1b387fb2762e74090f8636fe0273792a828" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -70,20 +70,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f531fb630e2d5d
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "f531fb630e2d5ddc3a286378c5dbb33f7335eaea", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "f531fb630e2d5ddc3a286378c5dbb33f7335eaea" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "f531fb630e2d5ddc3a286378c5dbb33f7335eaea" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "f531fb630e2d5ddc3a286378c5dbb33f7335eaea" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f531fb630e2d5ddc3a286378c5dbb33f7335eaea" }
-# Pin smoltcp to a v0.12.0 fork that backports upstream commit f56ed8b
-# ("tcp: Reject bytes outside the receive window"). Without it, peers that
-# accept bytes past our advertised window edge trigger a panic in
-# smoltcp::socket::tcp::Socket::last_scaled_window via the SeqNumber
-# subtraction underflow guard, aborting the PacketTunnel process. The fix
-# is in upstream main but has not been released; netstack-smoltcp 0.2 still
-# pins smoltcp 0.12, so a 0.13 bump would also need to fork netstack-smoltcp.
-[patch.crates-io]
-smoltcp = { git = "https://github.com/madeye/smoltcp", branch = "fix/reject-bytes-outside-recv-win" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "ac97e1b387fb2762e74090f8636fe0273792a828", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "ac97e1b387fb2762e74090f8636fe0273792a828" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "ac97e1b387fb2762e74090f8636fe0273792a828" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "ac97e1b387fb2762e74090f8636fe0273792a828" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "ac97e1b387fb2762e74090f8636fe0273792a828" }
 
 [build-dependencies]
 cbindgen = "0.28"


### PR DESCRIPTION
## Summary
- Add `suspendTun`/`resumeTun` to `MWTunnelEngine` — stop/start tun2socks while keeping the mihomo engine alive
- Override `sleepWithCompletionHandler:`/`wake` on the PacketTunnelProvider to shed per-flow memory before device sleep, surviving jetsam under the ~50 MB NE cap overnight
- `triggerReconnect` now does a full tun2socks stop+start on network path changes instead of just aborting TCP flows — fixes a crash where stale upstream connections accumulated retry state for ~14 min after a Wi-Fi reachability flip
- Bump meow-rs f531fb63 → ac97e1b3 (HEAD); remove dead smoltcp patch

## Test plan
- [x] `swiftformat --lint .` → 0 violations
- [x] `swiftlint --strict` → 0 violations
- [x] `MeowTests` → all passed (iPhone 17 simulator, iOS 26)
- [x] `cargo check` → 0 errors
- [x] Release build installed on device via `devicectl`
- [x] `git diff origin/main...HEAD --stat` verified — 5 files, no accidental additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)