### PR TITLE
fix(netstack): patch lwip to fix UAF SIGSEGV under TCP-flow churn

### DIFF
--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1571,8 +1571,7 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 [[package]]
 name = "lwip"
 version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7051f756d2ad2ee15f003ce2178646908a9d50bc966bd37dcd1eea8ce2bb13"
+source = "git+https://github.com/madeye/lwip?rev=f1ca6a855c57e48a2bd56a34105aaf4ae10f9e20#f1ca6a855c57e48a2bd56a34105aaf4ae10f9e20"
 dependencies = [
  "bindgen 0.69.5",
  "bytes",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -103,3 +103,18 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 panic = "abort"
+
+# Patched lwip: upstream 0.3.15's `Stream::poll_next` impls
+# (TcpListenerImpl / NetStackImpl / UdpSocket) mutate shared state
+# (queue/rx/waker) WITHOUT holding LWIP_MUTEX, while the lwIP callbacks
+# (tcp_accept_cb / output / udp_recv_cb) mutate the same state under the
+# lock. On the 2-worker runtime this races: a concurrent VecDeque realloc
+# in TcpListenerImpl::queue corrupts Box<TcpStreamImpl> ownership and hands
+# out a stream whose mpsc Receiver is freed -> SIGSEGV (use-after-free) in
+# TcpStreamImpl::poll_read under sustained TCP-flow churn (~115 flows/s,
+# crashes ~55s). The fork acquires LWIP_MUTEX at the top of each poll_next.
+# Verified: 20k+ flows over 180s at full churn on 2 workers, no crash, RSS
+# flat. Upstream this to https://github.com/ssrlive/lwip and drop the patch
+# once a fixed release ships.
+[patch.crates-io]
+lwip = { git = "https://github.com/madeye/lwip", rev = "f1ca6a855c57e48a2bd56a34105aaf4ae10f9e20" }


### PR DESCRIPTION
## What

Repoints the `lwip` netstack dependency to a patched fork (`madeye/lwip@f1ca6a85`, fork of `ssrlive/lwip`) via `[patch.crates-io]` to fix a **reproducible use-after-free SIGSEGV** under sustained TCP-flow churn.

## Root cause

`lwip` 0.3.15's `Stream::poll_next` impls (`TcpListenerImpl`, `NetStackImpl`, `UdpSocket`) read/mutate shared state (`queue` / `rx` / `waker`) **without** holding `LWIP_MUTEX`, while the lwIP C callbacks (`tcp_accept_cb` / `output` / `udp_recv_cb`) mutate that same state **under** the lock. On the 2-worker tokio runtime the accept-loop task races `tcp_accept_cb` on the listener's `VecDeque<Box<TcpStreamImpl>>`; a concurrent reallocation corrupts `Box` ownership and hands `dispatch_tcp` a stream whose embedded mpsc `Receiver` is freed → SIGSEGV in `TcpStreamImpl::poll_read`.

The fork acquires `LWIP_MUTEX` at the top of each `poll_next` (3-line change), serializing it with the callbacks.

## Why it matters on iOS

The NE extension uses the same `worker_threads(2)` runtime. Under heavy real-world connection churn (media-heavy pages, many parallel connections, speed tests) this crashes the extension — easily mis-attributed to the 50 MB jetsam OOM, but it's a distinct SIGSEGV. **No memory leak** — RSS is flat throughout.

## Verification (macOS utun harness, Tart VM, meow-rs `71871a30`)

- Repro: 2 workers, ~115 new flows/s → SIGSEGV in ~55s / ~6.3k flows, **3/3**. Identical backtrace each time (`Rx::pop ← poll_read`).
- `worker_threads(1)` never reproduces (confirms cross-thread race).
- Independent of `MEMP_NUM_TCP_PCB` (pool 16384 still crashes) — not pool exhaustion.
- **Patched build: 2 workers, full churn → 20,847 flows over 180s, no crash, RSS flat.**
- Fork compiles standalone (0 errors); `cargo metadata --locked` resolves the patch clean.
- `swiftformat --lint .` → 0/90; `swiftlint --strict` → 0 violations.

## Notes

- `main` baseline currently fails only the orthogonal `archive` (release-packaging) job; `build-core` / `lint` / `unit-test` / `ui-test` pass. This Rust-dep change is validated by the PR's `build-core` (real iOS cross-build with the patch).
- Follow-up: upstream the fix to `ssrlive/lwip` and drop the `[patch]` once a fixed release ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)