### PR TITLE
chore(release): bump build number to 2026060701

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026053101</string>
+	<string>2026060701</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>2026053101</string>
+	<string>2026060701</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026053101"
+        CFBundleVersion: "2026060701"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026053101"
+        CFBundleVersion: "2026060701"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
Build-only bump (marketing version stays 1.3.1) for the next TestFlight build. Ships #214, #216, #217, #218.

## Path B attestation (local CI green)

- [x] `swiftformat --lint .` at repo root → 0 violations (0/90 files require formatting)
- [x] `swiftlint --strict` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -testLanguage en` → **126 tests in 24 suites passed**
- [x] No Rust changes — FFI suite not applicable (full Rust verification ran on #218, same engine pin)
- [x] `git diff origin/main...HEAD --stat` verified — 3 files (App/Info.plist, PacketTunnel/Info.plist, project.yml), version strings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)