### PR TITLE
feat(tunnel): make the packet tunnel IPv4-only

### DIFF
--- a/MeowIntegrationTests/VPNLifecycle/TunnelSettings.swift
+++ b/MeowIntegrationTests/VPNLifecycle/TunnelSettings.swift
@@ -32,24 +32,6 @@ enum TunnelSettings {
         ]
     }
 
-    /// IPv6 equivalents: ULA + link-local + loopback + multicast. Computed
-    /// for the same Sendable reason as `ipv4LanExcludedRoutes`.
-    static var ipv6LanExcludedRoutes: [NEIPv6Route] {
-        // TODO: add split ULA (fc00::/7) exclusion back in a follow-up once
-        // the v4 narrow fix is confirmed green. Dropped here to minimise the
-        // diff for the recovery PR — tunnel uses fdfe:dcba:9876::/126, which
-        // sits inside fc00::/7, so the same interface-route shadowing risk
-        // applies until we split this the same way IPv4 is split.
-        // Loopback (::1/128) intentionally omitted: NEIPv6Route validator
-        // rejects loopback destinations and drops the entire settings payload
-        // when present — same failure mode as IPv4 127/8. Kernel handles
-        // loopback host-locally without a TUN exclusion.
-        [
-            route6(address: "fe80::", prefix: 10), // Link-local
-            route6(address: "ff00::", prefix: 8), // Multicast
-        ]
-    }
-
     static func make(serverAddress: String) -> NEPacketTunnelNetworkSettings {
         let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: serverAddress)
 
@@ -58,10 +40,9 @@ enum TunnelSettings {
         ipv4.excludedRoutes = ipv4LanExcludedRoutes
         settings.ipv4Settings = ipv4
 
-        let ipv6 = NEIPv6Settings(addresses: ["fdfe:dcba:9876::1"], networkPrefixLengths: [126])
-        ipv6.includedRoutes = [NEIPv6Route.default()]
-        ipv6.excludedRoutes = ipv6LanExcludedRoutes
-        settings.ipv6Settings = ipv6
+        // IPv4-only tunnel: ipv6Settings is intentionally left nil so the TUN
+        // claims no IPv6 address and installs no IPv6 routes. Mirrors
+        // MWTunnelSettings.makeWithServerAddress:.
 
         let dns = NEDNSSettings(servers: ["172.19.0.2"])
         // Leaving matchDomains at its default (nil) — see NEDNSSettings.h,
@@ -76,9 +57,5 @@ enum TunnelSettings {
 
     private static func route(address: String, mask: String) -> NEIPv4Route {
         NEIPv4Route(destinationAddress: address, subnetMask: mask)
-    }
-
-    private static func route6(address: String, prefix: Int) -> NEIPv6Route {
-        NEIPv6Route(destinationAddress: address, networkPrefixLength: NSNumber(value: prefix))
     }
 }

--- a/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
+++ b/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
@@ -93,25 +93,11 @@ final class TunnelSettingsLANExclusionTests: XCTestCase {
         )
     }
 
-    func testMakeAppliesIPv6LANExcludedRoutesInDeclaredOrder() {
-        // fc00::/7 (ULA) is intentionally absent for this iteration. The
-        // tunnel's own fdfe:dcba:9876::/126 sits inside that block, so the
-        // same shadowing risk as 172.16/12 applies. A split ULA exclusion
-        // will land in a follow-up once the v4 narrow fix is confirmed green.
-        let expected: [(String, Int)] = [
-            ("fe80::", 10),
-            ("ff00::", 8),
-        ]
-
+    /// The tunnel is IPv4-only: ipv6Settings must be left nil so the TUN
+    /// claims no IPv6 address and installs no IPv6 routes.
+    func testMakeConfiguresNoIPv6() {
         let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
-        let routes = settings.ipv6Settings?.excludedRoutes ?? []
-
-        XCTAssertEqual(routes.count, expected.count, "excludedRoutes count mismatch")
-        for (index, (address, prefix)) in expected.enumerated() {
-            let route = routes[index]
-            XCTAssertEqual(route.destinationAddress, address, "index \(index) destinationAddress")
-            XCTAssertEqual(route.destinationNetworkPrefixLength.intValue, prefix, "index \(index) prefix length")
-        }
+        XCTAssertNil(settings.ipv6Settings, "tunnel must be IPv4-only; ipv6Settings must stay nil")
     }
 
     func testMakeStillRoutesAllTrafficByDefault() {
@@ -120,9 +106,5 @@ final class TunnelSettingsLANExclusionTests: XCTestCase {
         let ipv4Included = settings.ipv4Settings?.includedRoutes ?? []
         XCTAssertEqual(ipv4Included.count, 1, "catch-all default route should remain")
         XCTAssertEqual(ipv4Included.first?.destinationAddress, "0.0.0.0")
-
-        let ipv6Included = settings.ipv6Settings?.includedRoutes ?? []
-        XCTAssertEqual(ipv6Included.count, 1)
-        XCTAssertEqual(ipv6Included.first?.destinationAddress, "::")
     }
 }

--- a/PacketTunnel/Sources/MWTunnelSettings.m
+++ b/PacketTunnel/Sources/MWTunnelSettings.m
@@ -14,29 +14,19 @@
     ipv4.excludedRoutes = [self ipv4LanExcludedRoutes];
     settings.IPv4Settings = ipv4;
 
-    // IPv6 — claimed unconditionally, even on IPv4-only networks. This is
-    // a deliberate sinkhole, not an oversight:
+    // IPv6 — intentionally NOT configured. This tunnel is IPv4-only:
+    // settings.IPv6Settings is left nil, so the TUN claims no IPv6 address
+    // and installs no IPv6 routes.
     //
-    //   * Claiming ::/0 prevents IPv6 leak-around: on a v6-capable network,
-    //     apps would otherwise reach the internet natively over v6,
-    //     bypassing the proxy entirely.
-    //   * It costs nothing on a v4-only network because almost no v6
-    //     traffic enters the TUN: the engine's resolver runs fake-IP with a
-    //     v4-only pool, and meow-dns answers AAAA with NOERROR-empty in
-    //     that configuration, so clients fall back to A / fake-v4 and the
-    //     proxy connects by hostname. Only hardcoded v6 literals (rare)
-    //     ever route in, and those fail fast at the engine's dial.
-    //   * Do NOT make this conditional on path capability: re-applying
-    //     network settings mid-tunnel reasserts the whole payload (fragile —
-    //     see the loopback-route lesson in ipv4LanExcludedRoutes) and
-    //     IPv4↔IPv6 transitions are already handled by the path monitor's
-    //     address-family restart in PacketTunnelProvider.
-    NEIPv6Settings *ipv6 = [[NEIPv6Settings alloc]
-        initWithAddresses:@[@"fdfe:dcba:9876::1"]
-     networkPrefixLengths:@[@126]];
-    ipv6.includedRoutes = @[[NEIPv6Route defaultRoute]];
-    ipv6.excludedRoutes = [self ipv6LanExcludedRoutes];
-    settings.IPv6Settings = ipv6;
+    // Leak-around note: with no ::/0 route claimed, apps on a v6-capable
+    // network could in principle reach the internet natively over IPv6,
+    // bypassing the proxy. In practice meow-dns strips AAAA unconditionally
+    // (fake-IP runs a v4-only pool), so clients fall back to A / fake-v4 and
+    // the proxy connects by hostname. The residual surface is hardcoded v6
+    // literals (rare), which simply fail to reach the proxy.
+    //
+    // IPv4↔IPv6 path transitions are handled by the path monitor's
+    // address-family restart in PacketTunnelProvider.
 
     // DNS
     NEDNSSettings *dns = [[NEDNSSettings alloc] initWithServers:@[@"172.19.0.2"]];
@@ -74,14 +64,6 @@
         // 127/8 intentionally omitted — iOS rejects loopback and drops the whole excludedRoutes payload
         [[NEIPv4Route alloc] initWithDestinationAddress:@"224.0.0.0"     subnetMask:@"240.0.0.0"],
         [[NEIPv4Route alloc] initWithDestinationAddress:@"255.255.255.255" subnetMask:@"255.255.255.255"],
-    ];
-}
-
-+ (NSArray<NEIPv6Route *> *)ipv6LanExcludedRoutes {
-    // ::1/128 intentionally omitted — iOS rejects loopback destinations
-    return @[
-        [[NEIPv6Route alloc] initWithDestinationAddress:@"fe80::" networkPrefixLength:@10],
-        [[NEIPv6Route alloc] initWithDestinationAddress:@"ff00::" networkPrefixLength:@8],
     ];
 }
 


### PR DESCRIPTION
## What

Makes the iOS packet tunnel **IPv4-only**. `NEPacketTunnelNetworkSettings.IPv6Settings` is no longer assigned (left nil), so the TUN claims no IPv6 address and installs no IPv6 routes.

## Why / tradeoff

The previous code claimed `::/0` deliberately as an anti-leak sinkhole. With IPv6 unclaimed, native IPv6 leak-around is now bounded only by meow-dns's **unconditional AAAA stripping** (fake-IP runs a v4-only pool) — apps fall back to A / fake-v4 and connect through the proxy by hostname. Residual surface is hardcoded IPv6 literals, which simply fail to reach the proxy. IPv4↔IPv6 path transitions remain handled by the path monitor's address-family restart in `PacketTunnelProvider`.

## Changes

- `PacketTunnel/Sources/MWTunnelSettings.m` — drop the `NEIPv6Settings` block and the now-dead `ipv6LanExcludedRoutes` helper; update the rationale comment.
- `MeowIntegrationTests/VPNLifecycle/TunnelSettings.swift` — mirror the change in the test fixture (remove IPv6 settings, `ipv6LanExcludedRoutes`, and the `route6` helper).
- `MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift` — replace the two IPv6 route-assertion tests with `testMakeConfiguresNoIPv6`.

## Path B local-CI attestation

- [x] `swiftformat --lint .` at repo root → **0 violations** (0/91 files require formatting)
- [x] `swiftlint --strict` at repo root → **0 violations** (82 files)
- [x] `xcodebuild test -only-testing:MeowIntegrationTests/TunnelSettingsLANExclusionTests -destination 'platform=iOS Simulator,name=iPhone 17' -testLanguage en` → **6 tests, 0 failures**
- [x] `git diff origin/main...HEAD --stat` verified → only the 3 intended files (no stray additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)