### PR TITLE
perf(packettunnel): proactively reclaim free pages on TCP teardown bursts

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -19,6 +19,21 @@ static os_log_t gLog;
 static const NSInteger kSoftCapFootprintMB    = 35;
 static const NSTimeInterval kReliefCooldownS  = 60.0;
 
+// Proactive-reclaim trigger for a TCP teardown burst. When a batch of flows
+// closes together — network handoff (Wi-Fi↔cellular), reconnect, or the app
+// dropping a page full of connections — their relay buffers (owned by meow's
+// `copy_bidirectional_buf`) free at once. That is the peak-fragmentation
+// moment: lots of just-freed pages the allocator is still holding. Returning
+// them now, rather than waiting up to the soft-cap watchdog, keeps the
+// footprint low while the extension is awake. We trigger off a drop in
+// `tcp_conns` (a clean integer count) rather than malloc's free-heap figure,
+// which includes non-resident reserved address space and reads larger than the
+// physical footprint itself (~21 MB free at a 12 MB footprint), so it can't
+// gate a reclaim. The short cooldown keeps normal open/close churn from
+// thrashing the allocator.
+static const int64_t kTeardownBurstFlows       = 16;
+static const NSTimeInterval kTeardownCooldownS = 5.0;
+
 @implementation MWTunnelEngine {
     NEPacketTunnelFlow *_flow;
     MWPacketWriter *_writer;
@@ -33,6 +48,8 @@ static const NSTimeInterval kReliefCooldownS  = 60.0;
     NSTimeInterval _lastTime;
     int _pumpTick;
     NSTimeInterval _lastReliefAttempt;  // CFAbsoluteTime; 0 = never
+    int64_t _lastTcpConns;              // prev snapshot's tcp_conns, for teardown-burst detection
+    NSTimeInterval _lastTeardownRelief; // CFAbsoluteTime; 0 = never
 }
 
 + (void)initialize {
@@ -271,6 +288,22 @@ static const NSTimeInterval kReliefCooldownS  = 60.0;
     if (_pumpTick % 10 == 0) {
         malloc_zone_pressure_relief(NULL, 0);
     }
+
+    // Proactive reclaim on a TCP teardown burst (see kTeardownBurstFlows). A
+    // sharp drop in live connections means a batch of relay buffers just
+    // freed; return those pages immediately rather than waiting for the next
+    // periodic relief or the soft-cap watchdog. The cooldown bounds this to at
+    // most one extra relief per kTeardownCooldownS so steady churn can't thrash
+    // the allocator.
+    if (_lastTcpConns - tcpConns >= kTeardownBurstFlows &&
+        (now - _lastTeardownRelief) >= kTeardownCooldownS) {
+        os_log_info(gLog,
+                    "teardown burst: tcp_conns %lld→%lld, returning free pages",
+                    _lastTcpConns, tcpConns);
+        malloc_zone_pressure_relief(NULL, 0);
+        _lastTeardownRelief = now;
+    }
+    _lastTcpConns = tcpConns;
 
     [self maybeRestartForFootprint:footprintMB now:now];
 


### PR DESCRIPTION
## Summary

Reduces iOS PacketTunnel memory fragmentation by proactively returning freed pages to the OS at the peak-fragmentation moment: a **TCP teardown burst**.

When a batch of TCP flows closes together — Wi-Fi↔cellular handoff, reconnect, or the app dropping a page full of connections — their relay buffers (meow's `copy_bidirectional_buf`, fixed `RELAY_BUF_SIZE` = 4 KiB each) all free at once. Those just-freed pages stay resident-and-counted against `phys_footprint` (the jetsam metric) until something scavenges them. Previously that only happened at the every-10-tick periodic relief or the 35 MB soft-cap watchdog.

## Change

`MWTunnelEngine.m`'s 500 ms traffic pump now detects a drop in `tcp_conns` of ≥16 between samples and calls `malloc_zone_pressure_relief(NULL, 0)` immediately, bounded by a 5 s cooldown so steady open/close churn can't thrash the allocator. One ObjC file, +33 lines.

### Design notes
- **Gated on `tcp_conns` (integer), not `heap_free`.** malloc's free-heap figure includes reserved-but-not-resident address space and reads *larger* than the physical footprint (~21 MB "free" at a 12 MB footprint), so it can't gate a reclaim. The live-connection count is a clean signal for "a batch of buffers just freed."
- **Why this is the right iOS lever:** custom allocators (jemalloc/mimalloc) don't reduce RSS on Darwin — `MADV_FREE` pages stay resident until kernel pressure, and jetsam fires first. `malloc_zone_pressure_relief` is the iOS-native way to force that scavenge. This is the same primitive the existing soft-cap watchdog and sleep handler already use, just triggered proactively.

## Investigation finding (no change needed)
Audited the TCP relay buffer path for per-flow size churn (the #1 fragmentation generator in a proxy): the relay uses a **fixed 4 KiB `RELAY_BUF_SIZE`** for both directions in meow-rs (`meow-tunnel/src/relay.rs`), matching the UDP reader's 4 KiB buffer. No variable-size per-flow buffer churn exists, so no change was warranted there.

## Test
- ObjC change; `swiftlint --strict` and `swiftformat --lint .` both clean (0 violations).
- Release build SUCCEEDED for `iphoneos`; installed on iPhone 17 Pro (iOS 26.5).
- `git diff origin/main...HEAD --stat` verified: only `PacketTunnel/Sources/MWTunnelEngine.m`.
- On-device reclaim verification (drive flows → mass teardown → footprint drop) pending; the `os_log` line `teardown burst: tcp_conns N→M` marks each trigger.

Running full remote CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
