### PR TITLE
chore(release): bump build number to 2026060702

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026060701</string>
+	<string>2026060702</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>2026060701</string>
+	<string>2026060702</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026060701"
+        CFBundleVersion: "2026060702"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026060701"
+        CFBundleVersion: "2026060702"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
Hotfix build for the engine livelock (#221). Build-only bump, marketing version stays 1.3.1.

## Path B attestation (local CI green)

- [x] `swiftformat --lint .` → 0 violations; `swiftlint --strict` → 0 violations (run on the #221 tree this sits on)
- [x] `xcodebuild test … -only-testing:MeowTests -testLanguage en` → **126 tests in 24 suites passed**
- [x] No Rust changes (full Rust verification ran on #221, same pins)
- [x] `git diff origin/main...HEAD --stat` verified — 3 files, version strings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)