### PR TITLE
fix(tun2socks): harden DNS upstream + stop blocking the ingress loop

### DIFF
--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -306,6 +306,12 @@ const DNS_TASK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 // with no on-device signal. Throttled via warn_capped to once per second.
 static EGRESS_DROP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
 
+// Throttle slot for the silent stack-ingress-drop log. The main ingress loop
+// drops inbound frames non-blockingly when the stack-driver queue is saturated
+// (see the drop site in `run_tun2socks`); without a log the user sees a
+// throughput cliff with no on-device signal. Throttled via warn_capped.
+static STACK_INGRESS_DROP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
+
 static UDP_CAP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
 
 static TCP_FLOW_ID_SEQ: AtomicU64 = AtomicU64::new(1);
@@ -889,7 +895,17 @@ async fn run_tun2socks(
                     let Some(reply_pkt) = build_udp_reply(&request, &response_payload) else {
                         return;
                     };
-                    let _ = egress.send(reply_pkt).await;
+                    // Match the rest of this file's "log, don't swallow" policy:
+                    // a send error here means egress_rx was dropped (tunnel
+                    // teardown), so the reply is lost. Surface it at trace so a
+                    // shutdown-time DNS stall has an on-device signal instead of
+                    // a silent discard.
+                    if let Err(e) = egress.send(reply_pkt).await {
+                        trace!(
+                            "tun2socks: DNS reply egress send failed (egress closed?): {}",
+                            e
+                        );
+                    }
                 };
                 if tokio::time::timeout(DNS_TASK_TIMEOUT, work).await.is_err() {
                     trace!(
@@ -903,8 +919,19 @@ async fn run_tun2socks(
 
         match stack_ingress_tx.try_send(ip_data) {
             Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(frame)) => {
-                let _ = stack_ingress_tx.send(frame).await;
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                // Never block the ingress loop on stack backpressure. Awaiting a
+                // full stack queue stalls DNS interception and packet intake for
+                // the entire tunnel, and can wedge against the single stack
+                // driver when it is itself parked in `stack.send().await`
+                // draining into lwip while egress can't drain (the 2026-06-06
+                // blackout shape). Drop instead — TCP retransmits, and every
+                // other saturation point in this file already drops rather than
+                // blocks (ingest, egress, UDP cap, DNS cap).
+                warn_capped(
+                    &STACK_INGRESS_DROP_LOG_LAST_MS,
+                    "tun2socks: stack ingress queue full, dropping inbound frame (stack driver backpressure)",
+                );
             }
             Err(mpsc::error::TrySendError::Closed(_)) => break,
         }
@@ -1577,10 +1604,18 @@ pub(crate) async fn forward_dns_to_upstream(
         let q = query_shared.clone();
         futs.push(Box::pin(async move {
             let socket = tokio::net::UdpSocket::bind(("0.0.0.0", 0u16)).await.ok()?;
-            socket.send_to(&q, addr).await.ok()?;
+            // `connect` pins the socket to this upstream so the kernel delivers
+            // only datagrams whose source is `addr`. Without it, `recv_from`
+            // accepts a reply from ANY source: an off-path attacker who forges
+            // the upstream's src IP/port and guesses the 16-bit transaction ID
+            // could race a spoofed answer in ahead of the real resolver, and
+            // ID-matching alone would accept it. connect() closes that hole and
+            // also lets the OS surface ICMP port-unreachable as a recv error.
+            socket.connect(addr).await.ok()?;
+            socket.send(&q).await.ok()?;
             let mut buf = [0u8; 1500];
-            let recv = tokio::time::timeout(timeout, socket.recv_from(&mut buf)).await;
-            let (n, _) = recv.ok()?.ok()?;
+            let recv = tokio::time::timeout(timeout, socket.recv(&mut buf)).await;
+            let n = recv.ok()?.ok()?;
             if n >= 2 && u16::from_be_bytes([buf[0], buf[1]]) == query_id {
                 Some(buf[..n].to_vec())
             } else {


### PR DESCRIPTION
## Summary

Three independent correctness/robustness fixes in the `tun2socks` data path (`core/rust/meow-ios-ffi/src/tun2socks.rs`), surfaced by an adversarial multi-lens audit of the netstack code. All are isolated, internal Rust changes — no FFI/header surface change.

### 1. DNS passthrough spoofing hardening (security)
`forward_dns_to_upstream` bound `0.0.0.0:0` and used `send_to`/`recv_from`, accepting a reply from **any** source and validating only the 16-bit DNS transaction ID. An off-path attacker who forges the upstream's source IP/port and guesses the ID could race a spoofed answer ahead of the real resolver, and ID-matching alone would accept it. Switched to `connect()` + `send`/`recv` so the kernel delivers only datagrams from the queried upstream (and surfaces ICMP port-unreachable as a recv error).

### 2. Ingress loop no longer blocks on stack backpressure (anti-wedge)
On a full stack-driver queue, the main ingress loop awaited `stack_ingress_tx.send()`, stalling DNS interception and packet intake for the whole tunnel — and could wedge against the single stack driver while it is itself parked in `stack.send().await` draining into lwip (the 2026-06-06 blackout shape). Now drops non-blockingly with a throttled `warn`, matching every other saturation point in this file (ingest, egress, UDP cap, DNS cap). TCP retransmits the dropped frame.

### 3. DNS reply egress send error is logged, not swallowed
`let _ = egress.send(...)` → log at `trace` so a shutdown-time DNS stall has an on-device signal, matching the file's existing "log, don't swallow" policy.

## Audit findings addressed
Confirmed-real findings #3 (DNS source validation), #9 (ingress blocking), #2 (silent DNS send error) from the netstack audit.

## Path B — local-CI-green attestation
- [x] `swiftformat --lint .` at repo root → **0 violations** (no Swift touched)
- [x] `swiftlint --strict` at repo root → **0 violations** (no Swift touched)
- [x] `cargo fmt -- --check` → clean
- [x] `cargo clippy --all-targets -- -D warnings` → **0 issues**
- [x] `cargo test --lib` → **45 passed**
- [x] `scripts/build-rust.sh` → device (aarch64-apple-ios) + simulator cross-build OK
- [x] `git diff origin/main...HEAD --stat` → single file: `core/rust/meow-ios-ffi/src/tun2socks.rs` (+41/-6)

No Swift/ObjC, `project.yml`, or workflow files touched — Rust-only internal change. `xcodebuild test` not required (no Swift diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)