### PR TITLE
fix(vpn): don't reclaim active-VPN slot on app launch

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026052801</string>
+	<string>2026052802</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -37,16 +37,35 @@ final class VpnManager {
         }
     }
 
-    /// Load (or create) the packet-tunnel configuration and install it in
-    /// Preferences. Called on app launch and after user edits.
+    /// Load (or create) the packet-tunnel configuration. Called on app launch
+    /// and after user edits.
+    ///
+    /// Critical: when an existing profile is found, this attaches without
+    /// re-saving the configuration. iOS allows only one VPN profile in the
+    /// "active" slot — calling `saveToPreferences()` with `isEnabled = true`
+    /// re-claims that slot, deactivating whatever other VPN app was active.
+    /// Doing that on every cold-launch is how "opening meow disconnects my
+    /// other VPN" regressions appear. Slot ownership is claimed only by
+    /// explicit user actions: `connect()`, or the first-install branch here.
+    /// On-demand pref changes are synced only when we already own the slot.
     func refresh() async {
         do {
             let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-            let mgr = managers.first ?? NETunnelProviderManager()
-            configureIfNeeded(mgr)
-            try await mgr.saveToPreferences()
-            try await mgr.loadFromPreferences()
-            attach(mgr)
+            if let existing = managers.first {
+                let want = Preferences.load(from: AppGroup.defaults).onDemand
+                if existing.isEnabled, existing.isOnDemandEnabled != want {
+                    existing.isOnDemandEnabled = want
+                    try await existing.saveToPreferences()
+                    try await existing.loadFromPreferences()
+                }
+                attach(existing)
+            } else {
+                let mgr = NETunnelProviderManager()
+                configureIfNeeded(mgr)
+                try await mgr.saveToPreferences()
+                try await mgr.loadFromPreferences()
+                attach(mgr)
+            }
         } catch {
             lastError = error.localizedDescription
             stage = .error
@@ -64,9 +83,22 @@ final class VpnManager {
         guard let manager else { return }
         do {
             let prefs = Preferences.load(from: AppGroup.defaults)
-            if prefs.onDemand, !manager.isOnDemandEnabled {
-                manager.isOnDemandEnabled = true
+            var dirty = false
+            if !manager.isEnabled {
+                manager.isEnabled = true
+                dirty = true
+            }
+            if (manager.onDemandRules ?? []).isEmpty {
+                manager.onDemandRules = [NEOnDemandRuleConnect()]
+                dirty = true
+            }
+            if manager.isOnDemandEnabled != prefs.onDemand {
+                manager.isOnDemandEnabled = prefs.onDemand
+                dirty = true
+            }
+            if dirty {
                 try await manager.saveToPreferences()
+                try await manager.loadFromPreferences()
             }
             try manager.connection.startVPNTunnel()
         } catch {

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>2026052801</string>
+	<string>2026052802</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026052801"
+        CFBundleVersion: "2026052802"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026052801"
+        CFBundleVersion: "2026052802"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

User report: enabling the on-demand toggle in meow and then opening meow caused other VPN apps to be disconnected.

Root cause: `VpnManager.refresh()` (called from `AppModel.bootstrap()` on every cold-launch) unconditionally ran `configureIfNeeded()` + `saveToPreferences()`. `configureIfNeeded` always set `mgr.isEnabled = true`, so each save re-claimed the iOS "active VPN" slot — and iOS allows only one such profile, so whichever other VPN was active got deactivated as a side effect.

Fix:
- `refresh()` now **attaches without re-saving** when an existing profile is found. The on-demand pref is synced into the NE only when we already own the slot (`existing.isEnabled == true`). A pref drift while we're dormant persists in `UserDefaults` and is applied on the next explicit `connect()`.
- `connect()` is now the sole slot-claim path. It sets `isEnabled = true`, restores `onDemandRules` if iOS nuked them, syncs `isOnDemandEnabled` with the user pref, and runs a single `saveToPreferences()` if any of those changed before `startVPNTunnel()`.
- First-install path (no profile yet on the device) is unchanged — that branch still saves immediately so the profile is installable from a fresh app.
- Build number bumped to `2026052802`.

## Path B local-CI attestation

Code paths touched (Swift / project.yml). All four applicable gates ran locally on this checkout:

- [x] `swiftformat --lint .` — 0/90 files require formatting, 33 skipped.
- [x] `swiftlint --strict` — 0 violations, 0 serious in 81 files.
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` — TEST SUCCEEDED.
- [x] No Rust / FFI changes → cargo gate not applicable.
- [x] `git diff origin/main...HEAD --stat` verified — 4 files: VpnManager.swift + 2 Info.plist + project.yml. No accidental additions.

## Notes

- Main's CI is currently red on the pre-existing PacketTunnel.appex size ceiling (11.14 MB > 10 MB). Unrelated to this PR.
- Workflow files NOT touched, so Path B applies.

## Test plan
- [x] Install another VPN, connect to it; open meow → other VPN stays active.
- [x] Toggle on-demand pref while another VPN is active → pref persists, other VPN stays active.
- [x] Hit Connect in meow → meow becomes the active VPN (expected slot claim).
- [x] Disconnect → meow tunnel stops; on-demand cleared so it doesn't auto-reconnect.
- [x] Reopen meow while meow tunnel is up → reattach, no extra save, tunnel undisturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)