### PR TITLE
Bump meow-rs to 619499b5 + ship 2026061502 to public TestFlight

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026061501</string>
+	<string>2026061502</string>
 	<key>GOOGLE_ANALYTICS_ADID_COLLECTION_ENABLED</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFA_COLLECTION_ENABLED</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>2026061501</string>
+	<string>2026061502</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 dependencies = [
  "axum",
  "base64",
@@ -1693,7 +1693,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1715,7 +1715,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1810,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1845,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1862,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 dependencies = [
  "async-trait",
  "base64",
@@ -1888,12 +1888,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=1454ef24dfd40413f6ec176b00b1339e3149699d#1454ef24dfd40413f6ec176b00b1339e3149699d"
+source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -62,9 +62,9 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 21ad771e — v0.14.0 main + pub UdpSession::touch/idle_for (merged via
-# meow-rs#212).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
+# HEAD: 619499b5 — fake-ip HTTPS/SVCB dual-stack-correct (ADR-0013, meow-rs#217)
+# on top of the UDP NAT-table shard-guard deadlock fix (1454ef24).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -72,11 +72,11 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd404
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "1454ef24dfd40413f6ec176b00b1339e3149699d" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/metadata/testflight/whats_new/2026061502.txt
+++ b/metadata/testflight/whats_new/2026061502.txt
@@ -1,0 +1,18 @@
+Build 2026061502 (1.3.2)
+
+WHAT'S NEW
+• Improved DNS handling of HTTPS / SVCB records (the records modern
+  apps and Safari use to negotiate HTTP/3). Fake-IP handling of these
+  records is now dual-stack-correct, so HTTP/3 apps resolve and route
+  through the tunnel reliably instead of occasionally reading a real
+  origin address out of the record and bypassing the proxy.
+• Includes everything from the previous build: the UDP NAT deadlock
+  fix (silent "from time to time" traffic stalls), the QUIC/HTTP-3
+  fake-IP fix, and the IPv4-only tunnel.
+
+FOR TESTERS
+• Exercise HTTP/3-heavy apps and Safari (Xiaohongshu / RedNote,
+  YouTube, Instagram). Pages and media should load normally and stay
+  routed through the proxy. If anything fails to resolve or appears to
+  bypass the tunnel, please report it with the app and rough time.
+• Issues: https://github.com/madeye/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026061502.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026061502.txt
@@ -1,0 +1,15 @@
+Build 2026061502 (1.3.2)
+
+更新内容
+• 改进了对 HTTPS / SVCB DNS 记录的处理（现代应用和 Safari 用它来
+  协商 HTTP/3）。fake-IP 模式下对这类记录的处理现在做到了双栈正确，
+  HTTP/3 应用能可靠地解析并经隧道路由，不再会偶尔从记录里读到真实
+  源站地址而绕过代理。
+• 包含上一个版本的全部修复：UDP NAT 死锁修复（"时不时"静默断流）、
+  QUIC/HTTP-3 fake-IP 修复，以及仅 IPv4 隧道。
+
+测试要点
+• 重点测试 HTTP/3 较多的应用和 Safari（小红书、YouTube、Instagram）。
+  页面和媒体应正常加载并保持经代理路由。如果出现无法解析或疑似绕过
+  隧道的情况，请反馈并附上应用名称和大致时间。
+• 问题反馈：https://github.com/madeye/meow-ios/issues

--- a/project.yml
+++ b/project.yml
@@ -47,7 +47,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.2"
-        CFBundleVersion: "2026061501"
+        CFBundleVersion: "2026061502"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -193,7 +193,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.2"
-        CFBundleVersion: "2026061501"
+        CFBundleVersion: "2026061502"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider

--- a/scripts/build-adhoc.sh
+++ b/scripts/build-adhoc.sh
@@ -63,9 +63,13 @@ EXPORT_DIR="$ROOT/build/export-adhoc"
 EXPORT_PLIST="$ROOT/build/ExportOptions-adhoc.plist"
 
 # Ad Hoc profiles installed on this Mac (UUIDs from
-# ~/Library/MobileDevice/Provisioning Profiles/)
-APP_PROFILE="${APP_PROFILE:-1530eda1-0fae-4c05-bbae-d07cde47ac39}"
-PT_PROFILE="${PT_PROFILE:-67929e8a-de89-4046-a21a-fad19f92071b}"
+# ~/Library/MobileDevice/Provisioning Profiles/). These must be Ad Hoc
+# profiles for the CURRENT bundle ids (com.tangzixiang.meow[.PacketTunnel])
+# under team 32B45SMMQL — "meow AdHoc" / "meow PT AdHoc". The old UUIDs here
+# were for the retired io.github.madeye.meow ids on team SK4GFF6AHN and made
+# exportArchive fall back to App Store profiles ("not an iOS Ad Hoc profile").
+APP_PROFILE="${APP_PROFILE:-699c208a-87ed-4d21-a5c1-2c4e9ad9a4b9}"
+PT_PROFILE="${PT_PROFILE:-a10c12ac-cbb5-4ec4-bfb4-1208f7c35252}"
 
 # Production team id + ASC key come from prod.env (gitignored, sourced above).
 # The team id is intentionally not committed.

--- a/scripts/upload-testflight.sh
+++ b/scripts/upload-testflight.sh
@@ -94,9 +94,14 @@ ASC_KEY_PATH="${ASC_KEY_PATH:-$HOME/AuthKey_9FU24T97RY.p8}"
 
 # App Store provisioning profile UUIDs already installed under
 # ~/Library/MobileDevice/Provisioning Profiles/. Override via env if
-# the profiles get rotated.
-APP_PROFILE="${APP_PROFILE:-1e7fc11e-15c4-4734-aca7-5c44014c396f}"
-PT_PROFILE="${PT_PROFILE:-7b6ce2a5-8843-47b7-991b-5a99f7db9ab7}"
+# the profiles get rotated. These must be App Store profiles for the
+# current com.tangzixiang.meow[.PacketTunnel] ids under team 32B45SMMQL
+# ("meow AppStore" / "meow PT AppStore"). The old UUIDs here were for the
+# retired io.github.madeye.meow ids on team SK4GFF6AHN; uploads only kept
+# working because exportArchive silently fell back to the right profile by
+# entitlement match — fragile, so point them at the correct ones.
+APP_PROFILE="${APP_PROFILE:-836e9b24-7a09-486f-ac1f-7957ec360d78}"
+PT_PROFILE="${PT_PROFILE:-7a37f4c1-5743-4f03-ac11-64a0fca57b4a}"
 
 SKIP_RUST_BUILD=0
 SKIP_ARCHIVE=0


### PR DESCRIPTION
## What

- **Bump embedded meow-rs** `1454ef24` → `619499b5` (latest `origin/main`): PR #217 *"fake-ip HTTPS/SVCB handling dual-stack-correct (ADR-0013)"* on top of the UDP NAT shard-guard deadlock fix. All 6 crate pins + `Cargo.lock`.
- **Release bump** to build `2026061502` (1.3.2) — uploaded, assigned to the *public testers* group, and submitted for Beta App Review.
- **Fix stale provisioning-profile defaults** in `scripts/build-adhoc.sh` (Ad Hoc) and `scripts/upload-testflight.sh` (App Store). Both pointed at retired `io.github.madeye.meow` / team `SK4GFF6AHN` profiles. Ad Hoc export failed outright ("not an iOS Ad Hoc profile"); App Store upload only survived via xcodebuild's entitlement-match fallback. Now point at the current `com.tangzixiang.meow[.PacketTunnel]` profiles under team `32B45SMMQL`.
- Add en-US + zh-Hans "What to Test" notes for `2026061502`.

## Path B attestation (admin rebase-merge)

Diff touches code paths (`Cargo.*`, `scripts/`, `project.yml`) but contains **no Swift or Rust source-logic changes** — only a dependency pin, a build number, shell-script defaults, and metadata.

- [x] `swiftformat --lint .` at repo root → **0/91 files require formatting**.
- [x] `swiftlint --strict` at repo root → **0 violations, 0 serious in 82 files**.
- [x] Rust: `scripts/build-rust.sh` → green (device + sim libs + xcframework rebuilt with `619499b5`). Full **Release archive built and uploaded to TestFlight end-to-end** (build `2026061502`, VALID on ASC) — strongest possible build-green signal. No Rust source changed, so `cargo test` is not exercised by this diff.
- [x] No Swift source changed → Swift test bundles (`MeowTests`/`MeowUITests`/`MeowIntegrationTests`) are not exercised by this diff.
- [x] `git diff origin/main...HEAD --stat` verified — 9 files, matches intent, no accidental additions.
- [x] Main CI baseline green (run 27519984469).

🤖 Generated with [Claude Code](https://claude.com/claude-code)