### PR TITLE
fix: start UDP NAT sweeper to stop slow PacketTunnel memory leak

### DIFF
--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -147,6 +147,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +594,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +755,12 @@ name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dynosaur"
@@ -1637,6 +1674,7 @@ dependencies = [
  "ipnetwork",
  "log",
  "memchr",
+ "memmap2",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -1658,9 +1696,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "meow-api"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
  "axum",
  "base64",
@@ -1691,8 +1738,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1704,6 +1751,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
+ "socket2 0.5.10",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
@@ -1712,8 +1760,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1745,9 +1793,10 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
+ "async-trait",
  "dashmap 6.2.1",
  "futures",
  "hickory-proto",
@@ -1802,15 +1851,21 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
+ "aes",
+ "aes-gcm",
  "async-trait",
  "base64",
  "bytes",
+ "chacha20poly1305",
+ "crc32fast",
  "futures",
  "hex",
+ "hmac",
  "libc",
+ "md-5",
  "meow-common",
  "meow-dns",
  "meow-transport",
@@ -1820,6 +1875,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shadowsocks",
+ "smol_str",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
@@ -1829,8 +1885,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1838,6 +1894,7 @@ dependencies = [
  "meow-common",
  "meow-trie",
  "regex",
+ "smol_str",
  "thiserror 2.0.18",
  "tracing",
  "zstd",
@@ -1845,8 +1902,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
  "async-trait",
  "base64",
@@ -1865,25 +1922,27 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite 0.24.0",
  "tracing",
+ "webpki-root-certs",
  "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "meow-trie"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "meow-tunnel"
-version = "0.7.6"
-source = "git+https://github.com/madeye/meow-rs?rev=0a7d702eba1c05dbedc391a776ce99121be8cec3#0a7d702eba1c05dbedc391a776ce99121be8cec3"
+version = "0.11.0"
+source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
 dependencies = [
  "arc-swap",
  "async-trait",
  "dashmap 6.2.1",
+ "itoa",
  "meow-common",
  "meow-dns",
  "meow-proxy",
@@ -1891,6 +1950,8 @@ dependencies = [
  "meow-trie",
  "parking_lot",
  "serde",
+ "smallvec",
+ "smol_str",
  "tokio",
  "tracing",
  "uuid",
@@ -2518,6 +2579,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2543,6 +2605,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3628,6 +3691,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/core/rust/macos-utun-harness/src/main.rs
+++ b/core/rust/macos-utun-harness/src/main.rs
@@ -45,7 +45,8 @@ use utun::Utun;
 // so we are exercising the exact bytes the PacketTunnel extension runs.
 use meow_ios_ffi::{
     debug_counts, meow_core_init, meow_core_last_error, meow_core_set_home_dir, meow_engine_start,
-    meow_engine_stop, meow_tun_ingest, meow_tun_set_accept_cap, meow_tun_start, meow_tun_stop, rss,
+    meow_engine_stop, meow_tun_ingest, meow_tun_set_accept_cap,
+    meow_tun_set_udp_first_reply_deadline_ms, meow_tun_start, meow_tun_stop, rss,
 };
 
 #[derive(Parser, Debug)]
@@ -126,6 +127,35 @@ struct Args {
     /// per second (≈ `udp_stress_conns / interval`/s new NAT sessions).
     #[arg(long, default_value_t = 20)]
     udp_stress_interval_ms: u64,
+
+    /// If set, SYNTHETICALLY inject IPv4/UDP packets straight into the
+    /// engine via `meow_tun_ingest` — bypassing the OS route table, system
+    /// DNS, and the utun device entirely. Each injected packet carries a
+    /// fresh `(src_ip,src_port)`, so the engine inserts a new `Arc<UdpSession>`
+    /// into its NAT table per packet. Use a REAL, reachable dst that won't
+    /// answer the chosen UDP port (e.g. `8.8.8.8:4433`): DIRECT dial succeeds
+    /// (so the session is created), no reply ever arrives (so it goes idle),
+    /// and the egress goes out the default route — no fake-IP, no DNS loop,
+    /// no routing loop. This is the deterministic way to drive the UDP NAT
+    /// leak path; `--udp-stress-target` (socket-based) needs fake-IP routing.
+    /// dst port MUST NOT be 53 (that hits the DNS intercept, not the NAT).
+    #[arg(long)]
+    udp_inject_target: Option<String>,
+
+    /// Synthetic-injection rate in packets/sec (each = one new NAT session).
+    /// Steady-state live sessions ≈ rate × 60s idle window once the sweeper
+    /// is reaping. Ignored unless `--udp-inject-target` is set.
+    #[arg(long, default_value_t = 50)]
+    udp_inject_rate: u64,
+
+    /// Override the FFI's UDP first-reply deadline (ms). -1 leaves the FFI
+    /// default (10_000). Set to 0 to DISABLE it, so a session that never
+    /// replies is NOT reaped at the deadline — it then relies on the 60s NAT
+    /// sweeper / post-first-reply idle timeout. This isolates the sweeper as
+    /// the bounding mechanism: with the fix `nat_table` plateaus at
+    /// ~rate×60s; without it, it grows unbounded (the leak).
+    #[arg(long, default_value_t = -1)]
+    udp_first_reply_deadline_ms: i32,
 }
 
 /// The egress callback runs on a tokio worker thread (inside the FFI's
@@ -247,6 +277,22 @@ fn main() -> Result<()> {
         }
     }
 
+    if args.udp_first_reply_deadline_ms >= 0 {
+        let rc = meow_tun_set_udp_first_reply_deadline_ms(args.udp_first_reply_deadline_ms);
+        if rc != 0 {
+            warn!(
+                "meow_tun_set_udp_first_reply_deadline_ms({}) returned {}",
+                args.udp_first_reply_deadline_ms, rc
+            );
+        } else {
+            info!(
+                "udp first-reply deadline = {} ms{}",
+                args.udp_first_reply_deadline_ms,
+                if args.udp_first_reply_deadline_ms == 0 { " (disabled)" } else { "" }
+            );
+        }
+    }
+
     info!("registering tun egress callback");
     // SAFETY: egress_callback matches MeowWritePacket; ctx is unused (we keep
     // shared state in EGRESS_FD instead).
@@ -342,6 +388,38 @@ fn main() -> Result<()> {
         None
     };
 
+    let udp_inject_thread = if let Some(target) = args.udp_inject_target.clone() {
+        let rate = args.udp_inject_rate.max(1);
+        let duration = if args.stress_duration_secs == 0 {
+            None
+        } else {
+            Some(std::time::Duration::from_secs(args.stress_duration_secs))
+        };
+        match target.parse::<std::net::SocketAddr>() {
+            Ok(dst) if dst.is_ipv4() && dst.port() != 53 => {
+                info!("udp_inject: dst={} rate={}/s duration={:?}", dst, rate, duration);
+                let exit_after = duration.is_some();
+                Some(thread::spawn(move || {
+                    udp_inject_loop(dst, rate, duration);
+                    if exit_after {
+                        info!("udp_inject: duration elapsed — signaling shutdown");
+                        SHUTDOWN.store(true, Ordering::SeqCst);
+                    }
+                }))
+            }
+            Ok(dst) => {
+                error!("udp_inject: target {} must be an IPv4 addr with port != 53", dst);
+                None
+            }
+            Err(e) => {
+                error!("udp_inject: target must be IP:port (got {:?}): {}", target, e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Park the main thread on the shutdown flag; ingestion runs on its own
     // thread so a blocking utun read doesn't gate signal handling.
     while !SHUTDOWN.load(Ordering::SeqCst) {
@@ -366,6 +444,9 @@ fn main() -> Result<()> {
         let _ = h.join();
     }
     if let Some(h) = udp_stress_thread {
+        let _ = h.join();
+    }
+    if let Some(h) = udp_inject_thread {
         let _ = h.join();
     }
     info!("clean exit");
@@ -618,6 +699,123 @@ fn udp_stress_loop(
         failed.load(Ordering::Relaxed),
         started.elapsed().as_secs_f64()
     );
+}
+
+/// Synthetic UDP NAT-churn injector. Crafts one IPv4/UDP packet per tick with
+/// a fresh `(src_ip, src_port)` and feeds it straight to `meow_tun_ingest`,
+/// bypassing the OS route table, system DNS, and the utun device. Each fresh
+/// source is a new NAT 5-tuple the engine inserts into `nat_table`; with a
+/// non-answering dst the session goes idle and the NAT sweeper must reap it.
+/// Deterministic, no network setup, no fake-IP, no routing/DNS loop.
+fn udp_inject_loop(dst: std::net::SocketAddr, rate: u64, duration: Option<std::time::Duration>) {
+    let dst_ip = match dst.ip() {
+        std::net::IpAddr::V4(v4) => v4.octets(),
+        std::net::IpAddr::V6(_) => {
+            error!("udp_inject: ipv6 dst unsupported");
+            return;
+        }
+    };
+    let dst_port = dst.port();
+    let interval = std::time::Duration::from_secs_f64(1.0 / rate as f64);
+    let started = std::time::Instant::now();
+    let mut counter: u32 = 0;
+    let mut injected: u64 = 0;
+    let mut last_report = started;
+    let payload: &[u8] = b"meow-udp-inject"; // arbitrary, non-DNS
+
+    while !SHUTDOWN.load(Ordering::Relaxed) {
+        if let Some(limit) = duration {
+            if started.elapsed() >= limit {
+                break;
+            }
+        }
+        // Map the counter to a fresh (src_ip, src_port): 10.<b2>.<b1>.<b0>
+        // with a 16-bit port window gives ~2^32 distinct keys before wrap —
+        // far beyond any run length at these rates.
+        let c = counter;
+        let src_ip = [10u8, (c >> 16) as u8, (c >> 8) as u8, c as u8];
+        let src_port = 1024u16.wrapping_add((c & 0xffff) as u16);
+        counter = counter.wrapping_add(1);
+
+        let pkt = build_udp_ipv4_packet(src_ip, src_port, dst_ip, dst_port, payload);
+        // SAFETY: `pkt` is a valid readable slice for its length; the FFI
+        // copies it into the ingress channel and does not retain the pointer.
+        unsafe {
+            meow_tun_ingest(pkt.as_ptr(), pkt.len());
+        }
+        injected += 1;
+
+        if last_report.elapsed() >= std::time::Duration::from_secs(5) {
+            info!(
+                "udp_inject: injected={} (≈{:.0}/s) elapsed={:.0}s",
+                injected,
+                injected as f64 / started.elapsed().as_secs_f64().max(0.001),
+                started.elapsed().as_secs_f64()
+            );
+            last_report = std::time::Instant::now();
+        }
+        thread::sleep(interval);
+    }
+    info!(
+        "udp_inject: done — injected={} elapsed={:.1}s",
+        injected,
+        started.elapsed().as_secs_f64()
+    );
+}
+
+/// One's-complement IPv4 header checksum (RFC 1071) over `header` (which must
+/// carry a zeroed checksum field).
+fn ipv4_checksum(header: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+    let mut i = 0;
+    while i + 1 < header.len() {
+        sum += u16::from_be_bytes([header[i], header[i + 1]]) as u32;
+        i += 2;
+    }
+    if i < header.len() {
+        sum += (header[i] as u32) << 8;
+    }
+    while (sum >> 16) != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+/// Build a minimal IPv4 + UDP packet (no IP options). The IP header checksum
+/// is computed (the non-53 UDP path traverses the lwip netstack, which may
+/// validate it); the UDP checksum is left 0, which is legal on IPv4.
+fn build_udp_ipv4_packet(
+    src_ip: [u8; 4],
+    src_port: u16,
+    dst_ip: [u8; 4],
+    dst_port: u16,
+    payload: &[u8],
+) -> Vec<u8> {
+    let udp_len: u16 = 8 + payload.len() as u16;
+    let total_len: u16 = 20 + udp_len;
+
+    let mut ip = [0u8; 20];
+    ip[0] = 0x45; // version 4, IHL 5
+    ip[1] = 0x00; // DSCP/ECN
+    ip[2..4].copy_from_slice(&total_len.to_be_bytes());
+    ip[4..6].copy_from_slice(&[0x12, 0x34]); // identification
+    ip[6..8].copy_from_slice(&[0x40, 0x00]); // flags=DF, frag offset 0
+    ip[8] = 64; // TTL
+    ip[9] = 17; // protocol = UDP
+                // ip[10..12] checksum left 0 for the computation
+    ip[12..16].copy_from_slice(&src_ip);
+    ip[16..20].copy_from_slice(&dst_ip);
+    let cksum = ipv4_checksum(&ip);
+    ip[10..12].copy_from_slice(&cksum.to_be_bytes());
+
+    let mut pkt = Vec::with_capacity(total_len as usize);
+    pkt.extend_from_slice(&ip);
+    pkt.extend_from_slice(&src_port.to_be_bytes());
+    pkt.extend_from_slice(&dst_port.to_be_bytes());
+    pkt.extend_from_slice(&udp_len.to_be_bytes());
+    pkt.extend_from_slice(&[0x00, 0x00]); // UDP checksum 0 (legal on IPv4)
+    pkt.extend_from_slice(payload);
+    pkt
 }
 
 fn ingest_loop(fd: RawFd) {

--- a/core/rust/macos-utun-harness/src/main.rs
+++ b/core/rust/macos-utun-harness/src/main.rs
@@ -44,7 +44,7 @@ use utun::Utun;
 // symbols are exported with C linkage from the staticlib that iOS links,
 // so we are exercising the exact bytes the PacketTunnel extension runs.
 use meow_ios_ffi::{
-    meow_core_init, meow_core_last_error, meow_core_set_home_dir, meow_engine_start,
+    debug_counts, meow_core_init, meow_core_last_error, meow_core_set_home_dir, meow_engine_start,
     meow_engine_stop, meow_tun_ingest, meow_tun_set_accept_cap, meow_tun_start, meow_tun_stop, rss,
 };
 
@@ -105,6 +105,27 @@ struct Args {
     /// Lowering this caps the steady-state per-flow buffer footprint.
     #[arg(long, default_value_t = 0)]
     tcp_accept_cap: i32,
+
+    /// If set, spawn a UDP load generator that fires datagrams at this
+    /// `host:port` from a FRESH ephemeral source port each time. Every
+    /// datagram is therefore a new `(src,dst)` 5-tuple — exactly what makes
+    /// the engine insert a new `Arc<UdpSession>` into its NAT table. This is
+    /// the load shape the slow-leak hunt identified (TCP churn does NOT
+    /// exercise it). Point it at the engine's DNS (or any UDP responder) to
+    /// also get replies, which exercises the "one reply then quiet" path.
+    /// Independent of `--stress-target`; both may run together.
+    #[arg(long)]
+    udp_stress_target: Option<String>,
+
+    /// Concurrent UDP sender threads. Ignored when `--udp-stress-target`
+    /// is unset.
+    #[arg(long, default_value_t = 32)]
+    udp_stress_conns: usize,
+
+    /// Per-worker delay between datagrams. Lower = higher 5-tuple churn
+    /// per second (≈ `udp_stress_conns / interval`/s new NAT sessions).
+    #[arg(long, default_value_t = 20)]
+    udp_stress_interval_ms: u64,
 }
 
 /// The egress callback runs on a tokio worker thread (inside the FFI's
@@ -297,6 +318,30 @@ fn main() -> Result<()> {
         None
     };
 
+    let udp_stress_thread = if let Some(target) = args.udp_stress_target.clone() {
+        let conns = args.udp_stress_conns.max(1);
+        let interval = std::time::Duration::from_millis(args.udp_stress_interval_ms);
+        let duration = if args.stress_duration_secs == 0 {
+            None
+        } else {
+            Some(std::time::Duration::from_secs(args.stress_duration_secs))
+        };
+        info!(
+            "udp_stress: target={} conns={} interval={:?} duration={:?}",
+            target, conns, interval, duration
+        );
+        let exit_after_stress = duration.is_some();
+        Some(thread::spawn(move || {
+            udp_stress_loop(target, conns, interval, duration);
+            if exit_after_stress {
+                info!("udp_stress: duration elapsed — signaling shutdown");
+                SHUTDOWN.store(true, Ordering::SeqCst);
+            }
+        }))
+    } else {
+        None
+    };
+
     // Park the main thread on the shutdown flag; ingestion runs on its own
     // thread so a blocking utun read doesn't gate signal handling.
     while !SHUTDOWN.load(Ordering::SeqCst) {
@@ -320,6 +365,9 @@ fn main() -> Result<()> {
     if let Some(h) = stress_thread {
         let _ = h.join();
     }
+    if let Some(h) = udp_stress_thread {
+        let _ = h.join();
+    }
     info!("clean exit");
     Ok(())
 }
@@ -332,11 +380,19 @@ fn rss_monitor_loop(interval: std::time::Duration) {
             if mib > peak_mib {
                 peak_mib = mib;
             }
+            // Per-flow state-map sizes alongside RSS so a multi-hour run pins
+            // WHICH structure grows: nat_table + reply_readers climbing in
+            // lockstep with RSS ⇒ the UDP NAT-session leak; tcp_flows flat
+            // rules out the TCP path. Zeros when the engine isn't running.
+            let c = debug_counts();
             info!(
-                "rss_monitor t={}s rss={:.2} MiB peak={:.2} MiB",
+                "rss_monitor t={}s rss={:.2} MiB peak={:.2} MiB tcp_flows={} reply_readers={} nat_table={}",
                 ticks * interval.as_secs(),
                 mib,
-                peak_mib
+                peak_mib,
+                c.tcp_flows,
+                c.reply_readers,
+                c.nat_table,
             );
         }
         ticks += 1;
@@ -440,6 +496,125 @@ fn stress_loop(
     info!(
         "stress: done — opened={} failed={} elapsed={:.1}s",
         opened.load(Ordering::Relaxed),
+        failed.load(Ordering::Relaxed),
+        started.elapsed().as_secs_f64()
+    );
+}
+
+/// Fire UDP datagrams at `target` from `conns` worker threads, each using a
+/// FRESH ephemeral source port per datagram so every send is a new
+/// `(src,dst)` 5-tuple — exactly what makes the engine insert a new
+/// `Arc<UdpSession>` into its NAT table, the per-session growth the slow
+/// leak lives in (TCP churn does not touch this path). After each send the
+/// worker briefly polls for a reply, so a responding target also exercises
+/// the reader task's post-first-reply path. Counters reported every 5s.
+fn udp_stress_loop(
+    target: String,
+    conns: usize,
+    interval: std::time::Duration,
+    duration: Option<std::time::Duration>,
+) {
+    use std::net::{ToSocketAddrs, UdpSocket};
+    use std::sync::atomic::AtomicU64;
+
+    let started = std::time::Instant::now();
+    let sent = std::sync::Arc::new(AtomicU64::new(0));
+    let failed = std::sync::Arc::new(AtomicU64::new(0));
+    let replies = std::sync::Arc::new(AtomicU64::new(0));
+
+    let mut workers = Vec::with_capacity(conns);
+    for w in 0..conns {
+        let target = target.clone();
+        let sent = sent.clone();
+        let failed = failed.clone();
+        let replies = replies.clone();
+        workers.push(thread::spawn(move || {
+            // Folded into the payload so a DNS/echo responder sees varying
+            // content (and, aimed at the engine DNS with distinct qnames,
+            // churns the fake-IP pool too).
+            let mut seq = 0u64;
+            while !SHUTDOWN.load(Ordering::Relaxed) {
+                if let Some(limit) = duration {
+                    if started.elapsed() >= limit {
+                        return;
+                    }
+                }
+                let addr = match target.to_socket_addrs() {
+                    Ok(mut it) => it.next(),
+                    Err(_) => None,
+                };
+                let Some(addr) = addr else {
+                    failed.fetch_add(1, Ordering::Relaxed);
+                    thread::sleep(std::time::Duration::from_millis(100));
+                    continue;
+                };
+                // Fresh socket → fresh ephemeral src port → new NAT 5-tuple.
+                let sock = match UdpSocket::bind("0.0.0.0:0") {
+                    Ok(s) => s,
+                    Err(_) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                        thread::sleep(std::time::Duration::from_millis(50));
+                        continue;
+                    }
+                };
+                let payload = [&w.to_be_bytes()[..], &seq.to_be_bytes()[..]].concat();
+                seq = seq.wrapping_add(1);
+                match sock.send_to(&payload, addr) {
+                    Ok(_) => {
+                        sent.fetch_add(1, Ordering::Relaxed);
+                        let _ = sock.set_read_timeout(Some(std::time::Duration::from_millis(50)));
+                        let mut buf = [0u8; 1500];
+                        if sock.recv(&mut buf).is_ok() {
+                            replies.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                    Err(_) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                drop(sock);
+                thread::sleep(interval);
+            }
+        }));
+    }
+
+    // Reporter: aggregate counters every 5s, mirroring the TCP stress loop.
+    let sent_r = sent.clone();
+    let failed_r = failed.clone();
+    let replies_r = replies.clone();
+    let reporter = thread::spawn(move || {
+        let mut last = 0u64;
+        while !SHUTDOWN.load(Ordering::Relaxed) {
+            if let Some(limit) = duration {
+                if started.elapsed() >= limit {
+                    return;
+                }
+            }
+            thread::sleep(std::time::Duration::from_secs(5));
+            let now_s = sent_r.load(Ordering::Relaxed);
+            let f = failed_r.load(Ordering::Relaxed);
+            let r = replies_r.load(Ordering::Relaxed);
+            let rate = (now_s - last) as f64 / 5.0;
+            info!(
+                "udp_stress: sent={} (Δ{:.1}/s) replies={} failed={} elapsed={:.0}s",
+                now_s,
+                rate,
+                r,
+                f,
+                started.elapsed().as_secs_f64()
+            );
+            last = now_s;
+        }
+    });
+
+    for w in workers {
+        let _ = w.join();
+    }
+    let _ = reporter.join();
+    info!(
+        "udp_stress: done — sent={} replies={} failed={} elapsed={:.1}s",
+        sent.load(Ordering::Relaxed),
+        replies.load(Ordering::Relaxed),
         failed.load(Ordering::Relaxed),
         started.elapsed().as_secs_f64()
     );

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -301,7 +301,17 @@ pub fn start(config_path: &str) -> Result<()> {
     // reaches. Over hours that slow growth crosses the ~50 MB NE jetsam cap
     // and the PacketTunnel is killed. `meow-app` calls this after building
     // its tunnel; the FFI must too. Idempotent — invoked once per engine.
-    tunnel.spawn_background_tasks();
+    //
+    // `start()` runs on the main thread, OUTSIDE the tokio runtime, and
+    // `spawn_background_tasks` uses a bare `tokio::spawn` (unlike the
+    // `get_runtime().spawn(...)` callsites below, which carry their own
+    // handle). Enter the runtime context for the call so the sweeper task
+    // lands on `get_runtime()` instead of panicking with "no reactor
+    // running". The guard only needs to outlive the spawn.
+    {
+        let _enter = crate::get_runtime().enter();
+        tunnel.spawn_background_tasks();
+    }
 
     let stats = tunnel.statistics().clone();
 

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -290,6 +290,19 @@ pub fn start(config_path: &str) -> Result<()> {
     tunnel.set_mode(cfg.general.mode);
     tunnel.update_rules(cfg.rules);
     tunnel.update_proxies(cfg.proxies);
+
+    // Start the tunnel's background tasks — currently just the UDP NAT
+    // sweeper, which evicts sessions idle > DEFAULT_UDP_IDLE (60 s) every
+    // DEFAULT_SWEEP_INTERVAL (15 s). Without this call the `nat_table` (and
+    // the `reply_readers` set + detached reader tasks the FFI keys off it)
+    // grows monotonically under UDP flow churn: every new 5-tuple inserts an
+    // `Arc<UdpSession>` that is only removed on a reader-task exit that a
+    // quiet session (one-shot DNS, abandoned QUIC, dead upstream) never
+    // reaches. Over hours that slow growth crosses the ~50 MB NE jetsam cap
+    // and the PacketTunnel is killed. `meow-app` calls this after building
+    // its tunnel; the FFI must too. Idempotent — invoked once per engine.
+    tunnel.spawn_background_tasks();
+
     let stats = tunnel.statistics().clone();
 
     // No `meow_app::geodata_fetch::run_on_startup` spawn here: the iOS app

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -31,6 +31,11 @@ mod tun2socks;
 #[cfg(test)]
 mod xdg_home_dir_tests;
 
+/// Live per-flow state-map sizes (TCP flows, UDP reply readers, UDP NAT
+/// table) for the dev harness RSS monitor — see the slow-leak hunt. Not part
+/// of the C ABI; consumed by `macos-utun-harness` via the rlib.
+pub use tun2socks::{debug_counts, DebugCounts};
+
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -331,6 +331,47 @@ fn ingress_slot() -> &'static Mutex<Option<mpsc::Sender<Vec<u8>>>> {
     S.get_or_init(|| Mutex::new(None))
 }
 
+/// Weak handle to the per-engine `reply_readers` set, published by
+/// `run_tun2socks` at startup. `Weak` so it never keeps the set alive past
+/// an engine stop, and so a restart's fresh set simply replaces it. Read
+/// only by `debug_counts`.
+#[allow(clippy::type_complexity)]
+fn reply_readers_slot(
+) -> &'static Mutex<Option<std::sync::Weak<Mutex<HashSet<(SocketAddr, SocketAddr)>>>>> {
+    static S: OnceLock<Mutex<Option<std::sync::Weak<Mutex<HashSet<(SocketAddr, SocketAddr)>>>>>> =
+        OnceLock::new();
+    S.get_or_init(|| Mutex::new(None))
+}
+
+/// Live sizes of the per-flow state maps the slow-leak investigation
+/// flagged (TCP flow registry, UDP reply-reader set, UDP NAT table), so the
+/// harness `rss_monitor` can chart them next to RSS and pin which structure
+/// grows under churn. All three reads are O(1)/O(shards) and only briefly
+/// locked — cheap enough for a per-tick (≥5 s) sample.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DebugCounts {
+    pub tcp_flows: u64,
+    pub reply_readers: u64,
+    pub nat_table: u64,
+}
+
+/// Snapshot [`DebugCounts`]. Returns zeros for any map whose owner isn't
+/// currently running (engine stopped, tun2socks not started).
+pub fn debug_counts() -> DebugCounts {
+    DebugCounts {
+        tcp_flows: tcp_flows().len() as u64,
+        reply_readers: reply_readers_slot()
+            .lock()
+            .as_ref()
+            .and_then(std::sync::Weak::upgrade)
+            .map(|m| m.lock().len() as u64)
+            .unwrap_or(0),
+        nat_table: crate::engine::tunnel()
+            .map(|t| t.inner().nat_table.len() as u64)
+            .unwrap_or(0),
+    }
+}
+
 pub fn start(ctx: *mut c_void, cb: WritePacketFn) -> Result<(), String> {
     if TUN2SOCKS_RUNNING.swap(true, Ordering::SeqCst) {
         return Err("tun2socks already running".into());
@@ -409,6 +450,9 @@ async fn run_tun2socks(
     // same tuple meow-tunnel uses, or dedupe breaks and we leak readers.
     let reply_readers: Arc<Mutex<HashSet<(SocketAddr, SocketAddr)>>> =
         Arc::new(Mutex::new(HashSet::new()));
+    // Publish a weak handle so `debug_counts()` (harness RSS monitor) can
+    // sample this set's size without owning it.
+    *reply_readers_slot().lock() = Some(Arc::downgrade(&reply_readers));
 
     let (stack_ingress_tx, mut stack_ingress_rx) = mpsc::channel::<AnyIpPktFrame>(256);
     let (egress_tx, mut egress_rx) = mpsc::channel::<Vec<u8>>(1024);
@@ -1121,7 +1165,31 @@ fn spawn_udp_reply_reader(
                     }
                 }
             } else {
-                session.conn.read_packet(&mut buf).await
+                // Post-first-reply idle backstop. The NAT sweeper
+                // (`spawn_background_tasks`) evicts the `nat_table` entry once
+                // a session is idle > DEFAULT_UDP_IDLE (60 s), but this reader
+                // task holds its OWN `Arc<UdpSession>` + 4 KiB `buf`, so the
+                // sweeper alone can't unblock a `read_packet` that never
+                // returns — the task (and its buffer) would leak for any
+                // session that gets one reply then goes silent (one-shot DNS,
+                // abandoned QUIC, dead upstream). Bound the read at the same
+                // 60 s idle the tunnel already uses, so once the NAT layer
+                // considers the session dead this reader exits and reaches the
+                // cleanup below. Genuinely active sessions (data within 60 s)
+                // are never evicted; a session quiet > 60 s is one the tunnel
+                // has already dropped from `nat_table` regardless.
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(60),
+                    session.conn.read_packet(&mut buf),
+                )
+                .await
+                {
+                    Ok(res) => res,
+                    Err(_) => {
+                        info!("UDP reply reader idle > 60s for {:?}; evicting session", key);
+                        break;
+                    }
+                }
             };
             match read {
                 Ok((n, _from)) => {


### PR DESCRIPTION
## Problem

`macos-utun-harness` (`meow-utun`) runs normally for **hours**, then PacketTunnel is killed: `phys_mem` grows slowly and monotonically toward the ~50 MB jetsam cap. Classic slow per-flow-state leak (not a burst, not fragmentation).

## Root cause

`meow-ios-ffi/src/engine.rs` built the `Tunnel` but **never called `tunnel.spawn_background_tasks()`**, so meow-tunnel's UDP NAT idle-sweeper (`udp.rs`, evicts sessions idle >60s every 15s) never ran. Every new UDP 5-tuple inserts an `Arc<UdpSession>` into `nat_table` (+ a `reply_readers` entry + detached reader task in the FFI), removed only on a reader-task exit. A session that gets one reply then goes quiet (one-shot DNS, abandoned QUIC, dead upstream) blocks forever on the **unbounded post-first-reply read** in `tun2socks.rs`, so cleanup never fires. `meow-app/src/main.rs:458` calls `spawn_background_tasks` — the FFI was the only consumer that forgot.

Diagnosed via a multi-agent leak-hunt workflow; root cause independently confirmed by three finders + adversarial verification, then by direct source inspection (zero `spawn_background_tasks` call sites in the FFI).

## Fix

- **`engine.rs`**: call `tunnel.spawn_background_tasks()` after config load — starts the NAT sweeper.
- **`tun2socks.rs`**: bound the post-first-reply UDP read with a 60s idle timeout. The reader task holds its *own* `Arc<UdpSession>` + 4 KiB buffer, so the sweeper alone can't unblock a read that never returns; the timeout lets the task self-terminate and reach its `nat_table`/`reply_readers` cleanup, matching the tunnel's own 60s NAT idle.

## Diagnostics added

- **`debug_counts()`** (FFI, Rust-only — *not* part of the C ABI; header unchanged): live `tcp_flows` / `reply_readers` / `nat_table` sizes.
- **Harness `--udp-stress-target`** (+ `--udp-stress-conns`, `--udp-stress-interval-ms`): fresh-src-port UDP churn — the load shape that exercises the NAT path (`--stress-target` is TCP-only and does *not*).
- **`rss_monitor`** now logs the three map sizes next to RSS, so one multi-hour run pins which structure grows.

Repro / confirm:
```
meow-utun --config <cfg> --home <layout> --rss-monitor-interval-secs 30 \
  --udp-stress-target <dns:port> --udp-stress-conns 64 --udp-stress-interval-ms 10
```
With the fix, `nat_table`+`reply_readers` should plateau instead of climbing with RSS.

## Not in this PR

- **fakeip `FileStore`** secondary unbounded-HashMap leak (upstream meow-rs; only bites under high unique-domain churn with `store-fake-ip: true`).
- Harness `Cargo.lock` synced from stale `meow-rs 0a7d702` → `71871a3` (the rev the FFI already pins). iOS/NE dependency graph (the FFI's own `Cargo.lock`) is unaffected.

## Verification (local)

- `cargo check` host **and iOS target** (`aarch64-apple-ios`) — clean
- `cargo clippy --all-targets -- -D warnings` — clean, both crates
- `cargo test -- --test-threads=1` — **40/40** (38 unit + 2 stress)
- `scripts/build-rust.sh` — device + sim + xcframework built; `meow_core.h` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)