### PR TITLE
chore(prod): bump build number to 2026061401 for TestFlight

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026061201</string>
+	<string>2026061401</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>2026061201</string>
+	<string>2026061401</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026061201"
+        CFBundleVersion: "2026061401"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026061201"
+        CFBundleVersion: "2026061401"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
Build-number-only bump (`2026061201` → `2026061401`) so `main` reflects the TestFlight build of **v1.3.1** carrying the just-merged fixes:

- #180 — proxy-group members absent from `/proxies` now render
- #213 — Clash-YAML detection when rule blocks precede `proxies:`
- #182 — edit a subscription's name + update URL

No code/logic change — only `CFBundleVersion` in `project.yml` and the two generated `Info.plist`s. The TestFlight build (`com.tangzixiang.meow`, team `32B45SMMQL`) is being uploaded from this build number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)