### PR TITLE
fix(tun): remove runtime watchdog that caused idle 断流

### DIFF
--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -36,8 +36,6 @@ static os_log_t gLog;
     // interleave the non-atomic _tunStarted checks in MWTunnelEngine and
     // double-start (or double-stop) tun2socks.
     dispatch_queue_t    _tunControlQueue;
-    dispatch_source_t   _watchdogTimer;
-    int                 _watchdogFailures;
 }
 
 + (void)initialize {
@@ -88,7 +86,6 @@ static os_log_t gLog;
             self->_ipcListener = listener;
 
             [self startPathMonitor];
-            [self startWatchdog];
 
             [self writeState:@"connected" profileID:profileID errorMessage:nil];
             completionHandler(nil);
@@ -99,7 +96,6 @@ static os_log_t gLog;
 - (void)stopTunnelWithReason:(NEProviderStopReason)reason
            completionHandler:(void (^)(void))completionHandler {
     os_log_info(gLog, "stopTunnel reason=%ld", (long)reason);
-    [self stopWatchdog];
     [self stopPathMonitor];
     [_engine stop];
     _engine = nil;
@@ -297,80 +293,6 @@ static os_log_t gLog;
         return;
     }
     [MWDarwinBridge post:MWNotificationState];
-}
-
-// MARK: - Runtime watchdog
-//
-// Liveness probe for the Rust engine's tokio runtime. The 2026-06-07
-// incident wedged BOTH worker threads (leaked lwip timer tasks spinning on
-// a yield-less lock): packet path, DNS, and the control API all went dark
-// for 8+ minutes while the process looked healthy — iOS kept the tunnel
-// "connected" and nothing recovered until a manual toggle. The underlying
-// bugs are fixed, but a runtime wedge is by definition unrecoverable from
-// inside the runtime, so the watchdog is the backstop: if a trivial task
-// can't get scheduled twice in a row (~30 s of deadness), exit the
-// extension. iOS tears the tunnel down visibly; with on-demand rules it
-// reconnects automatically. A 30-second visible blip beats an invisible
-// all-day blackout.
-
-static const uint64_t kWatchdogIntervalS     = 15;
-static const uint64_t kWatchdogPingTimeoutMs = 2000;
-static const int      kWatchdogFailureLimit  = 2;
-
-- (void)startWatchdog {
-    dispatch_queue_t q = dispatch_queue_create(
-        "io.github.madeye.meow.PacketTunnel.watchdog", DISPATCH_QUEUE_SERIAL);
-    dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, q);
-    dispatch_source_set_timer(timer,
-        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kWatchdogIntervalS * NSEC_PER_SEC)),
-        kWatchdogIntervalS * NSEC_PER_SEC,
-        NSEC_PER_SEC);
-    __weak __typeof__(self) weak = self;
-    dispatch_source_set_event_handler(timer, ^{
-        __strong __typeof__(weak) self = weak;
-        if (!self) return;
-        [self watchdogTick];
-    });
-    _watchdogFailures = 0;
-    _watchdogTimer = timer;
-    dispatch_resume(timer);
-}
-
-- (void)stopWatchdog {
-    if (_watchdogTimer) {
-        dispatch_source_cancel(_watchdogTimer);
-        _watchdogTimer = nil;
-    }
-}
-
-// Caller queue: the watchdog's private serial queue. Blocking up to
-// kWatchdogPingTimeoutMs here is fine — nothing else runs on it.
-- (void)watchdogTick {
-    if (!_engine) return;
-    if (meow_tun_runtime_ping(kWatchdogPingTimeoutMs) == 0) {
-        if (_watchdogFailures > 0) {
-            os_log_info(gLog, "watchdog: runtime recovered after %d failed ping(s)",
-                        _watchdogFailures);
-        }
-        _watchdogFailures = 0;
-        return;
-    }
-    _watchdogFailures += 1;
-    os_log_error(gLog, "watchdog: runtime ping timed out (%d/%d)",
-                 _watchdogFailures, kWatchdogFailureLimit);
-    if (_watchdogFailures < kWatchdogFailureLimit) return;
-
-    os_log_fault(gLog,
-                 "watchdog: tokio runtime wedged for %llu s — exiting for clean relaunch",
-                 (unsigned long long)(kWatchdogFailureLimit * kWatchdogIntervalS));
-    [self writeState:@"error"
-           profileID:nil
-        errorMessage:@"engine runtime wedged; tunnel was restarted"];
-    // Deliberate crash-recovery: a wedged runtime cannot service any FFI
-    // teardown call (engine stop would hang on it), so a clean in-process
-    // restart is impossible. exit() lets iOS tear down the tunnel and
-    // relaunch on demand.
-    exit(EXIT_FAILURE);
 }
 
 // MARK: - Network path monitoring


### PR DESCRIPTION
## Summary

The PacketTunnel runtime watchdog pinged the tokio runtime every 15s and called `exit(EXIT_FAILURE)` after 2 consecutive timeouts (~30s of perceived wedge), which iOS surfaces as a tunnel teardown. While the device is idle the NE is throttled (not actually wedged), so the probe false-positives and drops live connections — the idle **断流** the user reported.

The 2026-06-07 runtime-wedge incident this backstop guarded against has since been root-caused and fixed (PR #221 + the lwip pin + the lwip timer-task fix in b6c154f), so the watchdog is removed rather than retuned.

## Changes

`PacketTunnel/Sources/PacketTunnelProvider.m` (−78 lines, deletion only):
- Removed `_watchdogTimer` / `_watchdogFailures` ivars
- Removed `[self startWatchdog]` in `startTunnel` and `[self stopWatchdog]` in `stopTunnel`
- Removed the `kWatchdog*` constants and the `startWatchdog` / `stopWatchdog` / `watchdogTick` methods

The `meow_tun_runtime_ping` FFI export is left in place (now unused by the extension), so a watchdog can be reintroduced later without FFI churn.

## Trade-off

Removes the auto-recovery backstop against an invisible runtime wedge. The root-cause bugs are fixed, so the wedge itself should not recur; if a future regression wedges the runtime, recovery would require a manual VPN toggle.

## Verification
- `swiftformat --lint .` → 0/90 require formatting
- `swiftlint --strict` → 0 violations, 81 files
- Ad Hoc archive/export build succeeded (NE compiles); installed on-device (iPhone 17 Pro) via `devicectl`
- Pure Objective-C NE deletion — no Swift/Rust test bundle exercises this path; relying on remote CI for the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)