### PR TITLE
chore(core): bump meow-rs pin to f48dac74 for SS UDP relay family fallback

### DIFF
--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1638,8 +1638,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "axum",
  "base64",
@@ -1670,8 +1670,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1692,8 +1692,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1725,8 +1725,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1785,8 +1785,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1819,8 +1819,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1836,8 +1836,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "async-trait",
  "base64",
@@ -1862,16 +1862,16 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "meow-tunnel"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=71871a309e9e47945cb0fdf832e5e2a4425a7bea#71871a309e9e47945cb0fdf832e5e2a4425a7bea"
+version = "0.12.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1939,7 +1939,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2171,7 +2171,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2208,9 +2208,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2477,7 +2477,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2829,7 +2829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2924,7 +2924,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3661,7 +3661,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -61,8 +61,8 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 71871a30
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "71871a309e9e47945cb0fdf832e5e2a4425a7bea" }
+# HEAD: f48dac74
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -70,11 +70,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "71871a309e9e47
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "71871a309e9e47945cb0fdf832e5e2a4425a7bea", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "71871a309e9e47945cb0fdf832e5e2a4425a7bea" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "71871a309e9e47945cb0fdf832e5e2a4425a7bea" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "71871a309e9e47945cb0fdf832e5e2a4425a7bea" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "71871a309e9e47945cb0fdf832e5e2a4425a7bea" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
 
 [build-dependencies]
 cbindgen = "0.28"


### PR DESCRIPTION
## What

Bumps the meow-rs git pin `71871a30` → `f48dac74` (6 commits). Headline: [meow-rs#168](https://github.com/madeye/meow-rs/pull/168) — the SS UDP relay now tries every resolved address with a family-matched bind instead of committing to the first, closing [meow-rs#167](https://github.com/madeye/meow-rs/issues/167) (the upstream half of the IPv6→IPv4 transition work, companion to #217).

Also pulled in:
- fix: bound gRPC frame buffer, abort fakeip flush task, skip redundant geosite lowercase (meow-rs#164)
- feat: periodic health checks for fallback/url-test proxy groups
- chore: 0.12.0 version bump, coverage-instrumentation test fix, docs

Diff is `Cargo.toml` (rev pins + HEAD comment) + `Cargo.lock` only.

## Path B attestation (local CI green)

- [x] `swiftformat --lint .` at repo root → 0 violations (0/90 files require formatting)
- [x] `swiftlint --strict` at repo root → 0 violations
- [x] Rust: `cargo fmt --all -- --check` ✚ `cargo clippy --all-targets -- -D warnings` ✚ `cargo test --lib` → **41 passed, 0 failed** in `core/rust/meow-ios-ffi/` ✚ `scripts/build-rust.sh` → xcframework built green against the new pin
  - Note: `cargo test --lib` is 41 today, not the "44" quoted in #216's attestation — 41 matches the `#[test]` count in src exactly; the 44 was a miscount there, no tests were lost in this bump.
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -testLanguage en` against the rebuilt xcframework → **126 tests in 24 suites passed**
- [x] `git diff origin/main...HEAD --stat` verified — 2 files (`Cargo.toml`, `Cargo.lock`), no accidental additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)