### PR TITLE
fix(tun2socks): lwip timer-task livelock, stop/start race, runtime watchdog

### DIFF
--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -198,6 +198,25 @@ int meow_tun_ingest(const uint8_t *data, uintptr_t len);
 void meow_tun_stop(void);
 
 /**
+ * Liveness probe for the shared tokio runtime. Spawns a trivial task and
+ * waits up to `timeout_ms` for it to execute. Returns 0 if the runtime
+ * scheduled it in time, -1 otherwise.
+ *
+ * A -1 means the worker threads are wedged (deadlock or livelock): the
+ * packet path, DNS, and the control API are all dead even though the
+ * process looks healthy from outside. The 2026-06-07 on-device incident —
+ * leaked lwip timer tasks spinning on a yield-less lock across both
+ * workers — presented exactly this way for 8+ minutes until a manual
+ * toggle. The Swift watchdog polls this and force-exits the extension on
+ * repeated failure, converting any future silent blackout into a visible
+ * reconnect.
+ *
+ * Call from a non-runtime thread only (Swift watchdog queue): the caller
+ * blocks on a channel the spawned task signals.
+ */
+int meow_tun_runtime_ping(uint64_t timeout_ms);
+
+/**
  * Abort every in-flight TCP flow tracked by tun2socks. Used by the iOS
  * PacketTunnel side when the underlying network interface changes
  * (Wi-Fi → cellular, etc.) and we want to drop stale flows so they

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -31,6 +31,13 @@ static os_log_t gLog;
     nw_interface_type_t _lastInterfaceType;
     BOOL                _lastHasIPv4;
     BOOL                _lastHasIPv6;
+    // Serializes every suspendTun/resumeTun. sleep/wake arrive on a system
+    // thread and triggerReconnect on _pathQueue; unserialized they can
+    // interleave the non-atomic _tunStarted checks in MWTunnelEngine and
+    // double-start (or double-stop) tun2socks.
+    dispatch_queue_t    _tunControlQueue;
+    dispatch_source_t   _watchdogTimer;
+    int                 _watchdogFailures;
 }
 
 + (void)initialize {
@@ -70,6 +77,8 @@ static os_log_t gLog;
                 return;
             }
             self->_engine = engine;
+            self->_tunControlQueue = dispatch_queue_create(
+                "io.github.madeye.meow.PacketTunnel.tun-control", DISPATCH_QUEUE_SERIAL);
 
             MWIPCListener *listener = [[MWIPCListener alloc]
                 initWithHandler:^(NSDictionary *intent) {
@@ -79,6 +88,7 @@ static os_log_t gLog;
             self->_ipcListener = listener;
 
             [self startPathMonitor];
+            [self startWatchdog];
 
             [self writeState:@"connected" profileID:profileID errorMessage:nil];
             completionHandler(nil);
@@ -89,6 +99,7 @@ static os_log_t gLog;
 - (void)stopTunnelWithReason:(NEProviderStopReason)reason
            completionHandler:(void (^)(void))completionHandler {
     os_log_info(gLog, "stopTunnel reason=%ld", (long)reason);
+    [self stopWatchdog];
     [self stopPathMonitor];
     [_engine stop];
     _engine = nil;
@@ -100,14 +111,23 @@ static os_log_t gLog;
 
 - (void)sleepWithCompletionHandler:(void (^)(void))completionHandler {
     os_log_info(gLog, "sleep: suspending tun to shed memory before device sleep");
-    [_engine suspendTun];
-    malloc_zone_pressure_relief(NULL, 0);
-    completionHandler();
+    if (!_tunControlQueue) {
+        completionHandler();
+        return;
+    }
+    dispatch_async(_tunControlQueue, ^{
+        [self->_engine suspendTun];
+        malloc_zone_pressure_relief(NULL, 0);
+        completionHandler();
+    });
 }
 
 - (void)wake {
     os_log_info(gLog, "wake: resuming tun");
-    [_engine resumeTun];
+    if (!_tunControlQueue) return;
+    dispatch_async(_tunControlQueue, ^{
+        [self->_engine resumeTun];
+    });
 }
 
 // MARK: - App messages
@@ -279,6 +299,80 @@ static os_log_t gLog;
     [MWDarwinBridge post:MWNotificationState];
 }
 
+// MARK: - Runtime watchdog
+//
+// Liveness probe for the Rust engine's tokio runtime. The 2026-06-07
+// incident wedged BOTH worker threads (leaked lwip timer tasks spinning on
+// a yield-less lock): packet path, DNS, and the control API all went dark
+// for 8+ minutes while the process looked healthy — iOS kept the tunnel
+// "connected" and nothing recovered until a manual toggle. The underlying
+// bugs are fixed, but a runtime wedge is by definition unrecoverable from
+// inside the runtime, so the watchdog is the backstop: if a trivial task
+// can't get scheduled twice in a row (~30 s of deadness), exit the
+// extension. iOS tears the tunnel down visibly; with on-demand rules it
+// reconnects automatically. A 30-second visible blip beats an invisible
+// all-day blackout.
+
+static const uint64_t kWatchdogIntervalS     = 15;
+static const uint64_t kWatchdogPingTimeoutMs = 2000;
+static const int      kWatchdogFailureLimit  = 2;
+
+- (void)startWatchdog {
+    dispatch_queue_t q = dispatch_queue_create(
+        "io.github.madeye.meow.PacketTunnel.watchdog", DISPATCH_QUEUE_SERIAL);
+    dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, q);
+    dispatch_source_set_timer(timer,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kWatchdogIntervalS * NSEC_PER_SEC)),
+        kWatchdogIntervalS * NSEC_PER_SEC,
+        NSEC_PER_SEC);
+    __weak __typeof__(self) weak = self;
+    dispatch_source_set_event_handler(timer, ^{
+        __strong __typeof__(weak) self = weak;
+        if (!self) return;
+        [self watchdogTick];
+    });
+    _watchdogFailures = 0;
+    _watchdogTimer = timer;
+    dispatch_resume(timer);
+}
+
+- (void)stopWatchdog {
+    if (_watchdogTimer) {
+        dispatch_source_cancel(_watchdogTimer);
+        _watchdogTimer = nil;
+    }
+}
+
+// Caller queue: the watchdog's private serial queue. Blocking up to
+// kWatchdogPingTimeoutMs here is fine — nothing else runs on it.
+- (void)watchdogTick {
+    if (!_engine) return;
+    if (meow_tun_runtime_ping(kWatchdogPingTimeoutMs) == 0) {
+        if (_watchdogFailures > 0) {
+            os_log_info(gLog, "watchdog: runtime recovered after %d failed ping(s)",
+                        _watchdogFailures);
+        }
+        _watchdogFailures = 0;
+        return;
+    }
+    _watchdogFailures += 1;
+    os_log_error(gLog, "watchdog: runtime ping timed out (%d/%d)",
+                 _watchdogFailures, kWatchdogFailureLimit);
+    if (_watchdogFailures < kWatchdogFailureLimit) return;
+
+    os_log_fault(gLog,
+                 "watchdog: tokio runtime wedged for %llu s — exiting for clean relaunch",
+                 (unsigned long long)(kWatchdogFailureLimit * kWatchdogIntervalS));
+    [self writeState:@"error"
+           profileID:nil
+        errorMessage:@"engine runtime wedged; tunnel was restarted"];
+    // Deliberate crash-recovery: a wedged runtime cannot service any FFI
+    // teardown call (engine stop would hang on it), so a clean in-process
+    // restart is impossible. exit() lets iOS tear down the tunnel and
+    // relaunch on demand.
+    exit(EXIT_FAILURE);
+}
+
 // MARK: - Network path monitoring
 
 - (void)startPathMonitor {
@@ -401,7 +495,7 @@ static os_log_t gLog;
 }
 
 - (void)triggerReconnect {
-    if (!_engine) return;
+    if (!_engine || !_tunControlQueue) return;
 
     // Full tun2socks restart on network change: the gVisor netstack and
     // per-flow state (TCP connections, UDP NAT table, dispatch futures)
@@ -412,9 +506,15 @@ static os_log_t gLog;
     // 2026-05-27 crash #1). A clean stop+start gives the netstack a
     // fresh path with zero carryover. The engine (mihomo) stays alive
     // so proxy groups, routing rules, and the REST API persist.
+    //
+    // Serialized on _tunControlQueue with sleep/wake's suspend/resume —
+    // a wake-time resume racing a path-change restart on _pathQueue can
+    // otherwise interleave MWTunnelEngine's non-atomic _tunStarted checks.
     os_log_info(gLog, "path: restarting tun2socks on network change");
-    [_engine suspendTun];
-    [_engine resumeTun];
+    dispatch_async(_tunControlQueue, ^{
+        [self->_engine suspendTun];
+        [self->_engine resumeTun];
+    });
 }
 
 @end

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1571,7 +1571,7 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 [[package]]
 name = "lwip"
 version = "0.3.15"
-source = "git+https://github.com/madeye/lwip?rev=5adf5e24b14760d2ded93290c114809e2fd68e3b#5adf5e24b14760d2ded93290c114809e2fd68e3b"
+source = "git+https://github.com/madeye/lwip?rev=dab00c540cf0606fee14ddd99cfa6ec79d33681d#dab00c540cf0606fee14ddd99cfa6ec79d33681d"
 dependencies = [
  "bindgen 0.69.5",
  "bytes",
@@ -1939,7 +1939,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2171,7 +2171,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2208,7 +2208,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2477,7 +2477,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2829,7 +2829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2924,7 +2924,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3661,7 +3661,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -128,4 +128,4 @@ panic = "abort"
 # Upstream all of this to https://github.com/ssrlive/lwip and drop the
 # patch once a fixed release ships.
 [patch.crates-io]
-lwip = { git = "https://github.com/madeye/lwip", rev = "5adf5e24b14760d2ded93290c114809e2fd68e3b" }
+lwip = { git = "https://github.com/madeye/lwip", rev = "dab00c540cf0606fee14ddd99cfa6ec79d33681d" }

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -695,6 +695,33 @@ pub extern "C" fn meow_tun_stop() {
     tun2socks::stop();
 }
 
+/// Liveness probe for the shared tokio runtime. Spawns a trivial task and
+/// waits up to `timeout_ms` for it to execute. Returns 0 if the runtime
+/// scheduled it in time, -1 otherwise.
+///
+/// A -1 means the worker threads are wedged (deadlock or livelock): the
+/// packet path, DNS, and the control API are all dead even though the
+/// process looks healthy from outside. The 2026-06-07 on-device incident —
+/// leaked lwip timer tasks spinning on a yield-less lock across both
+/// workers — presented exactly this way for 8+ minutes until a manual
+/// toggle. The Swift watchdog polls this and force-exits the extension on
+/// repeated failure, converting any future silent blackout into a visible
+/// reconnect.
+///
+/// Call from a non-runtime thread only (Swift watchdog queue): the caller
+/// blocks on a channel the spawned task signals.
+#[no_mangle]
+pub extern "C" fn meow_tun_runtime_ping(timeout_ms: u64) -> c_int {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+    crate::get_runtime().spawn(async move {
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(std::time::Duration::from_millis(timeout_ms)) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
 /// Abort every in-flight TCP flow tracked by tun2socks. Used by the iOS
 /// PacketTunnel side when the underlying network interface changes
 /// (Wi-Fi → cellular, etc.) and we want to drop stale flows so they

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -81,8 +81,27 @@ impl EgressEmitter {
 }
 
 static TUN2SOCKS_RUNNING: AtomicBool = AtomicBool::new(false);
+// Monotonic instance id. `start()` bumps it; the spawned run task captures
+// its own value and only performs end-of-life cleanup (clearing
+// `ingress_slot`, lowering `TUN2SOCKS_RUNNING`) if it is STILL the current
+// generation. Without the guard, a rapid stop()→start() (sleep/wake +
+// path-change churn both restart tun2socks back-to-back) let the OLD task's
+// deferred cleanup steal the NEW instance's ingress sender and flag:
+// `stop()` is fire-and-forget, so the old task was still parked in `recv()`
+// when the new one started, and its teardown ran arbitrarily later.
+static TUN2SOCKS_GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 pub(crate) static ACTIVE_TCP_CONNS: std::sync::atomic::AtomicI64 =
     std::sync::atomic::AtomicI64::new(0);
+
+/// JoinHandle of the current (or most recent) run task. The next `start()`
+/// takes it and awaits its teardown (bounded) before building a new lwip
+/// netstack — the lwip globals (`OUTPUT_CB_PTR`, netif hooks, pcb lists)
+/// assume a single live stack, so two overlapping `run_tun2socks` instances
+/// are never allowed.
+fn run_handle_slot() -> &'static Mutex<Option<tokio::task::JoinHandle<()>>> {
+    static SLOT: OnceLock<Mutex<Option<tokio::task::JoinHandle<()>>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(None))
+}
 
 // TCP accept-side burst cap. Without this, every smoltcp-accepted flow
 // spawns a `dispatch_tcp` task immediately — and under a real burst (e.g.
@@ -475,20 +494,46 @@ pub fn start(ctx: *mut c_void, cb: WritePacketFn) -> Result<(), String> {
         cb,
     };
 
-    info!("tun2socks starting (direct-callback ingest)");
+    let my_gen = TUN2SOCKS_GEN.fetch_add(1, Ordering::SeqCst) + 1;
+    info!("tun2socks starting (direct-callback ingest, gen {my_gen})");
 
     let (ingress_tx, ingress_rx) = mpsc::channel::<Vec<u8>>(256);
     *ingress_slot().lock() = Some(ingress_tx);
 
+    // Take the previous instance's handle so the new task can wait for its
+    // teardown before touching the lwip globals.
+    let prev = run_handle_slot().lock().take();
+
     let rt = crate::get_runtime();
-    rt.spawn(async move {
+    let handle = rt.spawn(async move {
+        if let Some(prev) = prev {
+            // `stop()` is fire-and-forget: the previous run task may still
+            // be draining its channel or running its teardown. lwip's
+            // global state (OUTPUT_CB_PTR, netif hooks, pcb lists) assumes
+            // exactly one live NetStack, so wait — bounded — for the old
+            // instance to finish before building a new one. Packets that
+            // arrive meanwhile buffer (then drop) in the ingress channel,
+            // which beats corrupting the stack.
+            match tokio::time::timeout(std::time::Duration::from_secs(3), prev).await {
+                Ok(_) => {}
+                Err(_) => logging::bridge_log(
+                    "tun2socks: previous instance still tearing down after 3s; proceeding",
+                ),
+            }
+        }
         if let Err(e) = run_tun2socks(ingress_rx, emitter).await {
             logging::bridge_log(&format!("tun2socks error: {}", e));
         }
-        ingress_slot().lock().take();
-        TUN2SOCKS_RUNNING.store(false, Ordering::SeqCst);
-        info!("tun2socks exited");
+        // Generation-guarded cleanup: if a newer instance already started,
+        // these globals belong to IT — clearing them here would sever the
+        // live instance's ingest path and mark it not-running.
+        if TUN2SOCKS_GEN.load(Ordering::SeqCst) == my_gen {
+            ingress_slot().lock().take();
+            TUN2SOCKS_RUNNING.store(false, Ordering::SeqCst);
+        }
+        info!("tun2socks exited (gen {my_gen})");
     });
+    *run_handle_slot().lock() = Some(handle);
 
     Ok(())
 }
@@ -496,6 +541,8 @@ pub fn start(ctx: *mut c_void, cb: WritePacketFn) -> Result<(), String> {
 pub fn stop() {
     TUN2SOCKS_RUNNING.store(false, Ordering::SeqCst);
     // Dropping the sender terminates the ingress task on its next `recv()`.
+    // The run task's JoinHandle stays in `run_handle_slot` so the next
+    // `start()` can await the teardown it triggers here.
     ingress_slot().lock().take();
 }
 
@@ -2182,5 +2229,52 @@ mod tests {
             "0 must be accepted to opt out"
         );
         set_udp_first_reply_deadline_ms(prev);
+    }
+
+    /// Regression test for the 2026-06-07 stop()→start() clobber race: the
+    /// old run task's deferred cleanup used to clear `ingress_slot` and
+    /// lower `TUN2SOCKS_RUNNING` unconditionally — stealing them from the
+    /// instance started right after. With the generation guard, a rapid
+    /// stop/start cycle must leave the NEW instance fully wired.
+    ///
+    /// Builds two real lwip netstacks back-to-back (sequentially, as
+    /// production does on every sleep/wake) — also exercising the fork's
+    /// timeout-task abort + OUTPUT_CB_PTR self-check on teardown.
+    #[test]
+    fn rapid_stop_start_keeps_new_instance_wired() {
+        unsafe extern "C" fn noop_write(
+            _ctx: *mut std::os::raw::c_void,
+            _data: *const u8,
+            _len: usize,
+        ) {
+        }
+
+        start(std::ptr::null_mut(), noop_write).expect("first start");
+        stop();
+        start(std::ptr::null_mut(), noop_write).expect("second start");
+
+        // The first instance's deferred teardown runs within ~3s (the
+        // second instance awaits it before building its stack). The
+        // invariants must hold THROUGHOUT that window — the old bug only
+        // manifested when the stale cleanup finally ran.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(4);
+        while std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            assert!(
+                TUN2SOCKS_RUNNING.load(Ordering::SeqCst),
+                "old instance's teardown lowered TUN2SOCKS_RUNNING for the live instance"
+            );
+            assert!(
+                ingress_slot().lock().is_some(),
+                "old instance's teardown stole the live instance's ingress sender"
+            );
+        }
+        assert_eq!(
+            ingest(&[0u8; 20]),
+            0,
+            "live instance must still accept packets after the old teardown"
+        );
+
+        stop();
     }
 }


### PR DESCRIPTION
## Incident

2026-06-07 14:05 on-device (build 2026060701): tunnel "connected", zero traffic, control API accepting TCP but serving 0 bytes, for 8+ minutes until a manual toggle. Diagnosed from the device logarchive.

## Root cause

`NetStackImpl::new` (lwip fork) spawns a `loop { LWIP_MUTEX.lock(); sys_check_timeouts(); sleep(250ms) }` task **with no termination** — it outlives its stack. Every sleep/wake & network-change tun2socks restart leaks one; the incident process had built **97 netstacks** (= 97 immortal tasks). `LWIP_MUTEX.lock()` was a yield-less `loop { try_lock }` spin. On the FFI's `worker_threads(2)` runtime the 250 ms herd saturated both workers — one inside `sys_check_timeouts`, one spinning — permanently live-locking the runtime: drivers, DNS, axum/REST were never polled again. (Why now: #216's FIN_WAIT_2 reap gives `sys_check_timeouts` real work per closed flow, the idle sweeper adds close churn, #217 adds restarts. The leak itself predates all of that.)

## Fixes (three layers)

1. **lwip pin → [madeye/lwip@dab00c54](https://github.com/madeye/lwip/commit/dab00c540cf0606fee14ddd99cfa6ec79d33681d)**: timeout task aborted in `Drop` (the leak); `lock()` spins 64× then `yield_now()` (the amplifier); `Drop` only zeroes `OUTPUT_CB_PTR` if it still points at self.
2. **FFI** (`tun2socks.rs`, `lib.rs`): generation-guarded teardown so a rapid `stop()→start()` can't have the old task's deferred cleanup steal the new instance's `ingress_slot`/running flag; new run task awaits previous teardown (bounded 3 s) before building a stack — lwip globals assume exactly one live stack. New `meow_tun_runtime_ping(timeout_ms)` liveness FFI. Regression test `rapid_stop_start_keeps_new_instance_wired` builds two real stacks back-to-back.
3. **PacketTunnelProvider**: `suspendTun`/`resumeTun` serialized on one control queue (sleep/wake raced `triggerReconnect` through non-atomic `_tunStarted`); 15 s watchdog → two failed 2 s pings → fault log + error state + `exit()` so iOS visibly tears down/reconnects instead of an invisible blackout.

## Path B attestation (local CI green)

- [x] `swiftformat --lint .` → 0 violations (0/90 files)
- [x] `swiftlint --strict` → 0 violations
- [x] Rust in `core/rust/meow-ios-ffi/`: `cargo fmt --all -- --check` ✚ `cargo clippy --all-targets -- -D warnings` ✚ `cargo test --lib` → **42 passed** (41 + new regression test) ✚ `scripts/build-rust.sh` → xcframework green, header regenerated with `meow_tun_runtime_ping`
- [x] `xcodebuild test … -only-testing:MeowTests -only-testing:MeowIntegrationTests -testLanguage en` → **MeowTests 126/24 suites passed; IntegrationTests 26 Swift Testing + 18 XCTest passed**
- [x] `git diff origin/main...HEAD --stat` verified — 6 files, all intended: provider, FFI lib/tun2socks, Cargo.{toml,lock} (lwip pin), regenerated meow_core.h

## Follow-up

- On-device soak with sleep/wake churn (the incident's trigger pattern)
- Watchdog never fires in healthy operation — verify via syslog absence of `watchdog:` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)