### PR TITLE
feat(subscriptions): edit a subscription's name and update URL

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -68,6 +68,10 @@
 "subscriptions.add.field.url" = "URL";
 "subscriptions.add.button.add" = "Add";
 "subscriptions.add.button.adding" = "Adding…";
+"subscriptions.editInfo.swipe" = "Edit Info";
+"subscriptions.editInfo.nav.title" = "Edit Subscription";
+"subscriptions.editInfo.button.save" = "Save";
+"subscriptions.editInfo.footer" = "Changes to the URL take effect on the next refresh.";
 "subscriptions.import.errorTitle" = "Couldn't import subscription";
 "subscriptions.row.updatedAgo %@" = "Updated %@ ago";
 "subscriptions.row.a11y.edit %@" = "Edit YAML for %@";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -74,6 +74,10 @@
 "subscriptions.add.field.url" = "网址";
 "subscriptions.add.button.add" = "添加";
 "subscriptions.add.button.adding" = "添加中…";
+"subscriptions.editInfo.swipe" = "编辑信息";
+"subscriptions.editInfo.nav.title" = "编辑订阅";
+"subscriptions.editInfo.button.save" = "保存";
+"subscriptions.editInfo.footer" = "网址的更改将在下次刷新时生效。";
 "subscriptions.import.errorTitle" = "导入订阅失败";
 "subscriptions.row.updatedAgo %@" = "%@前更新";
 "subscriptions.row.a11y.edit %@" = "编辑 %@ 的 YAML";

--- a/App/Sources/Services/SubscriptionService.swift
+++ b/App/Sources/Services/SubscriptionService.swift
@@ -60,6 +60,16 @@ final class SubscriptionService {
         try modelContext.save()
     }
 
+    /// Edit a profile's display name and update URL without touching its YAML
+    /// body. A changed URL takes effect on the next `refresh(_:)` — the stored
+    /// config is left as-is here. Attaching a URL to a previously local-only
+    /// import (empty `url`) promotes it to a refreshable subscription.
+    func updateInfo(_ profile: Profile, name: String, url: String) throws {
+        profile.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        profile.url = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        try modelContext.save()
+    }
+
     func select(_ profile: Profile) throws {
         let fetch = FetchDescriptor<Profile>()
         let all = try modelContext.fetch(fetch)

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -8,6 +8,7 @@ struct SubscriptionsView: View {
     @State private var showingAdd = false
     @State private var showingImporter = false
     @State private var editing: Profile?
+    @State private var editingInfo: Profile?
     @State private var error: String?
 
     var body: some View {
@@ -65,6 +66,15 @@ struct SubscriptionsView: View {
                 .listRowSeparator(.hidden)
                 .contentShape(Rectangle())
                 .onTapGesture { try? service.select(profile) }
+                .swipeActions(edge: .leading) {
+                    Button {
+                        editingInfo = profile
+                    } label: {
+                        Label("subscriptions.editInfo.swipe", systemImage: "square.and.pencil")
+                    }
+                    .tint(.blue)
+                    .accessibilityIdentifier("subscriptions.row.editInfo")
+                }
                 .swipeActions(edge: .trailing) {
                     Button(role: .destructive) {
                         try? service.delete(profile)
@@ -125,6 +135,9 @@ struct SubscriptionsView: View {
             NavigationStack {
                 YamlEditorView(profile: profile)
             }
+        }
+        .sheet(item: $editingInfo) { profile in
+            EditSubscriptionInfoSheet(profile: profile, error: $error)
         }
         .alert("common.error", isPresented: .constant(error != nil)) {
             Button("common.ok") { error = nil }
@@ -225,6 +238,59 @@ private struct AddSubscriptionSheet: View {
                         }
                     }
                     .disabled(name.isEmpty || url.isEmpty || submitting)
+                }
+            }
+        }
+    }
+}
+
+/// Edits a subscription's name and update URL only — the YAML body is left
+/// untouched (that's what the pencil / `YamlEditorView` is for). A changed URL
+/// is picked up on the next refresh, not immediately. See issue #182.
+private struct EditSubscriptionInfoSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(SubscriptionService.self) private var service
+    let profile: Profile
+    @Binding var error: String?
+    @State private var name: String
+    @State private var url: String
+
+    init(profile: Profile, error: Binding<String?>) {
+        self.profile = profile
+        _error = error
+        _name = State(initialValue: profile.name)
+        _url = State(initialValue: profile.url)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("subscriptions.add.field.name", text: $name)
+                    TextField("subscriptions.add.field.url", text: $url)
+                        .keyboardType(.URL)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                } footer: {
+                    Text("subscriptions.editInfo.footer")
+                }
+            }
+            .navigationTitle("subscriptions.editInfo.nav.title")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("common.cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("subscriptions.editInfo.button.save") {
+                        do {
+                            try service.updateInfo(profile, name: name, url: url)
+                            dismiss()
+                        } catch {
+                            self.error = error.localizedDescription
+                        }
+                    }
+                    .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
         }

--- a/MeowTests/Services/SubscriptionServiceTests.swift
+++ b/MeowTests/Services/SubscriptionServiceTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+@testable import meow_ios
+import SwiftData
 import Testing
 
 /// `SubscriptionService` coordinates fetch → detect → convert → persist. Each
@@ -6,6 +8,53 @@ import Testing
 /// `MeowTests/Parsing/`.
 @Suite("SubscriptionService", .tags(.service))
 struct SubscriptionServiceTests {
+    @MainActor
+    private func makeService() throws -> (SubscriptionService, ModelContext) {
+        let container = try ModelContainer(
+            for: Profile.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true),
+        )
+        let context = ModelContext(container)
+        return (SubscriptionService(modelContext: context), context)
+    }
+
+    @Test
+    @MainActor
+    func `updateInfo overwrites name and url and persists`() throws {
+        let (service, context) = try makeService()
+        let profile = Profile(name: "Old", url: "https://example.com/a.yaml", yamlContent: "mixed-port: 7890\n")
+        context.insert(profile)
+        try context.save()
+
+        try service.updateInfo(profile, name: "New Name", url: "https://example.com/b.yaml")
+
+        #expect(profile.name == "New Name")
+        #expect(profile.url == "https://example.com/b.yaml")
+
+        // Survives a fresh fetch from the same store.
+        let fetched = try context.fetch(FetchDescriptor<Profile>())
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.name == "New Name")
+        #expect(fetched.first?.url == "https://example.com/b.yaml")
+    }
+
+    @Test
+    @MainActor
+    func `updateInfo trims whitespace and leaves the YAML body untouched`() throws {
+        let (service, context) = try makeService()
+        let body = "mixed-port: 7890\nproxies: []\n"
+        let profile = Profile(name: "Old", url: "", yamlContent: body)
+        context.insert(profile)
+        try context.save()
+
+        // Attaching a URL to a previously local-only import promotes it.
+        try service.updateInfo(profile, name: "  Trimmed  ", url: "  https://example.com/c.yaml  ")
+
+        #expect(profile.name == "Trimmed")
+        #expect(profile.url == "https://example.com/c.yaml")
+        #expect(profile.yamlContent == body)
+    }
+
     @Test(.disabled("blocked on T4.5"))
     func `happy-path fetch returns body string`() {
         // URLProtocolStub.responses[url] = .init(body: "mixed-port: 7890\n".data)


### PR DESCRIPTION
## Summary
Implements #182. After importing a subscription there was no way to change its **name** or **update URL** — you had to delete and re-import. (The pencil icon edits the YAML body, not the metadata.)

Adds a **leading-edge swipe action "Edit Info"** on each subscription row that opens a small `Form` to edit name + URL. Chosen over a third row icon (the row already has pencil + refresh); the trailing swipe is already Delete.

## Change
- `SubscriptionService.updateInfo(_:name:url:)` — trims and persists `name`/`url`. The YAML body is untouched; a changed URL takes effect on the next refresh. Attaching a URL to a previously local-only import (empty `url`) promotes it to a refreshable subscription.
- `SubscriptionsView` — leading swipe → `EditSubscriptionInfoSheet` (Name + URL fields, footer noting URL changes apply on next refresh).
- en / zh-Hans strings for the new sheet (parity-balanced).

## Tests
- New `SubscriptionServiceTests`: `updateInfo` overwrite+persist (survives a fresh fetch), and trim + YAML-body-untouched.
- `LocalizableParityTests` confirms the new en/zh keys are balanced.
- No UITest for the swipe gesture: this repo's MeowUITests tab-lookup is flaky under simulator locale (see prior notes); the new logic is covered by unit tests and the sheet reuses the existing `AddSubscriptionSheet` pattern.

## Path B local-CI attestation (CLAUDE.md)
- [x] `swiftformat --lint .` at repo root → **0 violations**
- [x] `swiftlint --strict` at repo root → **0 violations**
- [x] `xcodebuild test ... -only-testing:MeowTests` (iPhone 17, iOS 26) → **128 tests in 24 suites passed** (incl. the 2 new `updateInfo` tests + localization parity)
- [x] `git diff origin/main...HEAD --stat` → only the service method, the view, en/zh strings, and the new tests (no pbxproj change — no new files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)