### PR TITLE
fix(udp): resolve packet-tunnel freeze (NAT DashMap deadlock) + drop unused runtime_ping

### DIFF
--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -211,25 +211,6 @@ void meow_tun_stop(void);
 void meow_tun_stop_blocking(void);
 
 /**
- * Liveness probe for the shared tokio runtime. Spawns a trivial task and
- * waits up to `timeout_ms` for it to execute. Returns 0 if the runtime
- * scheduled it in time, -1 otherwise.
- *
- * A -1 means the worker threads are wedged (deadlock or livelock): the
- * packet path, DNS, and the control API are all dead even though the
- * process looks healthy from outside. The 2026-06-07 on-device incident —
- * leaked lwip timer tasks spinning on a yield-less lock across both
- * workers — presented exactly this way for 8+ minutes until a manual
- * toggle. The Swift watchdog polls this and force-exits the extension on
- * repeated failure, converting any future silent blackout into a visible
- * reconnect.
- *
- * Call from a non-runtime thread only (Swift watchdog queue): the caller
- * blocks on a channel the spawned task signals.
- */
-int meow_tun_runtime_ping(uint64_t timeout_ms);
-
-/**
  * Abort every in-flight TCP flow tracked by tun2socks. Used by the iOS
  * PacketTunnel side when the underlying network interface changes
  * (Wi-Fi → cellular, etc.) and we want to drop stale flows so they
@@ -330,9 +311,10 @@ int meow_tun_udp_first_reply_deadline_ms(void);
  * such accumulation exhausts the accept cap and the tunnel stops
  * passing new TCP flows ("connected but no traffic").
  *
- * Default 300000 ms (5 min, the conventional proxy connection-idle
- * timeout). Pass `0` to disable the sweeper. Negative values are
- * rejected.
+ * Default 600000 ms (10 min). Raised from the conventional 5-min proxy
+ * idle timeout so no-keepalive server-push channels with multi-minute quiet
+ * gaps aren't reaped while alive (2026-06-14 long-lived-TCP audit). Pass `0`
+ * to disable the sweeper. Negative values are rejected.
  *
  * Takes effect on the sweeper's next 30 s tick; no restart needed.
  *

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 dependencies = [
  "axum",
  "base64",
@@ -1692,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1861,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 dependencies = [
  "async-trait",
  "base64",
@@ -1887,12 +1887,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=27156845bd0a1f892b914d53a2db6026841794ad#27156845bd0a1f892b914d53a2db6026841794ad"
+source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -64,7 +64,7 @@ lwip = "0.3"
 #
 # HEAD: 21ad771e — v0.14.0 main + pub UdpSession::touch/idle_for (merged via
 # meow-rs#212).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -72,11 +72,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "27156845bd0a1f892b914d53a2db6026841794ad" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -710,33 +710,6 @@ pub extern "C" fn meow_tun_stop_blocking() {
     tun2socks::stop_blocking();
 }
 
-/// Liveness probe for the shared tokio runtime. Spawns a trivial task and
-/// waits up to `timeout_ms` for it to execute. Returns 0 if the runtime
-/// scheduled it in time, -1 otherwise.
-///
-/// A -1 means the worker threads are wedged (deadlock or livelock): the
-/// packet path, DNS, and the control API are all dead even though the
-/// process looks healthy from outside. The 2026-06-07 on-device incident —
-/// leaked lwip timer tasks spinning on a yield-less lock across both
-/// workers — presented exactly this way for 8+ minutes until a manual
-/// toggle. The Swift watchdog polls this and force-exits the extension on
-/// repeated failure, converting any future silent blackout into a visible
-/// reconnect.
-///
-/// Call from a non-runtime thread only (Swift watchdog queue): the caller
-/// blocks on a channel the spawned task signals.
-#[no_mangle]
-pub extern "C" fn meow_tun_runtime_ping(timeout_ms: u64) -> c_int {
-    let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
-    crate::get_runtime().spawn(async move {
-        let _ = tx.send(());
-    });
-    match rx.recv_timeout(std::time::Duration::from_millis(timeout_ms)) {
-        Ok(()) => 0,
-        Err(_) => -1,
-    }
-}
-
 /// Abort every in-flight TCP flow tracked by tun2socks. Used by the iOS
 /// PacketTunnel side when the underlying network interface changes
 /// (Wi-Fi → cellular, etc.) and we want to drop stale flows so they


### PR DESCRIPTION
## Root cause

The intermittent total freeze ("packet count stops increasing", control API also dead, needs a manual toggle) is a **DashMap shard-lock self-deadlock** in meow-tunnel's `handle_udp` — which every UDP datagram on the FFI's `dispatch_udp` path flows through:

```rust
if let Some(session) = tunnel.nat_table.get(&key) {        // shard RwLock READ guard, alive for whole block
    if let Err(e) = session.conn.write_packet(...).await {  // (1) read guard held across await
        tunnel.nat_table.remove(&key);                     // (2) WRITE on same shard while read guard alive → self-deadlock
    } else { session.touch(); }
    return;
}
```

A same-thread read+write on one shard parks the worker forever. On the `worker_threads(2)` runtime, both workers then wedge → total packet stall + dead REST API. Triggers when an established UDP session's upstream has died and the app sends another datagram on the same 5-tuple — common for QUIC / long-lived UDP.

## Changes

1. **Bump meow-rs `27156845` → `1454ef24`** (meow-rs#216): clone the `Arc<UdpSession>` out and drop the shard guard before the await/remove. Includes a regression test that drives the fast-path write-error branch under a 2s timeout.
2. **Remove `meow_tun_runtime_ping`** — a liveness probe that was never wired on the Swift/ObjC side; dead code once the wedge is fixed at the root. cbindgen-regenerated `meow_core.h` (also syncs the stale idle-TTL doc).

## Path B local-CI attestation

- [x] `swiftformat --lint .` → 0 violations (no Swift changed; run for CI lint-job parity).
- [x] `swiftlint --strict` → 0 violations (82 files).
- [x] Rust/FFI: `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean; `cargo test --lib` → **48 passed**. Upstream meow-rs#216: `cargo test -p meow-tunnel` → 39 passed.
- [x] `scripts/build-rust.sh` exercised via the cbindgen build + the Ad Hoc build below.
- [x] `git diff origin/main...HEAD --stat` → only `Cargo.toml`, `Cargo.lock`, `lib.rs`, `meow_core.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)