### PR TITLE
chore(ffi): regenerate meow_core.h for the 10-min idle-TTL doc

### DIFF
--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -330,9 +330,10 @@ int meow_tun_udp_first_reply_deadline_ms(void);
  * such accumulation exhausts the accept cap and the tunnel stops
  * passing new TCP flows ("connected but no traffic").
  *
- * Default 300000 ms (5 min, the conventional proxy connection-idle
- * timeout). Pass `0` to disable the sweeper. Negative values are
- * rejected.
+ * Default 600000 ms (10 min). Raised from the conventional 5-min proxy
+ * idle timeout so no-keepalive server-push channels with multi-minute quiet
+ * gaps aren't reaped while alive (2026-06-14 long-lived-TCP audit). Pass `0`
+ * to disable the sweeper. Negative values are rejected.
  *
  * Takes effect on the sweeper's next 30 s tick; no restart needed.
  *


### PR DESCRIPTION
Generated-header sync. `cbindgen` output drifted after the TCP idle-TTL default doc-comment change (`meow_tun_set_tcp_idle_ttl_ms`, 300000→600000 ms) landed in #236 without the regenerated header. Comment-only; no ABI change. CI's `build-rust.sh` regenerates this file anyway, so this just keeps the checked-in copy honest for Xcode-only builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)