### PR TITLE
fix(subscription): detect Clash YAML with late proxies

### DIFF
--- a/App/Sources/Services/SubscriptionService.swift
+++ b/App/Sources/Services/SubscriptionService.swift
@@ -134,8 +134,14 @@ enum SubscriptionParser {
 
     static func looksLikeClashYAML(_ data: Data) -> Bool {
         guard let text = String(data: data, encoding: .utf8) else { return false }
-        let prefix = text.prefix(4096)
-        return prefix.contains("proxies:") || prefix.contains("proxy-groups:")
+        return text
+            .split(whereSeparator: \.isNewline)
+            .contains { line in
+                guard line.first?.isWhitespace != true else { return false }
+                let text = String(line).trimmingCharacters(in: .whitespaces)
+                return isTopLevelYAMLKey("proxies:", line: text) ||
+                    isTopLevelYAMLKey("proxy-groups:", line: text)
+            }
     }
 
     static func looksLikeV2RayN(_ data: Data) -> Bool {
@@ -155,6 +161,10 @@ enum SubscriptionParser {
         }
         return text.contains("ss://") || text.contains("trojan://") ||
             text.contains("vless://") || text.contains("vmess://")
+    }
+
+    private static func isTopLevelYAMLKey(_ key: String, line: String) -> Bool {
+        line == key || line.hasPrefix("\(key) ")
     }
 }
 

--- a/MeowTests/Parsing/SubscriptionParserTests.swift
+++ b/MeowTests/Parsing/SubscriptionParserTests.swift
@@ -40,6 +40,27 @@ struct SubscriptionParserTests {
     }
 
     @Test
+    func `detects Clash YAML when rule blocks appear before proxies`() {
+        let rules = (0 ..< 180)
+            .map { "  - DOMAIN-SUFFIX,example\($0).com,DIRECT" }
+            .joined(separator: "\n")
+        let input = Data("""
+        rules:
+        \(rules)
+        proxies:
+          - name: late-node
+            type: direct
+        proxy-groups:
+          - name: Choose
+            type: select
+            proxies:
+              - late-node
+        """.utf8)
+
+        #expect(SubscriptionParser.detectFormat(input) == .clashYaml)
+    }
+
+    @Test
     func `detects v2rayN base64 nodelist`() throws {
         let input = try loadFixture("v2rayn_ss_pair")
         #expect(SubscriptionParser.detectFormat(input) == .v2rayN)

--- a/core/rust/meow-ios-ffi/src/subscription.rs
+++ b/core/rust/meow-ios-ffi/src/subscription.rs
@@ -62,8 +62,16 @@ pub fn convert(body: &[u8]) -> Result<String> {
 }
 
 fn looks_like_clash_yaml(text: &str) -> bool {
-    let prefix: String = text.chars().take(4096).collect();
-    prefix.contains("proxies:") || prefix.contains("proxy-groups:")
+    text.lines().map(str::trim_end).any(|line| {
+        is_top_level_yaml_key(line, "proxies:") || is_top_level_yaml_key(line, "proxy-groups:")
+    })
+}
+
+fn is_top_level_yaml_key(line: &str, key: &str) -> bool {
+    line == key
+        || line
+            .strip_prefix(key)
+            .is_some_and(|rest| rest.starts_with(' '))
 }
 
 fn try_base64(text: &str) -> Option<String> {
@@ -256,6 +264,21 @@ mod tests {
         let body = b"proxies:\n  - name: n1\n    type: ss\n    server: 1.2.3.4\n    port: 443\n    cipher: aes-256-gcm\n    password: p\n";
         let out = convert(body).unwrap();
         assert!(out.contains("proxies:"));
+    }
+
+    #[test]
+    fn clash_yaml_passthrough_with_late_proxies() {
+        let rules = (0..180)
+            .map(|i| format!("  - DOMAIN-SUFFIX,example{}.com,DIRECT", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let body = format!(
+            "rules:\n{}\nproxies:\n  - name: late-node\n    type: direct\nproxy-groups:\n  - name: Choose\n    type: select\n    proxies:\n      - late-node\n",
+            rules
+        );
+
+        let out = convert(body.as_bytes()).unwrap();
+        assert!(out.contains("late-node"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Detect Clash YAML by scanning for top-level `proxies:` and `proxy-groups:` keys across the full subscription body instead of only the first 4096 characters.
- Apply the same detection behavior in the Swift parser and Rust converter.
- Add regression coverage for rule-heavy Clash configs whose proxy block appears later in the file.

## Testing
- `swiftformat --lint .`
- `swiftlint --strict`
- `cargo test -p meow-ios-ffi clash_yaml_passthrough_with_late_proxies`
- `./scripts/build-rust.sh`
- `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests/SubscriptionParserTests ENABLE_DEBUG_DYLIB=NO`\n\n## Notes\n- `cargo fmt --check` still reports an unrelated pre-existing formatting diff in `core/rust/meow-ios-ffi/src/engine.rs`; this PR does not touch that file.\n- The local Xcode test required a generated `MeowCore.xcframework` and local `GoogleService-Info.plist`; neither is committed.