### PR TITLE
fix(net): repair long-lived TCP/UDP teardown (WebSocket, online gaming)

### DIFF
--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -118,6 +118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,7 +209,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -281,6 +293,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "blake3"
@@ -1638,8 +1659,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 dependencies = [
  "axum",
  "base64",
@@ -1670,8 +1691,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1692,8 +1713,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1725,8 +1746,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1742,6 +1763,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "smallvec",
  "smol_str",
  "thiserror 2.0.18",
  "tokio",
@@ -1786,11 +1808,12 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 dependencies = [
  "aes",
  "aes-gcm",
+ "argon2",
  "async-trait",
  "base64",
  "bytes",
@@ -1820,8 +1843,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1837,8 +1860,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 dependencies = [
  "async-trait",
  "base64",
@@ -1855,7 +1878,7 @@ dependencies = [
  "tokio",
  "tokio-boring",
  "tokio-rustls",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tracing",
  "webpki-root-certs",
  "webpki-roots 0.26.11",
@@ -1863,16 +1886,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
-dependencies = [
- "smallvec",
-]
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.12.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f48dac7481388cab9e0b741bfb7d0de0351d9978#f48dac7481388cab9e0b741bfb7d0de0351d9978"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2014,6 +2034,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2237,22 +2268,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2265,16 +2285,6 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3101,18 +3111,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -3120,7 +3118,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -3318,24 +3316,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.8.6",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -3407,12 +3387,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -62,8 +62,9 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: f48dac74
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
+# HEAD: 21ad771e — v0.14.0 main + pub UdpSession::touch/idle_for (merged via
+# meow-rs#212).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -71,11 +72,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388c
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f48dac7481388cab9e0b741bfb7d0de0351d9978" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -864,9 +864,10 @@ pub extern "C" fn meow_tun_udp_first_reply_deadline_ms() -> c_int {
 /// such accumulation exhausts the accept cap and the tunnel stops
 /// passing new TCP flows ("connected but no traffic").
 ///
-/// Default 300000 ms (5 min, the conventional proxy connection-idle
-/// timeout). Pass `0` to disable the sweeper. Negative values are
-/// rejected.
+/// Default 600000 ms (10 min). Raised from the conventional 5-min proxy
+/// idle timeout so no-keepalive server-push channels with multi-minute quiet
+/// gaps aren't reaped while alive (2026-06-14 long-lived-TCP audit). Pass `0`
+/// to disable the sweeper. Negative values are rejected.
 ///
 /// Takes effect on the sweeper's next 30 s tick; no restart needed.
 ///

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -425,8 +425,7 @@ pub unsafe extern "C" fn meow_proxy_select(group: *const c_char, name: *const c_
         set_error("engine not running".into());
         return -2;
     };
-    let proxies = tunnel.proxies();
-    let Some(proxy) = proxies.get(group_name) else {
+    let Some(proxy) = tunnel.proxy(group_name) else {
         set_error(format!("proxy group not found: {group_name}"));
         return -3;
     };

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -245,15 +245,31 @@ pub fn udp_first_reply_deadline_ms() -> u64 {
 // (RAII cleanup on both halves, permit released) and the netstack stream
 // (RST / tcp_close to the app side, which reconnects on next use).
 //
-// 300 s default matches the industry-standard proxy connection-idle
-// timeout (v2ray `connIdle`, sing-box inactivity defaults). Long-lived
-// idle-but-legit flows (push channels) see a reconnect on next activity —
-// the standard tradeoff every proxy core makes. Tunable at runtime via
+// 600 s default. Raised from 300 s after the 2026-06-14 long-lived-TCP audit:
+// 300 s (v2ray `connIdle` / sing-box inactivity defaults) reaps a no-keepalive
+// server-push channel (live feed, SSE, some game lobbies) whenever its quiet
+// gap between pushes exceeds 5 min, even though the flow is alive. `touch()`
+// refreshes on BOTH directions, so any flow with traffic — including a
+// well-behaved WebSocket sending ping/pong — never hits this; only a flow
+// genuinely silent in both directions is reaped. 10 min covers the common
+// push-interval range while still reclaiming a wedged-but-silent pcb (the
+// after-hours-idle failure mode above) well inside the time it would take to
+// accumulate ~256 of them against the accept cap. Tunable at runtime via
 // [`set_tcp_idle_ttl_ms`] / `meow_tun_set_tcp_idle_ttl_ms`; 0 disables.
-const TCP_IDLE_TTL_MS_DEFAULT: u64 = 300_000;
+const TCP_IDLE_TTL_MS_DEFAULT: u64 = 600_000;
 static TCP_IDLE_TTL_MS: AtomicU64 = AtomicU64::new(TCP_IDLE_TTL_MS_DEFAULT);
 
 const TCP_IDLE_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+// After the app half-closes (local FIN), how long the relay may stay quiet in
+// the DOWNLOAD direction before `dispatch_tcp` drops it. The window is
+// *idle-based*, not absolute: each downstream byte refreshes it (see the
+// local-FIN arm in `dispatch_tcp`), so a slow/large half-closed response — a
+// raw TCP half-close that keeps receiving, an HTTP/1.1 request-body EOF before
+// a big response — drains fully instead of being truncated by a fixed timer.
+// Only a half-closed flow that also goes download-silent is dropped, and the
+// 300/600 s idle sweeper is the ultimate backstop regardless.
+const HALF_CLOSE_IDLE_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Set the per-TCP-flow idle TTL, in milliseconds. `0` disables the
 /// sweeper (legacy behaviour: wedged flows hold their accept permit until
@@ -1113,6 +1129,11 @@ async fn dispatch_tcp(
 
     // Dial-deadline watchdog (see DIAL_DEADLINE_MS docs above and
     // `run_dial_watchdog` for the actual polling logic).
+    // `watchdog_state` is moved into the watchdog; keep a handle to the same
+    // FlowState so the local-FIN arm can watch download progress via
+    // `last_active_ms` (bumped by `IdleTracking::poll_write` on each
+    // downstream byte).
+    let eof_state = watchdog_state.clone();
     let dial_watchdog = run_dial_watchdog(watchdog_state, accepted_at_ms, dial_deadline);
     tokio::pin!(dial_watchdog);
 
@@ -1120,15 +1141,31 @@ async fn dispatch_tcp(
         biased;
         _ = &mut fut => {}
         _ = local_eof.notified() => {
-            // 250 ms is enough for the relay to land its
-            // `poll_shutdown` on the outbound write half (rustls
-            // writes close_notify + the encrypted record fits in
-            // one TCP segment) without holding the task indefinitely
-            // if the proxy peer is wedged.
-            let _ = tokio::time::timeout(
-                std::time::Duration::from_millis(250),
-                &mut fut,
-            ).await;
+            // The app sent FIN. `handle_tcp` already half-closes correctly
+            // (poll_shutdown upstream) and keeps the DOWNLOAD direction alive,
+            // but then waits forever for the peer's FIN — which wedges
+            // long-poll / SSE / dead-peer flows. Don't truncate a still-
+            // flowing download with a fixed window (the old 250 ms drop):
+            // extend the grace as long as downstream bytes keep arriving, and
+            // give up only once the download side has been quiet for
+            // HALF_CLOSE_IDLE_GRACE. A wedged/dead peer is dropped ~2 s after
+            // FIN; a slow large response drains in full.
+            loop {
+                let before = eof_state.last_active_ms.load(Ordering::Relaxed);
+                match tokio::time::timeout(HALF_CLOSE_IDLE_GRACE, &mut fut).await {
+                    // Relay finished (peer FIN'd / closed) — clean done.
+                    Ok(_) => break,
+                    // No completion within the window. If a downstream byte
+                    // landed (last_active_ms advanced) the response is still
+                    // draining, so loop and extend; otherwise it's quiet —
+                    // drop the future (RAII close on every layer).
+                    Err(_) => {
+                        if eof_state.last_active_ms.load(Ordering::Relaxed) == before {
+                            break;
+                        }
+                    }
+                }
+            }
         }
         _ = &mut dial_watchdog => {
             warn!(

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -314,6 +314,12 @@ static STACK_INGRESS_DROP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
 
 static UDP_CAP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
 
+// Throttle slot for the UDP reply-writer-backpressure drop log. When the
+// shared `udp_reply_tx` channel is momentarily full the reply reader drops the
+// datagram (UDP is lossy) and keeps the session alive; without a log this
+// silent loss has no on-device signal. Throttled via warn_capped.
+static UDP_REPLY_DROP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
+
 static TCP_FLOW_ID_SEQ: AtomicU64 = AtomicU64::new(1);
 
 /// Per-active-flow timestamp. The Arc-shared cell lets `IdleTrackingConn`
@@ -1421,6 +1427,30 @@ async fn dispatch_udp(
     );
 }
 
+/// Forward one upstream→app UDP reply onto the shared writer channel.
+///
+/// A full `reply_tx` is treated as lossy packet drop (UDP semantics), NOT as a
+/// reason to terminate the reply reader. Earlier this site did
+/// `if reply_tx.try_send(msg).is_err() { break; }`, which tore the whole NAT
+/// session + reader down on a single transient full queue: every subsequent
+/// datagram on that 5-tuple then went through a full re-dispatch + re-dial
+/// (fresh source port), and under multi-session bursts — where the single
+/// shared writer is the bottleneck — that became a pathological
+/// destroy-and-rebuild loop across every live session (online-gaming flows the
+/// worst hit). Dropping the datagram instead keeps the session alive; a
+/// genuinely dead session is still reaped by the first-reply deadline, the 60 s
+/// idle backstop, and read errors. A blocking `send().await` is deliberately
+/// avoided here: it would let one backed-up writer apply head-of-line
+/// backpressure across the shared channel and stall every other session.
+fn forward_udp_reply(reply_tx: &mpsc::Sender<UdpMsg>, msg: UdpMsg) {
+    if reply_tx.try_send(msg).is_err() {
+        warn_capped(
+            &UDP_REPLY_DROP_LOG_LAST_MS,
+            "tun2socks: UDP reply writer backed up, dropping datagram",
+        );
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn spawn_udp_reply_reader(
     key: (SocketAddr, SocketAddr),
@@ -1509,11 +1539,7 @@ fn spawn_udp_reply_reader(
                     // TO the app (app_src). netstack's Sink builds the header
                     // from (src, dst) in that argument order.
                     let msg: UdpMsg = (buf[..n].to_vec(), app_dst, app_src);
-                    // UDP is inherently lossy; drop if writer is backed up
-                    // rather than accumulating unbounded Vec<u8> allocations.
-                    if reply_tx.try_send(msg).is_err() {
-                        break;
-                    }
+                    forward_udp_reply(&reply_tx, msg);
                 }
                 Err(e) => {
                     info!("UDP reply reader closing for {:?}: {}", key, e);
@@ -2042,6 +2068,42 @@ mod tests {
         assert_eq!(parsed.src_port, 54321);
         assert_eq!(parsed.dst_port, 53);
         assert_eq!(parsed.payload, b"QQQQ");
+    }
+
+    /// Regression: a momentarily-full reply-writer channel must DROP the
+    /// datagram (UDP is lossy) and leave the reply reader running — a full
+    /// queue is transient backpressure, not a dead flow. Before this fix the
+    /// reader did `if reply_tx.try_send(msg).is_err() { break; }`, so a single
+    /// full-queue hiccup tore down the whole NAT session and forced a re-dial
+    /// (fresh source port) on the next datagram — a destroy-and-rebuild loop
+    /// under burst that broke long-lived UDP apps (online gaming).
+    /// `forward_udp_reply` must absorb the full-channel case as a drop and stay
+    /// usable afterwards.
+    #[test]
+    fn forward_udp_reply_drops_when_full_without_terminating() {
+        let src = SocketAddr::from((Ipv4Addr::new(10, 0, 0, 1), 5000));
+        let dst = SocketAddr::from((Ipv4Addr::new(1, 1, 1, 1), 443));
+
+        // Capacity-1 channel; the first forward fills the only slot.
+        let (tx, mut rx) = mpsc::channel::<UdpMsg>(1);
+        forward_udp_reply(&tx, (vec![1u8], dst, src));
+
+        // Second forward hits a full channel. The pre-fix code signalled
+        // teardown here; the helper must simply drop the datagram and return.
+        forward_udp_reply(&tx, (vec![2u8], dst, src));
+
+        let first = rx.try_recv().expect("first datagram delivered");
+        assert_eq!(first.0, vec![1u8]);
+        assert!(
+            rx.try_recv().is_err(),
+            "second datagram must be dropped, not queued behind the first"
+        );
+
+        // The channel is still open and usable — i.e. the session was NOT torn
+        // down by the full-queue drop. A drained slot accepts the next reply.
+        forward_udp_reply(&tx, (vec![3u8], dst, src));
+        let third = rx.try_recv().expect("post-drop datagram still deliverable");
+        assert_eq!(third.0, vec![3u8]);
     }
 
     /// All tests in this module mutate the process-wide `tcp_flows()`

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -1427,6 +1427,17 @@ async fn dispatch_udp(
     );
 }
 
+/// Poll cadence for the post-first-reply UDP reply reader. Short so the reader
+/// re-checks the bidirectional idle clock (which an outbound forward may have
+/// just refreshed) promptly, without busy-spinning. Worst-case eviction
+/// latency is `UDP_REPLY_IDLE_TTL + UDP_REPLY_POLL_INTERVAL`.
+const UDP_REPLY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Both-directions-idle TTL after which the post-first-reply reply reader
+/// evicts its session. Matches meow-tunnel's `DEFAULT_UDP_IDLE` (60 s) so the
+/// FFI backstop and the NAT sweeper agree on when a session is dead.
+const UDP_REPLY_IDLE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Forward one upstream→app UDP reply onto the shared writer channel.
 ///
 /// A full `reply_tx` is treated as lossy packet drop (UDP semantics), NOT as a
@@ -1484,7 +1495,7 @@ fn spawn_udp_reply_reader(
         // active session on quiet idle periods (long-poll, NAT keepalive).
         let first_reply_deadline_ms = UDP_FIRST_REPLY_DEADLINE_MS.load(Ordering::Relaxed);
         let mut had_first_reply = false;
-        loop {
+        'reader: loop {
             let read = if !had_first_reply && first_reply_deadline_ms > 0 {
                 match tokio::time::timeout(
                     std::time::Duration::from_millis(first_reply_deadline_ms),
@@ -1498,42 +1509,63 @@ fn spawn_udp_reply_reader(
                             "UDP first-reply deadline exceeded for {:?} after {} ms; evicting session",
                             key, first_reply_deadline_ms,
                         );
-                        break;
+                        break 'reader;
                     }
                 }
             } else {
-                // Post-first-reply idle backstop. The NAT sweeper
-                // (`spawn_background_tasks`) evicts the `nat_table` entry once
-                // a session is idle > DEFAULT_UDP_IDLE (60 s), but this reader
-                // task holds its OWN `Arc<UdpSession>` + 4 KiB `buf`, so the
-                // sweeper alone can't unblock a `read_packet` that never
-                // returns — the task (and its buffer) would leak for any
-                // session that gets one reply then goes silent (one-shot DNS,
-                // abandoned QUIC, dead upstream). Bound the read at the same
-                // 60 s idle the tunnel already uses, so once the NAT layer
-                // considers the session dead this reader exits and reaches the
-                // cleanup below. Genuinely active sessions (data within 60 s)
-                // are never evicted; a session quiet > 60 s is one the tunnel
-                // has already dropped from `nat_table` regardless.
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(60),
-                    session.conn.read_packet(&mut buf),
-                )
-                .await
-                {
-                    Ok(res) => res,
-                    Err(_) => {
-                        info!(
-                            "UDP reply reader idle > 60s for {:?}; evicting session",
-                            key
-                        );
-                        break;
+                // Post-first-reply idle backstop — BIDIRECTIONAL.
+                //
+                // The NAT sweeper (`spawn_background_tasks`) evicts the
+                // `nat_table` entry once a session is idle > DEFAULT_UDP_IDLE
+                // (60 s), but this reader task holds its OWN `Arc<UdpSession>`
+                // + 4 KiB `buf`, so the sweeper alone can't unblock a
+                // `read_packet` that never returns — the task would leak for
+                // any session that gets one reply then goes silent.
+                //
+                // This used to bound each read at a flat 60 s and evict on
+                // INBOUND silence alone, which diverged from the sweeper's
+                // OUTBOUND-stamped clock: a session where the client keeps
+                // sending (game input) while the server is briefly quiet > 60 s
+                // got torn down here even though the NAT layer still considered
+                // it active — forcing a re-dial on a fresh source port and
+                // dropping in-flight replies. Instead, poll on a short interval
+                // and evict only when BOTH directions have been idle for the
+                // TTL: `idle_for()` reads the same `last_activity_ms` that
+                // `handle_udp` bumps on every outbound forward AND that we now
+                // bump on every inbound reply (touch() below). So an active
+                // flow in EITHER direction keeps the reader alive; only a
+                // genuinely two-way-silent session is reaped.
+                loop {
+                    match tokio::time::timeout(
+                        UDP_REPLY_POLL_INTERVAL,
+                        session.conn.read_packet(&mut buf),
+                    )
+                    .await
+                    {
+                        Ok(res) => break res,
+                        Err(_) => {
+                            if session.idle_for() >= UDP_REPLY_IDLE_TTL {
+                                info!(
+                                    "UDP reply reader idle (both directions) > {}s for {:?}; evicting session",
+                                    UDP_REPLY_IDLE_TTL.as_secs(),
+                                    key
+                                );
+                                break 'reader;
+                            }
+                            // Outbound-active: the shared clock was refreshed
+                            // elsewhere, so keep polling for inbound replies.
+                        }
                     }
                 }
             };
             match read {
                 Ok((n, _from)) => {
                     had_first_reply = true;
+                    // Inbound traffic is activity too: refresh the shared NAT
+                    // idle clock so neither the sweeper nor the backstop above
+                    // evicts a receive-active / send-quiet session while data
+                    // is still arriving.
+                    session.touch();
                     // Reply injection: the IP frame handed back to the app
                     // must look like it came FROM the external peer (app_dst)
                     // TO the app (app_src). netstack's Sink builds the header
@@ -1543,7 +1575,7 @@ fn spawn_udp_reply_reader(
                 }
                 Err(e) => {
                     info!("UDP reply reader closing for {:?}: {}", key, e);
-                    break;
+                    break 'reader;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes five issues found by a 2026-06-14 audit of what breaks long-lived TCP/UDP apps (WebSocket, online gaming). Online gaming over **UDP** was the main casualty — three converging bugs in the UDP reply reader.

Pinned to meow-rs `21ad771` on **main** (`pub UdpSession::touch/idle_for`, landed via madeye/meow-rs#212).

## Changes

| Commit | Bug | Fix |
|---|---|---|
| `keep NAT session alive…` | #3 (UDP, gaming) | A momentarily-full reply-writer channel now **drops the datagram** (UDP is lossy) instead of `break`-ing and destroying the whole NAT session. Prevents a destroy-and-rebuild loop under multi-session burst. + regression test. |
| `make NAT idle clock bidirectional` | #1/#2 (UDP, gaming) | `session.touch()` on every inbound reply + a 10s-poll backstop that evicts only when `idle_for()` shows **both** directions idle ≥60s. Bumps meow-rs to 0.14.0 (`Tunnel::proxies()`→`proxy(name)`). |
| `idle-based half-close grace…` | #4 (TCP, WS) / #10 | Local-FIN grace is now **idle-based** (extends while downstream bytes arrive) instead of a fixed 250ms drop that truncated live half-closed downloads. TCP idle TTL default 300s→**600s** so no-keepalive push channels survive. |

No Swift touched; FFI/Rust only.

## Path B local-CI attestation

All run locally on the final branch HEAD:

- [x] `cargo fmt -- --check` (core/rust/meow-ios-ffi) → 0 violations
- [x] `cargo clippy --lib --all-targets -- -D warnings` → no issues
- [x] `cargo test --lib` → **48 passed**
- [x] `scripts/build-rust.sh` → aarch64-apple-ios + -sim compiled, MeowCore.xcframework packed
- [x] meow-tunnel (dep) `cargo fmt/clippy/test --lib` → clean, 14 passed
- [x] `git diff origin/main...HEAD --stat` verified: only `core/rust/meow-ios-ffi/{Cargo.toml,Cargo.lock,src/lib.rs,src/tun2socks.rs}`

swiftformat/swiftlint not run — no Swift in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)