### PR TITLE
fix(dns): route HTTPS/SVCB through meow-dns to fix QUIC/HTTP3 fake-IP bypass

### DIFF
--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -787,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1241,7 +1241,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 dependencies = [
  "axum",
  "base64",
@@ -1692,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1861,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 dependencies = [
  "async-trait",
  "base64",
@@ -1887,12 +1887,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=21ad771e329c8a0ed3f486bcd65e08a6a8da2018#21ad771e329c8a0ed3f486bcd65e08a6a8da2018"
+source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1960,7 +1960,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2203,7 +2203,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2240,7 +2240,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2488,7 +2488,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2840,7 +2840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2935,7 +2935,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3637,7 +3637,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -64,7 +64,7 @@ lwip = "0.3"
 #
 # HEAD: 21ad771e — v0.14.0 main + pub UdpSession::touch/idle_for (merged via
 # meow-rs#212).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -72,11 +72,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "21ad771e329c8a0ed3f486bcd65e08a6a8da2018" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -7,17 +7,20 @@
 //! Egress packets (netstack output) are handed back to Swift via a C
 //! callback registered in [`start`]. No file descriptors cross the FFI.
 //!
-//! DNS: A (1) queries are delegated to meow's resolver running in fake-IP
-//! mode (`DnsServer::handle_query`). AAAA (28) queries are answered
-//! NOERROR-empty by the intercept itself, unconditionally — only the IPv4
-//! fake-IP path is proxied, so stripping AAAA forces every client onto it
-//! instead of leaking (or black-holing) connections over v6. Anything else
-//! (HTTPS=65, SVCB=64, TXT=16, MX=15, PTR=12, …) is forwarded as a raw UDP
-//! packet to the pinned upstream pool and the response is injected straight
-//! back. meow's DnsServer returns NXDOMAIN for non-A/AAAA queries, which
-//! kills modern iOS connection setup (Safari's HTTPS-record probe, ECH,
-//! DNS-SD, mDNS-fallback) — the passthrough path lets those queries get a
-//! real answer instead.
+//! DNS: A (1), HTTPS (65) and SVCB (64) queries are delegated to meow's
+//! resolver (`DnsServer::handle_query`). A gets fake-IP synthesis; HTTPS/SVCB
+//! take meow-dns's generic-forward path, which in fake-IP mode strips the
+//! ipv4hint/ipv6hint SvcParams from the answer (meow-rs #215) so an HTTP/3
+//! client can't read the origin's real IP out of the HTTPS record and connect
+//! QUIC straight there, bypassing the fake-IP mapping the tunnel routes on.
+//! AAAA (28) queries are answered NOERROR-empty by the intercept itself,
+//! unconditionally — only the IPv4 fake-IP path is proxied, so stripping AAAA
+//! forces every client onto it instead of leaking (or black-holing)
+//! connections over v6. Anything else (TXT=16, MX=15, PTR=12, …) is forwarded
+//! as a raw UDP packet to the pinned upstream pool and the response is injected
+//! straight back. meow's DnsServer returns NXDOMAIN for those, which kills
+//! modern iOS connection setup (DNS-SD, mDNS-fallback) — the passthrough path
+//! lets them get a real answer instead.
 //!
 //! NEDNSSettings advertises a TUN-subnet address as the system resolver, so
 //! every UDP DNS query arrives as an in-TUN IP packet; the ingress loop below
@@ -878,10 +881,15 @@ async fn run_tun2socks(
         //   * AAAA (28)          → NOERROR-empty, unconditionally. Only the
         //     IPv4 fake-IP path is intercepted and proxied; stripping AAAA
         //     forces every client onto it.
-        //   * A (1)              → meow's `DnsServer::handle_query`
-        //     (fake-IP synthesis, reverse map, hosts, TTL).
+        //   * A (1) / SVCB (64)  → meow's `DnsServer::handle_query`. A gets
+        //     / HTTPS (65)         fake-IP synthesis; SVCB/HTTPS take the
+        //                          generic-forward path which strips the
+        //                          ipv4hint/ipv6hint SvcParams in fake-IP mode
+        //                          (meow-rs #215), keeping HTTP/3 origins on
+        //                          the fake-IP A record instead of letting the
+        //                          client connect direct to the real IP.
         //   * anything else      → raw UDP forward to the pinned upstream
-        //     pool (HTTPS, SVCB, TXT, MX, PTR, …). meow's DnsServer
+        //     pool (TXT, MX, PTR, …). meow's DnsServer
         //     synthesises NXDOMAIN for non-A/AAAA, which kills iOS's
         //     HTTPS-record probe + ECH + Safari's modern connect path; the
         //     passthrough route lets those queries reach a real resolver.
@@ -927,9 +935,25 @@ async fn run_tun2socks(
                             return;
                         };
                         bytes
-                    } else if qtype == Some(1) {
+                    } else if matches!(qtype, Some(1) | Some(64) | Some(65)) {
+                        // A (1) + SVCB (64) / HTTPS (65) → meow's resolver
+                        // pipeline. A gets fake-IP synthesis; SVCB/HTTPS take
+                        // meow-dns's generic-forward path, which (meow-rs #215,
+                        // fake-IP mode) strips the ipv4hint/ipv6hint SvcParams
+                        // from the answer. Without that strip an HTTP/3 client
+                        // reads the origin's real IP out of the HTTPS record and
+                        // connects QUIC straight there — bypassing the fake-IP
+                        // mapping, so domain routing / sniffing / proxy-select
+                        // silently break for exactly the dual-stack HTTP/3
+                        // origins (Xiaohongshu et al.). With the hints gone the
+                        // client falls back to the A / fake-IPv4 record and the
+                        // flow rides the proxy. On upstream failure handle_query
+                        // returns SERVFAIL, which also drives the client to the
+                        // A path — strictly better than the old plaintext-UDP/53
+                        // passthrough, which left the real-IP hints intact AND
+                        // stalled ~2 s on censored type-65 lookups.
                         let Some(tunnel) = crate::engine::tunnel() else {
-                            trace!("tun2socks: UDP/53 A query dropped — engine not yet running");
+                            trace!("tun2socks: UDP/53 query dropped — engine not yet running");
                             return;
                         };
                         let resolver = tunnel.resolver().clone();
@@ -941,11 +965,10 @@ async fn run_tun2socks(
                             }
                         }
                     } else {
-                        // Non-A/AAAA: forward verbatim to the upstream pool,
-                        // first response wins. Falls through to NXDOMAIN-shaped
-                        // dropped reply if every upstream times out — better
-                        // than meow's blanket NXDOMAIN, which actively
-                        // misleads the client.
+                        // Remaining non-address qtypes (TXT, MX, PTR, …):
+                        // forward verbatim to the upstream pool, first response
+                        // wins. Falls through to a dropped reply if every
+                        // upstream times out — the client retries on its own.
                         match forward_dns_to_upstream(
                             parsed.payload,
                             DNS_PASSTHROUGH_UPSTREAMS,


### PR DESCRIPTION
## What

Fixes QUIC/HTTP-3 traffic (Xiaohongshu and other HTTP/3-first apps) failing or bypassing the proxy. Two parts:

1. **Bump meow-rs `21ad771e` → `27156845`**, bringing:
   - **#215** `strip ipv4hint/ipv6hint from HTTPS/SVCB answers in fake-ip mode` (the core fix)
   - **#214** `bind direct UDP reply socket in destination address family`
   - **#213** UDP `touch`/`idle_for` (already consumed by our reply reader)
2. **Route HTTPS (65) / SVCB (64) DNS queries through meow's `DnsServer::handle_query`** instead of the FFI's plaintext-UDP/53 passthrough (`tun2socks.rs`).

## Why

The HTTPS resource record carries the origin's **real IPs** in its `ipv4hint`/`ipv6hint` SvcParams. The old FFI passthrough re-emitted the record verbatim, so an HTTP/3 client read those hints and connected QUIC **straight to the real IP — bypassing the fake-IP mapping** the tunnel routes/sniffs on. It also stalled ~2 s on censored type-65 lookups over plaintext UDP/53 (the `resolver:dns_stall` seen on device).

meow-dns's generic-forward path now strips the IP hints in fake-IP mode (#215), so the client falls back to the **A / fake-IPv4 record and the flow rides the proxy**. On upstream failure `handle_query` returns SERVFAIL, which also drives the client to the A path. TXT/MX/PTR keep the existing upstream passthrough.

## Path B local-CI attestation

- [x] `swiftformat --lint .` at repo root → **0 violations** (0/91 files require formatting). No Swift changed, run for completeness.
- [x] `swiftlint --strict` at repo root → **0 violations** (82 files).
- [x] Rust/FFI (the actual diff): `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean; `cargo test --lib` → **48 passed, 0 failed**.
- [x] `scripts/build-rust.sh` built the iOS xcframework clean (as part of the Ad Hoc build); installed + smoke-tested on device (iPhone 17 Pro).
- [x] `git diff origin/main...HEAD --stat` verified → only `Cargo.toml`, `Cargo.lock`, `tun2socks.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)