### PR TITLE
chore(release): bump build to 2026053101

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026052901</string>
+	<string>2026053101</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>2026052901</string>
+	<string>2026053101</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026052901"
+        CFBundleVersion: "2026053101"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026052901"
+        CFBundleVersion: "2026053101"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

Build-number bump to **2026053101** (marketing version stays **1.3.1**). Ships the two on-device-verified memory fixes merged since the last build.

## What's in this build
- **fix(tun2socks): bound live UDP sessions via udp_sem held for reader lifetime** (#210) — closes the UDP NAT session-count leak. On-device verified: footprint flat at 15 MB through 8 min of sustained UDP/QUIC load.
- **perf(packettunnel): proactively reclaim free pages on TCP teardown bursts** (#211) — reduces `phys_footprint` fragmentation. On-device verified: footprint drops promptly after a mass teardown.

## Change
`CFBundleVersion` 2026052901 → 2026053101 for both the App and PacketTunnel targets in `project.yml` (xcodegen source of truth) + the generated `App/Info.plist` and `PacketTunnel/Info.plist`. `CFBundleShortVersionString` unchanged (1.3.1).

`git diff origin/main...HEAD --stat`: only `project.yml`, `App/Info.plist`, `PacketTunnel/Info.plist` (4 lines, build config only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
