### PR TITLE
fix(packettunnel): restart tun2socks when the network's address-family set changes

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -155,7 +155,6 @@
 "settings.nav.title" = "Settings";
 "settings.section.general" = "General";
 "settings.toggle.allowLan" = "Allow LAN";
-"settings.toggle.ipv6" = "IPv6";
 "settings.toggle.onDemand" = "Connect On Demand";
 "settings.picker.logLevel" = "Log Level";
 "settings.logLevel.debug" = "Debug";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -161,7 +161,6 @@
 "settings.nav.title" = "设置";
 "settings.section.general" = "通用";
 "settings.toggle.allowLan" = "允许局域网";
-"settings.toggle.ipv6" = "IPv6";
 "settings.toggle.onDemand" = "按需自动连接";
 "settings.picker.logLevel" = "日志级别";
 "settings.logLevel.debug" = "调试";

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -22,8 +22,6 @@ struct SettingsView: View {
             Section("settings.section.general") {
                 Toggle("settings.toggle.allowLan", isOn: binding(\.allowLan))
                     .accessibilityIdentifier("settings.toggle.allowLan")
-                Toggle("settings.toggle.ipv6", isOn: binding(\.ipv6))
-                    .accessibilityIdentifier("settings.toggle.ipv6")
                 Toggle("settings.toggle.onDemand", isOn: binding(\.onDemand))
                     .accessibilityIdentifier("settings.toggle.onDemand")
                 Picker("settings.picker.logLevel", selection: binding(\.logLevel)) {
@@ -92,7 +90,6 @@ struct SettingsView: View {
             }
         #endif
             .onChange(of: preferences.allowLan) { _, _ in persist() }
-            .onChange(of: preferences.ipv6) { _, _ in persist() }
             .onChange(of: preferences.logLevel) { _, _ in persist() }
             .onChange(of: preferences.onDemand) { _, _ in
                 persist()

--- a/MeowShared/Sources/MeowModels/Preferences.swift
+++ b/MeowShared/Sources/MeowModels/Preferences.swift
@@ -7,7 +7,6 @@ public enum PreferenceKey {
     public static let mixedPort = "com.meow.mixedPort"
     public static let logLevel = "com.meow.logLevel"
     public static let allowLan = "com.meow.allowLan"
-    public static let ipv6 = "com.meow.ipv6"
     public static let onDemand = "com.meow.onDemand"
     public static let pendingIntent = "com.meow.pendingIntent"
     public static let selectedProfileID = "com.meow.selectedProfileID"
@@ -18,7 +17,6 @@ public enum PreferenceDefaults {
     public static let mixedPort: Int = 7890
     public static let logLevel: String = "info"
     public static let allowLan: Bool = false
-    public static let ipv6: Bool = false
     public static let onDemand: Bool = false
 }
 
@@ -26,20 +24,17 @@ public struct Preferences: Sendable {
     public var mixedPort: Int
     public var logLevel: String
     public var allowLan: Bool
-    public var ipv6: Bool
     public var onDemand: Bool
 
     public init(
         mixedPort: Int = PreferenceDefaults.mixedPort,
         logLevel: String = PreferenceDefaults.logLevel,
         allowLan: Bool = PreferenceDefaults.allowLan,
-        ipv6: Bool = PreferenceDefaults.ipv6,
         onDemand: Bool = PreferenceDefaults.onDemand,
     ) {
         self.mixedPort = mixedPort
         self.logLevel = logLevel
         self.allowLan = allowLan
-        self.ipv6 = ipv6
         self.onDemand = onDemand
     }
 
@@ -52,9 +47,6 @@ public struct Preferences: Sendable {
         if defaults.object(forKey: PreferenceKey.allowLan) != nil {
             prefs.allowLan = defaults.bool(forKey: PreferenceKey.allowLan)
         }
-        if defaults.object(forKey: PreferenceKey.ipv6) != nil {
-            prefs.ipv6 = defaults.bool(forKey: PreferenceKey.ipv6)
-        }
         if defaults.object(forKey: PreferenceKey.onDemand) != nil {
             prefs.onDemand = defaults.bool(forKey: PreferenceKey.onDemand)
         }
@@ -65,7 +57,6 @@ public struct Preferences: Sendable {
         defaults.set(mixedPort, forKey: PreferenceKey.mixedPort)
         defaults.set(logLevel, forKey: PreferenceKey.logLevel)
         defaults.set(allowLan, forKey: PreferenceKey.allowLan)
-        defaults.set(ipv6, forKey: PreferenceKey.ipv6)
         defaults.set(onDemand, forKey: PreferenceKey.onDemand)
     }
 }

--- a/PacketTunnel/Sources/MWPreferences.h
+++ b/PacketTunnel/Sources/MWPreferences.h
@@ -5,13 +5,11 @@
 extern NSString *const MWPrefKeyMixedPort;
 extern NSString *const MWPrefKeyLogLevel;
 extern NSString *const MWPrefKeyAllowLan;
-extern NSString *const MWPrefKeyIpv6;
 extern NSString *const MWPrefKeyPendingIntent;
 
 @interface MWPreferences : NSObject
 @property (nonatomic, assign) NSInteger mixedPort;
 @property (nonatomic, copy)   NSString *logLevel;
 @property (nonatomic, assign) BOOL allowLan;
-@property (nonatomic, assign) BOOL ipv6;
 + (instancetype)loadFromDefaults:(NSUserDefaults *)defaults;
 @end

--- a/PacketTunnel/Sources/MWPreferences.m
+++ b/PacketTunnel/Sources/MWPreferences.m
@@ -3,7 +3,6 @@
 NSString *const MWPrefKeyMixedPort     = @"com.meow.mixedPort";
 NSString *const MWPrefKeyLogLevel      = @"com.meow.logLevel";
 NSString *const MWPrefKeyAllowLan      = @"com.meow.allowLan";
-NSString *const MWPrefKeyIpv6          = @"com.meow.ipv6";
 NSString *const MWPrefKeyPendingIntent = @"com.meow.pendingIntent";
 
 @implementation MWPreferences
@@ -14,7 +13,6 @@ NSString *const MWPrefKeyPendingIntent = @"com.meow.pendingIntent";
         _mixedPort  = 7890;
         _logLevel   = @"info";
         _allowLan   = NO;
-        _ipv6       = NO;
     }
     return self;
 }
@@ -27,8 +25,6 @@ NSString *const MWPrefKeyPendingIntent = @"com.meow.pendingIntent";
     p.logLevel = level ?: @"info";
     if ([defaults objectForKey:MWPrefKeyAllowLan])
         p.allowLan = [defaults boolForKey:MWPrefKeyAllowLan];
-    if ([defaults objectForKey:MWPrefKeyIpv6])
-        p.ipv6 = [defaults boolForKey:MWPrefKeyIpv6];
     return p;
 }
 

--- a/PacketTunnel/Sources/MWTunnelSettings.m
+++ b/PacketTunnel/Sources/MWTunnelSettings.m
@@ -14,7 +14,23 @@
     ipv4.excludedRoutes = [self ipv4LanExcludedRoutes];
     settings.IPv4Settings = ipv4;
 
-    // IPv6
+    // IPv6 — claimed unconditionally, even on IPv4-only networks. This is
+    // a deliberate sinkhole, not an oversight:
+    //
+    //   * Claiming ::/0 prevents IPv6 leak-around: on a v6-capable network,
+    //     apps would otherwise reach the internet natively over v6,
+    //     bypassing the proxy entirely.
+    //   * It costs nothing on a v4-only network because almost no v6
+    //     traffic enters the TUN: the engine's resolver runs fake-IP with a
+    //     v4-only pool, and meow-dns answers AAAA with NOERROR-empty in
+    //     that configuration, so clients fall back to A / fake-v4 and the
+    //     proxy connects by hostname. Only hardcoded v6 literals (rare)
+    //     ever route in, and those fail fast at the engine's dial.
+    //   * Do NOT make this conditional on path capability: re-applying
+    //     network settings mid-tunnel reasserts the whole payload (fragile —
+    //     see the loopback-route lesson in ipv4LanExcludedRoutes) and
+    //     IPv4↔IPv6 transitions are already handled by the path monitor's
+    //     address-family restart in PacketTunnelProvider.
     NEIPv6Settings *ipv6 = [[NEIPv6Settings alloc]
         initWithAddresses:@[@"fdfe:dcba:9876::1"]
      networkPrefixLengths:@[@126]];

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -29,6 +29,8 @@ static os_log_t gLog;
     BOOL                _havePath;
     BOOL                _lastSatisfied;
     nw_interface_type_t _lastInterfaceType;
+    BOOL                _lastHasIPv4;
+    BOOL                _lastHasIPv6;
 }
 
 + (void)initialize {
@@ -285,6 +287,8 @@ static os_log_t gLog;
     _havePath = NO;
     _lastSatisfied = NO;
     _lastInterfaceType = nw_interface_type_other;
+    _lastHasIPv4 = NO;
+    _lastHasIPv6 = NO;
 
     nw_path_monitor_t monitor = nw_path_monitor_create();
     nw_path_monitor_set_queue(monitor, _pathQueue);
@@ -317,6 +321,8 @@ static os_log_t gLog;
     BOOL satisfied = (status == nw_path_status_satisfied);
 
     nw_interface_type_t iface = nw_interface_type_other;
+    BOOL hasIPv4 = NO;
+    BOOL hasIPv6 = NO;
     if (satisfied) {
         if (nw_path_uses_interface_type(path, nw_interface_type_wifi)) {
             iface = nw_interface_type_wifi;
@@ -325,13 +331,18 @@ static os_log_t gLog;
         } else if (nw_path_uses_interface_type(path, nw_interface_type_wired)) {
             iface = nw_interface_type_wired;
         }
+        hasIPv4 = nw_path_has_ipv4(path);
+        hasIPv6 = nw_path_has_ipv6(path);
     }
 
     if (!_havePath) {
         _havePath = YES;
         _lastSatisfied = satisfied;
         _lastInterfaceType = iface;
-        os_log_info(gLog, "path: initial satisfied=%d iface=%d", satisfied, iface);
+        _lastHasIPv4 = hasIPv4;
+        _lastHasIPv6 = hasIPv6;
+        os_log_info(gLog, "path: initial satisfied=%d iface=%d v4=%d v6=%d",
+                    satisfied, iface, hasIPv4, hasIPv6);
         return;
     }
 
@@ -342,10 +353,22 @@ static os_log_t gLog;
     } else if (satisfied && iface != _lastInterfaceType) {
         os_log_info(gLog, "path: interface changed %d -> %d", _lastInterfaceType, iface);
         meaningful = YES;
+    } else if (satisfied && (hasIPv4 != _lastHasIPv4 || hasIPv6 != _lastHasIPv6)) {
+        // Same interface, same satisfied state, but the address-family set
+        // changed — e.g. the Wi-Fi network silently lost (or gained) IPv6
+        // via expired RAs or an upstream change. Without this branch the
+        // flip is invisible: upstream connections the engine established
+        // over the vanished family black-hole until the idle-TTL sweeper
+        // reaps them, while the tunnel still reports "connected".
+        os_log_info(gLog, "path: address family changed v4 %d -> %d, v6 %d -> %d",
+                    _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6);
+        meaningful = YES;
     }
 
     _lastSatisfied = satisfied;
     _lastInterfaceType = iface;
+    _lastHasIPv4 = hasIPv4;
+    _lastHasIPv6 = hasIPv6;
 
     if (meaningful) {
         [self scheduleReconnect];


### PR DESCRIPTION
## Problem

Switching from an IPv6-capable network to an IPv4-only one (or vice versa) was only handled when the flip coincided with an interface-type change (Wi-Fi ↔ cellular) or a connectivity gap. A **same-interface family change** — Wi-Fi silently losing IPv6 via expired RAs, a carrier dropping v6 mid-session — produced no path event `handlePathUpdate` considered meaningful. Upstream connections the engine had established over the vanished family black-holed until the idle-TTL sweeper (PR #216, 300 s) reaped them, while the tunnel still reported "connected".

## Investigation notes (what turned out NOT to be broken)

- **AAAA / fake-IP**: meow-dns already answers AAAA with NOERROR-empty when only a v4 fake-IP pool is configured, so apps fall back to A cleanly — domain traffic never rides v6 inside the tunnel. No change needed.
- **TCP proxy dial**: `TcpStream::connect((host, port))` tries every resolved address sequentially with Darwin's RFC 6724 sorting — family fallback already exists. The one real gap (SS **UDP** relay `resolve_host` takes first-addr-only) is upstream: filed madeye/meow-rs#167.

## Changes

- **PacketTunnelProvider**: track `nw_path_has_ipv4`/`nw_path_has_ipv6` per path update; an address-family change on a satisfied path is now a meaningful event → debounced tun2socks restart (same machinery as interface changes), promptly clearing stale upstream conns, UDP NAT entries, and health-check state.
- **MWTunnelSettings**: document that claiming `::/0` unconditionally is a deliberate anti-leak sinkhole and must not become path-conditional.
- **Remove the Settings "IPv6" toggle** (`com.meow.ipv6` pref): dead weight end to end — stored, loaded, and consumed by nothing; even the engine ignores the `ipv6:` config key it parses. Removed from SettingsView, `Preferences.swift`, `MWPreferences.{h,m}`, and both Localizable.strings.

## Path B attestation (local CI green)

- [x] `swiftformat --lint .` at repo root → 0 violations (0/90 files require formatting)
- [x] `swiftlint --strict` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -only-testing:MeowIntegrationTests` (clean DerivedData) → **MeowTests 126 tests / 24 suites passed; MeowIntegrationTests passed (18 XCTest + 26 Swift Testing)**; MeowUITests passed with `-testLanguage en` (24 executed, 0 failures)
  - Note: on a Chinese-locale simulator, `TrafficScreenTests.testEmptyStateShowsOnFreshInstall` fails **on main too** — the `.accessibilityIdentifier` set on tab items doesn't propagate to tab-bar buttons on the iOS 26.4 runtime, so the page object falls back to matching the localized label. Pre-existing, locale-dependent test-infra issue, unrelated to this diff; CI runs English and is unaffected. Follow-up candidate: make `MeowApp` tab lookups locale-independent.
- [x] No Rust / FFI changes — `scripts/build-rust.sh` / `cargo test` not applicable.
- [x] `git diff origin/main...HEAD --stat` verified — 8 files, all intended: PacketTunnelProvider.m, MWTunnelSettings.m (comment only), MWPreferences.{h,m}, Preferences.swift, SettingsView.swift, 2× Localizable.strings. No accidental additions.

## Follow-up

- On-device check: join a v6-capable Wi-Fi, drop v6 on the router (or flip to a v4-only AP without leaving Wi-Fi), confirm syslog shows `path: address family changed` + tun2socks restart and traffic continues.
- madeye/meow-rs#167 — SS UDP relay family fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)