### PR TITLE
fix(tun2socks): blocking stop closes egress-callback UAF + ingress epoch guard

### DIFF
--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -193,9 +193,22 @@ int meow_tun_start(void *ctx, MeowWritePacket write_cb);
 int meow_tun_ingest(const uint8_t *data, uintptr_t len);
 
 /**
- * Stop the tun2socks task. Idempotent.
+ * Stop the tun2socks task. Idempotent. Fire-and-forget: the run task drains
+ * on the runtime after this returns. Use for suspend/resume, where the egress
+ * `ctx` is retained for reuse.
  */
 void meow_tun_stop(void);
+
+/**
+ * Stop the tun2socks task and BLOCK until its run task (including the egress
+ * callback loop) has fully torn down. Once this returns, the egress write
+ * callback is guaranteed never to fire again, so the caller may safely
+ * release the `ctx` it passed to `meow_tun_start` — required for a terminal
+ * stop, where releasing the writer while the egress task is still draining
+ * is a use-after-free. Call from a NON-runtime thread (the Swift tunnel
+ * control queue). Idempotent.
+ */
+void meow_tun_stop_blocking(void);
 
 /**
  * Liveness probe for the shared tokio runtime. Spawns a trivial task and

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -41,6 +41,12 @@ static const NSTimeInterval kTeardownCooldownS = 5.0;
 
     BOOL _started;
     _Atomic BOOL _ingressRunning;
+    // Bumped on every suspend/stop. A readPackets completion handler captures
+    // the epoch when it arms and drops itself if the epoch advanced in the
+    // meantime — so an in-flight handler from a superseded suspend/resume
+    // generation can neither ingest into the new tun2socks instance nor re-arm
+    // a second concurrent read chain.
+    _Atomic uint64_t _ingressEpoch;
     _Atomic int64_t _ingressPackets;
     dispatch_source_t _trafficTimer;
     int64_t _lastUp;
@@ -63,6 +69,7 @@ static const NSTimeInterval kTeardownCooldownS = 5.0;
     if (self) {
         _flow = flow;
         atomic_init(&_ingressRunning, NO);
+        atomic_init(&_ingressEpoch, 0);
         atomic_init(&_ingressPackets, 0);
     }
     return self;
@@ -134,10 +141,17 @@ static const NSTimeInterval kTeardownCooldownS = 5.0;
     _started = NO;
 
     atomic_store_explicit(&_ingressRunning, NO, memory_order_relaxed);
+    atomic_fetch_add_explicit(&_ingressEpoch, 1, memory_order_relaxed);
 
     [self stopTrafficPump];
 
-    meow_tun_stop();
+    // BLOCKING stop: wait for the tun2socks run task — and its egress callback
+    // loop — to fully terminate before releasing the writer ctx below.
+    // meow_tun_stop() is fire-and-forget, so CFBridgingRelease-ing the
+    // CFBridgingRetain'd writer right after it returned could free the object
+    // while the still-draining egress task calls meowPacketWriterCB on it: a
+    // use-after-free. meow_tun_stop_blocking() joins the run task first.
+    meow_tun_stop_blocking();
     _tunStarted = NO;
     meow_engine_stop();
 
@@ -154,8 +168,13 @@ static const NSTimeInterval kTeardownCooldownS = 5.0;
     if (!_tunStarted) return;
 
     atomic_store_explicit(&_ingressRunning, NO, memory_order_relaxed);
+    atomic_fetch_add_explicit(&_ingressEpoch, 1, memory_order_relaxed);
     [self stopTrafficPump];
 
+    // Fire-and-forget here (unlike -stop): the writer ctx is NOT released on
+    // suspend — it is reused by the following -resumeTun, whose meow_tun_start
+    // awaits the previous teardown via run_handle_slot — so there is no ctx to
+    // free underneath the egress task and no UAF window.
     meow_tun_stop();
     _tunStarted = NO;
 
@@ -203,6 +222,7 @@ static const NSTimeInterval kTeardownCooldownS = 5.0;
 
 - (void)readNextPackets {
     if (!atomic_load_explicit(&_ingressRunning, memory_order_relaxed)) return;
+    uint64_t epoch = atomic_load_explicit(&_ingressEpoch, memory_order_relaxed);
     __weak __typeof__(self) weak = self;
     [_flow readPacketsWithCompletionHandler:^(NSArray<NSData *> *packets,
                                               NSArray<NSNumber *> *protocols) {
@@ -210,6 +230,12 @@ static const NSTimeInterval kTeardownCooldownS = 5.0;
             __strong __typeof__(weak) self = weak;
             if (!self) return;
             if (!atomic_load_explicit(&self->_ingressRunning, memory_order_relaxed)) return;
+            // Epoch guard: a suspend/stop after this read was armed bumps
+            // _ingressEpoch. Drop the stale completion so an in-flight handler
+            // from a superseded generation neither ingests into the new
+            // tun2socks instance nor re-arms a second concurrent readPackets
+            // chain (NEPacketTunnelFlow expects one outstanding read at a time).
+            if (atomic_load_explicit(&self->_ingressEpoch, memory_order_relaxed) != epoch) return;
             for (NSData *pkt in packets) {
                 meow_tun_ingest((const uint8_t *)pkt.bytes, (uintptr_t)pkt.length);
                 atomic_fetch_add_explicit(&self->_ingressPackets, 1, memory_order_relaxed);

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -689,11 +689,26 @@ pub unsafe extern "C" fn meow_tun_ingest(data: *const u8, len: usize) -> c_int {
     tun2socks::ingest(slice)
 }
 
-/// Stop the tun2socks task. Idempotent.
+/// Stop the tun2socks task. Idempotent. Fire-and-forget: the run task drains
+/// on the runtime after this returns. Use for suspend/resume, where the egress
+/// `ctx` is retained for reuse.
 #[no_mangle]
 pub extern "C" fn meow_tun_stop() {
     logging::bridge_log("meow_tun_stop");
     tun2socks::stop();
+}
+
+/// Stop the tun2socks task and BLOCK until its run task (including the egress
+/// callback loop) has fully torn down. Once this returns, the egress write
+/// callback is guaranteed never to fire again, so the caller may safely
+/// release the `ctx` it passed to `meow_tun_start` — required for a terminal
+/// stop, where releasing the writer while the egress task is still draining
+/// is a use-after-free. Call from a NON-runtime thread (the Swift tunnel
+/// control queue). Idempotent.
+#[no_mangle]
+pub extern "C" fn meow_tun_stop_blocking() {
+    logging::bridge_log("meow_tun_stop_blocking");
+    tun2socks::stop_blocking();
 }
 
 /// Liveness probe for the shared tokio runtime. Spawns a trivial task and

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -564,6 +564,52 @@ pub fn stop() {
     ingress_slot().lock().take();
 }
 
+/// Blocking shutdown: signal stop, then wait (bounded) for the run task to
+/// fully tear down before returning.
+///
+/// The egress write callback can only be invoked from inside the run task —
+/// its `egress` task is `abort_and_join`ed as part of `run_tun2socks`'s
+/// teardown — so once this returns the FFI caller is guaranteed the callback
+/// will never fire again and may safely release the egress `ctx` it passed to
+/// [`start`].
+///
+/// [`stop`] alone is fire-and-forget: it only drops the ingress sender and
+/// lowers the running flag, leaving the run task to drain on the runtime.
+/// Swift's terminal `stop` `CFBridgingRelease`s the writer immediately after
+/// the FFI returns, so without this join the still-draining egress task can
+/// call the write callback on a freed Objective-C object — a use-after-free.
+/// `suspendTun` deliberately keeps using [`stop`] because it does NOT release
+/// the ctx (it is reused by the following `resumeTun`, whose `start` awaits
+/// the previous teardown via `run_handle_slot`).
+///
+/// MUST be called from a NON-runtime thread (the Swift control queue): it
+/// `block_on`s the shared runtime. Bounded by `JOIN_TIMEOUT` so a
+/// pathological teardown hang can't freeze iOS's `stopTunnel` grace window;
+/// if the bound trips we log and return anyway (a hung teardown is a separate
+/// failure, and freezing shutdown is worse than a vanishingly-rare late
+/// callback). Idempotent.
+pub fn stop_blocking() {
+    stop();
+    let Some(handle) = run_handle_slot().lock().take() else {
+        return;
+    };
+    const JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    crate::get_runtime().block_on(async move {
+        match tokio::time::timeout(JOIN_TIMEOUT, handle).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                logging::bridge_log(&format!("tun2socks: stop_blocking join error: {e}"));
+            }
+            Err(_) => {
+                warn!(
+                    "tun2socks: stop_blocking timed out after {:?}; run task still draining, releasing ctx anyway",
+                    JOIN_TIMEOUT
+                );
+            }
+        }
+    });
+}
+
 /// Push a raw IP packet produced by `NEPacketTunnelFlow.readPackets` into the
 /// netstack. Returns 0 on success, -1 if tun2socks isn't running or the queue
 /// is closed. Swift-side flow-control lives inside the mpsc channel: when full
@@ -2006,6 +2052,15 @@ mod tests {
         GUARD.lock().unwrap_or_else(|e| e.into_inner())
     }
 
+    /// Serializes the lifecycle tests that drive the process-global tun2socks
+    /// start/stop state (`TUN2SOCKS_RUNNING`, `ingress_slot`, `run_handle_slot`).
+    /// Default `cargo test` parallelism would otherwise let one test's `start()`
+    /// observe another's still-running instance and fail with "already running".
+    fn lifecycle_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static GUARD: StdMutex<()> = StdMutex::new(());
+        GUARD.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     fn dummy_addr(port: u16) -> SocketAddr {
         SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
     }
@@ -2399,6 +2454,8 @@ mod tests {
     /// timeout-task abort + OUTPUT_CB_PTR self-check on teardown.
     #[test]
     fn rapid_stop_start_keeps_new_instance_wired() {
+        let _guard = lifecycle_test_guard();
+
         unsafe extern "C" fn noop_write(
             _ctx: *mut std::os::raw::c_void,
             _data: *const u8,
@@ -2432,6 +2489,51 @@ mod tests {
             "live instance must still accept packets after the old teardown"
         );
 
-        stop();
+        stop_blocking();
+    }
+
+    /// `stop_blocking()` must JOIN the run task before returning — unlike the
+    /// fire-and-forget `stop()`. The egress write callback can only fire from
+    /// inside the run task, so a drained `run_handle_slot` on return is the
+    /// invariant that lets Swift's terminal `stop` `CFBridgingRelease` the
+    /// writer ctx without a use-after-free. Builds a real lwip netstack.
+    #[test]
+    fn stop_blocking_joins_run_task_synchronously() {
+        let _guard = lifecycle_test_guard();
+
+        unsafe extern "C" fn noop_write(
+            _ctx: *mut std::os::raw::c_void,
+            _data: *const u8,
+            _len: usize,
+        ) {
+        }
+
+        start(std::ptr::null_mut(), noop_write).expect("start");
+        assert!(
+            run_handle_slot().lock().is_some(),
+            "start must publish the run handle"
+        );
+
+        stop_blocking();
+
+        // Synchronous teardown: the handle is taken and joined before return,
+        // so the slot is empty and the run task (incl. its egress callback
+        // loop) is guaranteed gone — the ctx is now safe to free.
+        assert!(
+            run_handle_slot().lock().is_none(),
+            "stop_blocking must take and join the run handle before returning"
+        );
+        assert!(
+            !TUN2SOCKS_RUNNING.load(Ordering::SeqCst),
+            "stop_blocking must leave the tunnel not-running"
+        );
+        assert_eq!(
+            ingest(&[0u8; 20]),
+            -1,
+            "ingress must be closed after stop_blocking"
+        );
+
+        // Idempotent: a second call with nothing to join is a no-op.
+        stop_blocking();
     }
 }


### PR DESCRIPTION
## Summary

Two teardown-lifecycle correctness fixes in the PacketTunnel engine bridge, surfaced by an adversarial multi-lens audit of the netstack code. One is a **critical use-after-free on stop**; the other a suspend/resume ingress race.

### 1. Egress-callback use-after-free on terminal stop (critical)

`MWTunnelEngine -stop` called `meow_tun_stop()` — which is **fire-and-forget** (it only drops the ingress sender and lowers a flag, leaving the `run_tun2socks` task to drain on the tokio runtime) — and then **immediately** `CFBridgingRelease`'d the writer ctx. The still-draining egress task can invoke the C write callback (`meowPacketWriterCB`, an unconditional `(__bridge MWPacketWriter *)ctx` cast) on the `CFBridgingRetain`'d writer **after it was freed** → memory corruption / crash on any stop with egress traffic still in flight or buffered (TCP FIN/ACK, a DNS reply, the 1024-deep egress queue).

**Fix:** new blocking FFI `meow_tun_stop_blocking()` → `tun2socks::stop_blocking()`. It signals stop, then `block_on`s the run task's `JoinHandle` (bounded 5s) before returning. `run_tun2socks`'s teardown `abort_and_join`s the egress task — awaiting any in-flight `emit()` — so once `stop_blocking` returns the callback is **guaranteed never to fire again**, and `-stop` can `CFBridgingRelease` the ctx safely.

`suspendTun` deliberately keeps the fire-and-forget `meow_tun_stop()`: it does **not** release the ctx (it's reused by the following `resumeTun`, whose `meow_tun_start` awaits the prior teardown via `run_handle_slot`), so there is no UAF window and no need to block the sleep/wake / path-change queue.

### 2. Ingress epoch guard for suspend/resume (high)

`readNextPackets`' completion handler only checked `_ingressRunning` before ingesting + re-arming. During a `suspend → resume` (sleep/wake, network path change) an in-flight completion from the **old** generation could observe `_ingressRunning` back at `YES` (re-set by `resumeTun`) and re-arm a **second concurrent** `readPacketsWithCompletionHandler` chain — violating NEPacketTunnelFlow's one-outstanding-read contract — and ingest stale-generation packets. Added a monotonic `_ingressEpoch` bumped on every suspend/stop; `readNextPackets` captures it when arming and the completion drops itself if the epoch advanced. Also closes the window where an old handler's `ingest` landed during the brief channel-swap gap.

## Audit findings addressed
#1/#5/#6/#7 (egress UAF — confirmed from four independent lenses) and #8/#10 (ingress lifecycle race).

## Path B — local-CI-green attestation
- [x] `cargo fmt -- --check` → clean
- [x] `cargo clippy --all-targets -- -D warnings` → **0 issues**
- [x] `cargo test --lib` → **46 passed** (incl. new `stop_blocking_joins_run_task_synchronously`)
- [x] `scripts/build-rust.sh` → device + simulator cross-build OK; regenerated `MeowCore/include/meow_core.h` (new `meow_tun_stop_blocking` decl)
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests -testLanguage en` → **\*\* TEST SUCCEEDED \*\*** (26 tests / 4 suites, incl. the `tun2socks bridge` start→stop→start restart-cycle suite; ObjC extension compiled clean)
- [x] `swiftformat --lint .` → **0** ; `swiftlint --strict` → **0**
- [x] `git diff origin/main...HEAD --stat` → 4 files: `MeowCore/include/meow_core.h`, `PacketTunnel/Sources/MWTunnelEngine.m`, `core/rust/meow-ios-ffi/src/lib.rs`, `core/rust/meow-ios-ffi/src/tun2socks.rs` (+160/-4). The xcframework binary is gitignored (CI rebuilds it).

No `.github/workflows/*` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)