### PR TITLE
chore(release): bump to 1.3.2 (build 2026061402) for public TestFlight

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026061401</string>
+	<string>2026061402</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>2026061401</string>
+	<string>2026061402</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -46,8 +46,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026061401"
+        CFBundleShortVersionString: "1.3.2"
+        CFBundleVersion: "2026061402"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -192,8 +192,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.3.1"
-        CFBundleVersion: "2026061401"
+        CFBundleShortVersionString: "1.3.2"
+        CFBundleVersion: "2026061402"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
Bumps marketing version **1.3.1 → 1.3.2** and **CFBundleVersion 2026061401 → 2026061402** across the app + PacketTunnel targets, then regenerates `App/Info.plist` + `PacketTunnel/Info.plist` via xcodegen.

Ships to public TestFlight testers:
- PR #239 — QUIC/HTTP-3 fake-IP-bypass fix (HTTPS/SVCB hint stripping via meow-rs #215)
- PR #238 — IPv4-only packet tunnel

Version/config only — no Swift/Rust behavior change. `swiftformat --lint .` and `swiftlint --strict` both clean (0 violations); diff is `project.yml` + the two generated Info.plists only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)