### PR TITLE
[codex] Refactor FFI traffic through meow listeners

### DIFF
--- a/App/Sources/Services/SubscriptionService.swift
+++ b/App/Sources/Services/SubscriptionService.swift
@@ -179,16 +179,18 @@ enum SubscriptionParser {
 }
 
 enum YamlPatcher {
+    private static let defaultDNSPort: Int32 = 1053
+
     static func applyMixedPort(_ yaml: String, port: Int) throws -> String {
         try yaml.withCString { src -> String in
-            let needed = meow_patch_config(src, Int32(port), nil, 0)
+            let needed = meow_patch_config(src, Int32(port), 0, defaultDNSPort, nil, 0)
             if needed < 0 {
                 throw SubscriptionError.conversionFailed(lastCoreError())
             }
             let cap = Int(needed) + 1
             var buffer = [CChar](repeating: 0, count: cap)
             let wrote = buffer.withUnsafeMutableBufferPointer { buf -> Int32 in
-                meow_patch_config(src, Int32(port), buf.baseAddress, Int32(cap))
+                meow_patch_config(src, Int32(port), 0, defaultDNSPort, buf.baseAddress, Int32(cap))
             }
             if wrote < 0 {
                 throw SubscriptionError.conversionFailed(lastCoreError())

--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -170,8 +170,9 @@ int meow_proxy_select(const char *group, const char *name);
 
 /**
  * Patch a Clash YAML config for iOS: strips `dns` and `subscriptions`;
- * pins `mixed-port`; injects a hardened `external-controller` (random
- * loopback port) + random bearer `secret`; injects `geox-url` when absent.
+ * pins `mixed-port`, `allow-lan`, listener bind address, and DNS listen
+ * socket; injects a hardened `external-controller` (random loopback port)
+ * + random bearer `secret`; injects `geox-url` when absent.
  * Writes NUL-terminated UTF-8 into `out`/`out_cap`. Returns bytes needed (excl
  * NUL) on success; callers allocate `ret + 1` and retry if `ret >= out_cap`.
  * Returns -1 on error (inspect `meow_core_last_error`).
@@ -180,7 +181,12 @@ int meow_proxy_select(const char *group, const char *name);
  * `source_yaml` must be NUL-terminated UTF-8. `out` must reference `out_cap`
  * bytes if non-NULL.
  */
-int meow_patch_config(const char *source_yaml, int mixed_port, char *out, int out_cap);
+int meow_patch_config(const char *source_yaml,
+                      int mixed_port,
+                      int allow_lan,
+                      int dns_port,
+                      char *out,
+                      int out_cap);
 
 /**
  * Start tun2socks with a Swift-owned egress callback. The ingest side is
@@ -248,9 +254,8 @@ int meow_tun_close_all_tcp_flows(void);
  * Set the TCP accept-side cap. Bounds the number of concurrent
  * `dispatch_tcp` tasks live at once, which is the dominant factor in
  * peak FFI RSS under burst (1000+ concurrent dispatches each carrying
- * per-flow Metadata, Box<dyn ProxyConn>, meow outbound dial state,
- * and netstack ring buffers can push the extension past the 50 MiB
- * jetsam cap). Default 128.
+ * SOCKS5 loopback streams, meow listener handler state, and netstack ring
+ * buffers can push the extension past the 50 MiB jetsam cap). Default 128.
  *
  * Takes effect on the next `meow_tun_start`. Calls during a live
  * tunnel are accepted but do not resize the running semaphore.

--- a/MeowIntegrationTests/EngineIntegration/EngineBootTests.swift
+++ b/MeowIntegrationTests/EngineIntegration/EngineBootTests.swift
@@ -129,6 +129,13 @@ private struct EngineFixture {
         let yaml = """
         mixed-port: 57890
         external-controller: 127.0.0.1:59090
+        dns:
+          enable: true
+          listen: 127.0.0.1:57953
+          enhanced-mode: fake-ip
+          fake-ip-range: 28.0.0.0/8
+          nameserver:
+            - 119.29.29.29
         mode: rule
         log-level: warning
         proxies: []

--- a/MeowIntegrationTests/EngineIntegration/TunBridgeTests.swift
+++ b/MeowIntegrationTests/EngineIntegration/TunBridgeTests.swift
@@ -161,6 +161,13 @@ private struct EngineFixture {
         let yaml = """
         mixed-port: 57891
         external-controller: 127.0.0.1:59091
+        dns:
+          enable: true
+          listen: 127.0.0.1:57954
+          enhanced-mode: fake-ip
+          fake-ip-range: 28.0.0.0/8
+          nameserver:
+            - 119.29.29.29
         mode: rule
         log-level: warning
         proxies: []

--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -5,12 +5,12 @@ import Yams
 /// actually loads. Mirrors the Android `MeowInstance.start` pipeline:
 ///
 ///   1. Remove user-managed `dns:` and `subscriptions:` blocks — the extension
-///      owns DNS (DoH + fake-ip) and the app owns subscription fetching.
+///      owns DNS (fake-ip + local listener) and the app owns subscription fetching.
 ///   2. Strip `secret:` so the REST API runs open on loopback — the app talks
 ///      to the engine via `MeowAPI(secret: "")` and would 401 if the user's
 ///      profile happened to ship a token.
-///   3. Pin `mixed-port` (defaults to 7890) so the tun2socks dispatcher and the
-///      REST API know the listener port without consulting the YAML.
+///   3. Pin `mixed-port` (defaults to 7890), `allow-lan`, `bind-address`, and
+///      a DNS listener so tun2socks and LAN clients can use meow's listeners.
 ///   4. Pin `external-controller: 127.0.0.1:9090` so the app can talk to the
 ///      engine's REST API over loopback.
 ///   5. Inject a `geox-url:` block (jsDelivr-hosted) when the user didn't
@@ -20,6 +20,7 @@ import Yams
 /// goes to `AppGroup.effectiveConfigURL`.
 public enum EffectiveConfigWriter {
     public static let defaultMixedPort = 7890
+    public static let defaultDNSPort = 1053
     public static let defaultExternalController = "127.0.0.1:9090"
 
     /// Matches the Android client's jsDelivr mirrors of the MetaCubeX databases.
@@ -56,7 +57,20 @@ public enum EffectiveConfigWriter {
         root.removeValue(forKey: "secret")
 
         let mixedPort = prefs.mixedPort > 0 ? prefs.mixedPort : defaultMixedPort
+        let bindAddress = prefs.allowLan ? "0.0.0.0" : "127.0.0.1"
         root["mixed-port"] = mixedPort
+        root["allow-lan"] = prefs.allowLan
+        root["bind-address"] = bindAddress
+        root["dns"] = [
+            "enable": true,
+            "listen": "\(bindAddress):\(defaultDNSPort)",
+            "enhanced-mode": "fake-ip",
+            "fake-ip-range": "28.0.0.0/8",
+            "nameserver": [
+                "119.29.29.29",
+                "223.5.5.5",
+            ],
+        ]
         root["external-controller"] = defaultExternalController
 
         if root["geox-url"] == nil {

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -6,7 +6,7 @@ import Yams
 @Suite("EffectiveConfigWriter")
 struct EffectiveConfigWriterTests {
     @Test
-    func `strips dns and subscriptions top-level blocks`() throws {
+    func `replaces dns and strips subscriptions top-level block`() throws {
         let source = """
         dns:
           enable: true
@@ -23,9 +23,12 @@ struct EffectiveConfigWriterTests {
             password: p
         """
         let out = try EffectiveConfigWriter.patch(sourceYAML: source, prefs: Preferences())
-        #expect(!out.contains("nameserver"))
         #expect(!out.contains("subscriptions:"))
         #expect(out.contains("proxies:"))
+        let parsed = try Yams.load(yaml: out) as? [String: Any]
+        let dns = parsed?["dns"] as? [String: Any]
+        #expect(dns?["listen"] as? String == "127.0.0.1:1053")
+        #expect((dns?["nameserver"] as? [String]) == ["119.29.29.29", "223.5.5.5"])
     }
 
     @Test
@@ -54,6 +57,18 @@ struct EffectiveConfigWriterTests {
         let out = try EffectiveConfigWriter.patch(sourceYAML: source, prefs: prefs)
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         #expect(parsed?["mixed-port"] as? Int == 17890)
+    }
+
+    @Test
+    func `pins allow-lan and bind-address from preferences`() throws {
+        var prefs = Preferences()
+        prefs.allowLan = true
+        let out = try EffectiveConfigWriter.patch(sourceYAML: "proxies: []\n", prefs: prefs)
+        let parsed = try Yams.load(yaml: out) as? [String: Any]
+        let dns = parsed?["dns"] as? [String: Any]
+        #expect(parsed?["allow-lan"] as? Bool == true)
+        #expect(parsed?["bind-address"] as? String == "0.0.0.0")
+        #expect(dns?["listen"] as? String == "0.0.0.0:1053")
     }
 
     @Test

--- a/MeowTests/Parsing/SubscriptionParserTests.swift
+++ b/MeowTests/Parsing/SubscriptionParserTests.swift
@@ -5,12 +5,15 @@ import Testing
 @Suite("YAML patcher", .tags(.parsing))
 struct YamlPatcherTests {
     @Test
-    func `strips subscriptions block and sets mixed-port`() throws {
+    func `strips subscriptions block and pins listener settings`() throws {
         let data = try loadFixture("clash_minimal")
         let yaml = try #require(String(data: data, encoding: .utf8))
         let patched = try YamlPatcher.applyMixedPort(yaml, port: 7890)
         #expect(!patched.contains("subscriptions:"))
         #expect(patched.contains("mixed-port: 7890"))
+        #expect(patched.contains("allow-lan: false"))
+        #expect(patched.contains("bind-address: 127.0.0.1"))
+        #expect(patched.contains("listen: 127.0.0.1:1053"))
     }
 }
 

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -34,6 +34,7 @@ static const NSTimeInterval kReliefCooldownS  = 60.0;
 // thrashing the allocator.
 static const int64_t kTeardownBurstFlows       = 16;
 static const NSTimeInterval kTeardownCooldownS = 5.0;
+static const int kLocalDNSPort                 = 1053;
 
 @implementation MWTunnelEngine {
     NEPacketTunnelFlow *_flow;
@@ -398,7 +399,7 @@ static const NSTimeInterval kTeardownCooldownS = 5.0;
     if (!source) return NO;
 
     const char *src = source.UTF8String;
-    int needed = meow_patch_config(src, (int)prefs.mixedPort, NULL, 0);
+    int needed = meow_patch_config(src, (int)prefs.mixedPort, prefs.allowLan ? 1 : 0, kLocalDNSPort, NULL, 0);
     if (needed < 0) {
         NSString *msg = [self lastRustError] ?: @"config patch failed";
         if (error) *error = [NSError errorWithDomain:@"MWTunnelEngine"
@@ -414,7 +415,7 @@ static const NSTimeInterval kTeardownCooldownS = 5.0;
                                             userInfo:@{NSLocalizedDescriptionKey: @"out of memory"}];
         return NO;
     }
-    meow_patch_config(src, (int)prefs.mixedPort, buf, needed + 1);
+    meow_patch_config(src, (int)prefs.mixedPort, prefs.allowLan ? 1 : 0, kLocalDNSPort, buf, needed + 1);
     NSString *patched = [NSString stringWithUTF8String:buf];
     free(buf);
 

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -265,7 +265,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
+ "shlex 1.3.0",
  "syn",
  "which",
 ]
@@ -279,20 +279,20 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 2.1.2",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake2"
@@ -416,14 +416,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -709,9 +709,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -726,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -796,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1038,9 +1035,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1153,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1198,9 +1195,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1250,7 +1247,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1423,6 +1420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,13 +1495,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1573,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -1653,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -1669,7 +1674,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 dependencies = [
  "axum",
  "base64",
@@ -1701,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1723,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1756,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1798,6 +1803,7 @@ dependencies = [
  "meow-common",
  "meow-config",
  "meow-dns",
+ "meow-listener",
  "meow-proxy",
  "meow-tunnel",
  "oslog",
@@ -1817,9 +1823,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "meow-listener"
+version = "0.14.0"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
+dependencies = [
+ "base64",
+ "libc",
+ "meow-common",
+ "meow-trie",
+ "meow-tunnel",
+ "smallvec",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "meow-proxy"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1843,6 +1864,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shadowsocks",
+ "smallvec",
  "smol_str",
  "socket2 0.5.10",
  "tokio",
@@ -1854,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1871,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 dependencies = [
  "async-trait",
  "base64",
@@ -1897,12 +1919,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=619499b51dcfb7882f64e819d883f22182997148#619499b51dcfb7882f64e819d883f22182997148"
+source = "git+https://github.com/madeye/meow-rs?rev=7e47ce60b65fb30837670e84d05bdcde8bf4813b#7e47ce60b65fb30837670e84d05bdcde8bf4813b"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1936,9 +1958,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1970,7 +1992,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2213,7 +2235,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2250,7 +2272,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2362,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2385,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2485,7 +2507,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2498,7 +2520,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2729,7 +2751,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "shadowsocks-crypto",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "spin",
  "thiserror 2.0.18",
  "tokio",
@@ -2777,6 +2799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,9 +2844,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -2845,12 +2873,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2951,7 +2979,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3005,12 +3033,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3020,15 +3047,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3071,7 +3098,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3120,7 +3147,7 @@ dependencies = [
  "log",
  "once_cell",
  "pin-project",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "windows-sys 0.60.2",
 ]
@@ -3361,9 +3388,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3431,9 +3458,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3480,9 +3507,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -3498,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3511,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3521,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3531,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3544,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -3587,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3666,7 +3693,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3739,6 +3766,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4001,9 +4037,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4024,18 +4060,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4065,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "meow-ios-ffi"
 version = "0.1.0"
 edition = "2021"
-description = "meow-rs engine + tun2socks for meow-ios — C ABI, no Go, no JNI. DNS is delegated in-process to meow's resolver in fake-IP mode."
+description = "meow-rs engine + tun2socks for meow-ios — C ABI, no Go, no JNI. TCP/UDP dispatch through local meow listeners."
 
 [lib]
 # `staticlib` is the iOS xcframework consumer; `rlib` exists so the
@@ -44,9 +44,9 @@ oslog = { version = "0.2", default-features = false, features = ["logger"] }
 
 # `rustls` is declared so `engine::start` can install the ring crypto
 # provider once at process init for any HTTPS the meow engine itself
-# opens (subscription fetch, HTTPS outbound, …). The tun2socks UDP/53
-# intercept defers parse/serialize to `meow_dns::DnsServer::handle_query`,
-# so this is the only direct rustls consumer.
+# opens (subscription fetch, HTTPS outbound, …). The tun2socks UDP/53 path
+# delegates DNS parse/serialize to the local meow-dns listener, so this is
+# the only direct rustls consumer.
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
@@ -70,7 +70,7 @@ lwip = "0.3"
 #
 # HEAD: 619499b5 — fake-ip HTTPS/SVCB dual-stack-correct (ADR-0013, meow-rs#217)
 # on top of the UDP NAT-table shard-guard deadlock fix (1454ef24).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "7e47ce60b65fb30837670e84d05bdcde8bf4813b" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -78,11 +78,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "619499b51dcfb7882f64e819d883f22182997148" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "7e47ce60b65fb30837670e84d05bdcde8bf4813b", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "7e47ce60b65fb30837670e84d05bdcde8bf4813b" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "7e47ce60b65fb30837670e84d05bdcde8bf4813b" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "7e47ce60b65fb30837670e84d05bdcde8bf4813b", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "7e47ce60b65fb30837670e84d05bdcde8bf4813b" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "7e47ce60b65fb30837670e84d05bdcde8bf4813b" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -1,16 +1,11 @@
-//! Embedded meow-rs engine. Owns the REST API task and holds the
-//! `Tunnel` used directly (in-process) by `tun2socks` — there is no local
-//! SOCKS listener; TCP flows hop Rust-to-Rust through a shared
-//! `Arc<TunnelInner>` rather than through a loopback socket.
+//! Embedded meow-rs engine. Owns the REST API task plus the local mixed and
+//! DNS listeners that `tun2socks` dials through loopback.
 //!
-//! DNS is delegated end-to-end to meow's resolver. The pinned `dns:` block
-//! injected below puts the resolver in fake-IP mode with the FFI's chosen
-//! CIDR (`28.0.0.0/8`) and no listening socket (`listen: ""`). The tun2socks
-//! UDP/53 intercept hands every in-TUN DNS datagram straight to
-//! `meow_dns::DnsServer::handle_query`, which both synthesises the fake-IP
-//! answer and owns the reverse mapping that `meow_tunnel::pre_handle_metadata`
-//! consults on the TCP/UDP dispatch path. The engine spawns no separate DNS
-//! task and binds no DNS socket.
+//! DNS is delegated end-to-end to meow's resolver. The pinned `dns:` block from
+//! `meow_patch_config` puts the resolver in fake-IP mode with the FFI's chosen
+//! CIDR (`28.0.0.0/8`) and a local DNS listen socket. The tun2socks UDP/53
+//! path sends non-blocked DNS queries to that listener, so synthesis and
+//! fake-IP reverse mapping stay owned by meow-dns.
 //!
 //! Lifecycle: `start(config_path)` spawns the REST API on the meow-engine
 //! tokio runtime and keeps its `JoinHandle` in `EngineState`. `stop()` aborts
@@ -23,9 +18,12 @@ use dashmap::DashMap;
 use meow_api::log_stream::{LogBroadcastLayer, LogMessage};
 use meow_api::ApiServer;
 use meow_config::{load_config, load_config_from_str, Config};
+use meow_dns::DnsServer;
+use meow_listener::{MixedListener, SnifferRuntime};
 use meow_tunnel::{Statistics, Tunnel};
 use parking_lot::{Mutex, RwLock};
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::{Arc, Once, OnceLock};
 use tokio::sync::broadcast;
@@ -36,10 +34,24 @@ use tracing_subscriber::prelude::*;
 
 use crate::logging::LogForwardLayer;
 
+fn loopback_addr(port: u16) -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+}
+
+fn bind_socket_addr(listen: &str, port: u16) -> Result<SocketAddr> {
+    let ip: IpAddr = listen
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid bind address '{listen}': {e}"))?;
+    Ok(SocketAddr::new(ip, port))
+}
+
 struct EngineState {
     stats: Arc<Statistics>,
     tunnel: Tunnel,
+    mixed_dial_addr: Option<SocketAddr>,
+    dns_dial_addr: Option<SocketAddr>,
     api_task: Option<JoinHandle<()>>,
+    listener_tasks: Vec<JoinHandle<()>>,
 }
 
 fn slot() -> &'static Mutex<Option<EngineState>> {
@@ -51,18 +63,10 @@ fn install_tls_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
-/// Strip the shorthand listener ports and explicit `listeners:` array from a
-/// raw config YAML. iOS dispatches TCP flows in-process via the netstack →
-/// `meow_tunnel` Rust-to-Rust hop (no SOCKS loopback) and answers DNS
-/// inline by handing every in-TUN UDP/53 datagram to
-/// `meow_dns::DnsServer::handle_query` (no bound resolver port); there is
-/// no loopback listener and no bound port. Upstream's `build_named_listeners`
-/// (meow-config/src/lib.rs) hard-errors on duplicate ports (ADR-0002
-/// Class A) — e.g. "port 7890 already used by listener 'mixed'" — so a
-/// user YAML combining `mixed-port: 7890` with a listeners entry on the
-/// same port would fail parse-time validation even though iOS never
-/// actually binds either. This strip enforces the no-listener constraint
-/// architecturally at the FFI boundary, regardless of YAML content.
+/// Normalize the effective YAML before `load_config`: iOS owns exactly one
+/// mixed listener (`mixed-port`) and exactly one DNS listener (`dns.listen`).
+/// Drop other listener shorthands / explicit listener arrays so subscriptions
+/// cannot create duplicate ports or unexpected inbound sockets.
 ///
 /// Operates on a generic `serde_yaml::Value` rather than projecting through
 /// `RawConfig`: the latter has no `#[serde(flatten)]` catch-all and no
@@ -70,13 +74,12 @@ fn install_tls_provider() {
 /// silently drop any top-level key it doesn't model (`tun:`, `profile:`,
 /// `experimental:`, `global-client-fingerprint`, `unified-delay`, etc.)
 /// and pollute the output with `key: null` for every unset Option.
-fn strip_listener_fields(yaml: &str) -> Result<String> {
+fn prepare_ios_config(yaml: &str) -> Result<String> {
     let mut doc: serde_yaml::Value = serde_yaml::from_str(yaml).context("parsing config YAML")?;
     if let serde_yaml::Value::Mapping(m) = &mut doc {
         for key in [
             "port",
             "socks-port",
-            "mixed-port",
             "tproxy-port",
             "listeners",
             // Drop the entire `sniffer:` block. meow's
@@ -89,63 +92,11 @@ fn strip_listener_fields(yaml: &str) -> Result<String> {
             // resolution time. Strip at the FFI boundary so user
             // subscriptions can't re-enable it.
             "sniffer",
-            // Drop any user-supplied `dns:` block. iOS pins its own resolver
-            // configuration via `pinned_dns_block` below so the resolver is
-            // always in fake-IP mode with the FFI's chosen CIDR and known-good
-            // CN upstreams, regardless of subscription content.
-            "dns",
         ] {
             m.remove(serde_yaml::Value::String(key.to_string()));
         }
-        // Inject the pinned DNS config last so it always wins over any
-        // residue we just removed.
-        if let serde_yaml::Value::Mapping(dns) = pinned_dns_block() {
-            m.insert(
-                serde_yaml::Value::String("dns".into()),
-                serde_yaml::Value::Mapping(dns),
-            );
-        }
     }
     serde_yaml::to_string(&doc).context("serializing stripped config YAML")
-}
-
-/// Pinned DNS block injected into every engine config. Configures meow's
-/// resolver in fake-IP mode with the FFI's chosen CIDR; the tun2socks
-/// UDP/53 intercept answers AAAA itself (NOERROR-empty, unconditionally)
-/// and hands in-TUN A queries straight to
-/// `meow_dns::DnsServer::handle_query`, so this block is the single source
-/// of truth for synthesis, reverse mapping, hosts / NXDOMAIN, and
-/// upstream nameserver selection.
-///
-/// The nameserver set is restricted to CN-side resolvers because meow's
-/// `query_pool` races every entry in parallel ("first response wins"), and
-/// mixing a global anycast resolver into the same pool lets it win the race
-/// from outside CN — returning the global / SG / HK PoP for split-horizon
-/// hosts like xiaohongshu.com, which then misses the GEOIP-driven CN bypass
-/// inside meow's rule engine.
-///
-///   * 119.29.29.29 (DNSPod / Tencent) — fast inside CN, also reachable
-///     externally; primary for split-horizon hosts that need the CN view.
-///   * 223.5.5.5    (Alibaba PublicDNS) — secondary CN-side nameserver.
-///
-/// If a global fallback is ever needed for sites the CN resolvers refuse to
-/// answer, the right place to wire it is meow-rs's `fallback:` block
-/// (which only runs when the primary pool yields nothing or the answer
-/// trips `fallback-filter`), not the primary `nameserver:` pool.
-///
-/// `listen: ""` keeps meow from binding its own UDP/53 socket — the FFI
-/// owns the in-TUN intercept and calls `DnsServer::handle_query` directly.
-fn pinned_dns_block() -> serde_yaml::Value {
-    let yaml = r#"
-enable: true
-listen: ""
-enhanced-mode: fake-ip
-fake-ip-range: 28.0.0.0/8
-nameserver:
-  - 119.29.29.29
-  - 223.5.5.5
-"#;
-    serde_yaml::from_str(yaml).expect("pinned DNS YAML is a compile-time constant")
 }
 
 /// RAII handle that removes a file on drop. Used so the sibling
@@ -170,7 +121,7 @@ impl Drop for TempFileGuard {
 fn load_stripped_config(config_path: &str) -> Result<Config> {
     let original = std::fs::read_to_string(config_path)
         .with_context(|| format!("reading config from {config_path}"))?;
-    let stripped = strip_listener_fields(&original)?;
+    let stripped = prepare_ios_config(&original)?;
     let stripped_path = PathBuf::from(format!("{config_path}.ios-stripped.yaml"));
     std::fs::write(&stripped_path, stripped)
         .with_context(|| format!("writing stripped config to {}", stripped_path.display()))?;
@@ -218,7 +169,7 @@ fn load_stripped_config_from_str(yaml: &str) -> Result<Config> {
 /// that path `load_providers` runs against a non-nested context
 /// (file-backed `load_config` uses a different load path).
 fn strip_for_validation(yaml: &str) -> Result<String> {
-    let listener_stripped = strip_listener_fields(yaml)?;
+    let listener_stripped = prepare_ios_config(yaml)?;
     let mut doc: serde_yaml::Value =
         serde_yaml::from_str(&listener_stripped).context("parsing stripped YAML for validation")?;
     if let serde_yaml::Value::Mapping(m) = &mut doc {
@@ -285,10 +236,6 @@ pub fn start(config_path: &str) -> Result<()> {
     install_tls_provider();
     install_tracing_subscriber();
 
-    // Strip listener shorthand + `listeners:` from the raw YAML before
-    // load_config parses it — upstream's `build_named_listeners` rejects
-    // duplicate ports (ADR-0002 Class A) even though iOS never binds any
-    // of them. See `load_stripped_config` doc for the constraint rationale.
     let cfg = load_stripped_config(config_path)?;
     let raw_config = Arc::new(RwLock::new(cfg.raw.clone()));
 
@@ -338,6 +285,44 @@ pub fn start(config_path: &str) -> Result<()> {
     // re-introduce a fetch — but in a memory-bounded form (streamed to
     // disk, no full-body buffer) suitable for the NE budget.
 
+    let mut listener_tasks = Vec::new();
+    let mixed_dial_addr = cfg.listeners.mixed_port.map(loopback_addr);
+    let dns_dial_addr = cfg.dns.listen_addr.map(|addr| loopback_addr(addr.port()));
+
+    if let Some(listen_addr) = cfg.dns.listen_addr {
+        let dns_server = DnsServer::new(resolver.clone(), listen_addr);
+        listener_tasks.push(crate::get_engine_runtime().spawn(async move {
+            if let Err(e) = dns_server.run().await {
+                error!("DNS server error: {}", e);
+            }
+        }));
+    }
+
+    let sniffer_runtime = Arc::new(SnifferRuntime::new(cfg.sniffer.clone()));
+    let auth = cfg.auth.clone();
+    for nl in &cfg.listeners.named {
+        let addr = bind_socket_addr(&nl.listen, nl.port)
+            .with_context(|| format!("listener '{}'", nl.name))?;
+        match nl.listener_type {
+            meow_config::ListenerType::Mixed
+            | meow_config::ListenerType::Http
+            | meow_config::ListenerType::Socks5 => {
+                let listener = MixedListener::new(tunnel.clone(), addr, nl.name.clone())
+                    .with_sniffer(sniffer_runtime.clone())
+                    .with_auth(auth.clone())
+                    .with_max_connections(nl.max_connections);
+                listener_tasks.push(crate::get_engine_runtime().spawn(async move {
+                    if let Err(e) = listener.run().await {
+                        error!("Mixed listener error: {}", e);
+                    }
+                }));
+            }
+            meow_config::ListenerType::TProxy => {
+                // iOS deliberately does not start transparent-proxy listeners.
+            }
+        }
+    }
+
     // `ApiServer::new` grew from 5 to 9 parameters to serve the new
     // `/providers/*`, `/rules`, `/listeners`, and `/logs` routes. Build the
     // required shapes from the loaded Config.
@@ -352,9 +337,8 @@ pub fn start(config_path: &str) -> Result<()> {
     let log_tx = log_broadcast_tx().clone();
 
     // No FFI-side fake-IP pool, no FFI-side CN-IP table, no resolver hand-off:
-    // meow's own fake-IP pool (configured by `pinned_dns_block`) owns
-    // synthesis + reverse mapping, and the tun2socks UDP/53 intercept fetches
-    // the resolver lazily through `engine::tunnel()?.resolver()`.
+    // meow's own fake-IP pool owns synthesis + reverse mapping behind the DNS
+    // listener that tun2socks dials.
 
     let api_task = cfg.api.external_controller.map(|addr| {
         let api_server = ApiServer::new(
@@ -375,12 +359,18 @@ pub fn start(config_path: &str) -> Result<()> {
         })
     });
 
-    info!("meow-rs engine running (in-process dispatch)");
+    info!(
+        "meow-rs engine running (mixed={:?}, dns={:?})",
+        mixed_dial_addr, dns_dial_addr
+    );
 
     *slot().lock() = Some(EngineState {
         stats,
         tunnel,
+        mixed_dial_addr,
+        dns_dial_addr,
         api_task,
+        listener_tasks,
     });
     Ok(())
 }
@@ -401,8 +391,10 @@ pub fn stop() {
         h.abort();
         let _ = runtime.block_on(h);
     }
-    // DNS owns no background task — `DnsServer::handle_query` runs inline on
-    // the tun2socks UDP/53 intercept path, so there's nothing to abort here.
+    for h in state.listener_tasks {
+        h.abort();
+        let _ = runtime.block_on(h);
+    }
     info!("meow-rs engine stopped");
 }
 
@@ -422,6 +414,14 @@ pub fn tunnel() -> Option<Tunnel> {
     slot().lock().as_ref().map(|s| s.tunnel.clone())
 }
 
+pub fn mixed_dial_addr() -> Option<SocketAddr> {
+    slot().lock().as_ref().and_then(|s| s.mixed_dial_addr)
+}
+
+pub fn dns_dial_addr() -> Option<SocketAddr> {
+    slot().lock().as_ref().and_then(|s| s.dns_dial_addr)
+}
+
 pub fn validate(yaml: &str) -> Result<()> {
     install_tls_provider();
     // Match start()'s strip behaviour so the editor doesn't surface
@@ -432,10 +432,11 @@ pub fn validate(yaml: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::strip_listener_fields;
+    use super::{load_stripped_config_from_str, prepare_ios_config};
+    use std::net::SocketAddr;
 
     #[test]
-    fn strip_removes_listener_keys_only() {
+    fn prepare_removes_extra_listener_keys_only() {
         let yaml = r#"
 port: 7890
 socks-port: 7891
@@ -453,45 +454,22 @@ sniffer:
 mode: rule
 log-level: info
 "#;
-        let out = strip_listener_fields(yaml).expect("strip ok");
+        let out = prepare_ios_config(yaml).expect("strip ok");
         let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
         let m = doc.as_mapping().unwrap();
-        for k in [
-            "port",
-            "socks-port",
-            "mixed-port",
-            "tproxy-port",
-            "listeners",
-            "sniffer",
-        ] {
+        for k in ["port", "socks-port", "tproxy-port", "listeners", "sniffer"] {
             assert!(
                 !m.contains_key(serde_yaml::Value::String(k.into())),
                 "{k} should have been stripped",
             );
         }
+        assert_eq!(m.get("mixed-port").and_then(|v| v.as_i64()), Some(7892));
         assert_eq!(m.get("mode").and_then(|v| v.as_str()), Some("rule"));
         assert_eq!(m.get("log-level").and_then(|v| v.as_str()), Some("info"));
-
-        // Pinned DNS block must always be present after strip, with the
-        // CN-side nameservers in order. The set is intentionally
-        // CN-only — see `pinned_dns_block`'s doc comment on why a global
-        // resolver (1.1.1.1 etc.) is *not* part of this pool.
-        let dns = m
-            .get(serde_yaml::Value::String("dns".into()))
-            .and_then(|v| v.as_mapping())
-            .expect("pinned dns block injected");
-        let ns: Vec<&str> = dns
-            .get(serde_yaml::Value::String("nameserver".into()))
-            .and_then(|v| v.as_sequence())
-            .unwrap()
-            .iter()
-            .map(|v| v.as_str().unwrap())
-            .collect();
-        assert_eq!(ns, vec!["119.29.29.29", "223.5.5.5"]);
     }
 
     #[test]
-    fn user_dns_is_replaced_by_pinned() {
+    fn user_dns_survives_runtime_prepare() {
         let yaml = r#"
 dns:
   enable: true
@@ -500,7 +478,7 @@ dns:
     - 9.9.9.9
 mode: rule
 "#;
-        let out = strip_listener_fields(yaml).expect("strip ok");
+        let out = prepare_ios_config(yaml).expect("strip ok");
         let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
         let dns = doc
             .as_mapping()
@@ -517,8 +495,40 @@ mode: rule
             .collect();
         assert_eq!(
             ns,
-            vec!["119.29.29.29", "223.5.5.5"],
-            "user nameservers must not survive the strip+inject"
+            vec!["8.8.8.8", "9.9.9.9"],
+            "prepare_ios_config must not rewrite dns; meow_patch_config owns pinning"
+        );
+    }
+
+    #[test]
+    fn stripped_config_loads_mixed_and_dns_listeners() {
+        let yaml = r#"
+mixed-port: 23456
+allow-lan: true
+bind-address: 0.0.0.0
+dns:
+  enable: true
+  listen: 0.0.0.0:1053
+  enhanced-mode: fake-ip
+  fake-ip-range: 28.0.0.0/8
+  nameserver:
+    - 119.29.29.29
+rules:
+  - MATCH,DIRECT
+"#;
+        let cfg = load_stripped_config_from_str(yaml).expect("config loads");
+        assert_eq!(cfg.listeners.mixed_port, Some(23456));
+        let mixed = cfg
+            .listeners
+            .named
+            .iter()
+            .find(|listener| listener.name == "mixed")
+            .expect("mixed listener is auto-created from mixed-port");
+        assert_eq!(mixed.listen, "0.0.0.0");
+        assert_eq!(mixed.port, 23456);
+        assert_eq!(
+            cfg.dns.listen_addr,
+            Some("0.0.0.0:1053".parse::<SocketAddr>().unwrap())
         );
     }
 
@@ -543,10 +553,10 @@ proxies:
   - name: p1
     type: direct
 "#;
-        let out = strip_listener_fields(yaml).expect("strip ok");
+        let out = prepare_ios_config(yaml).expect("strip ok");
         let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
         let m = doc.as_mapping().unwrap();
-        assert!(!m.contains_key(serde_yaml::Value::String("mixed-port".into())));
+        assert!(m.contains_key(serde_yaml::Value::String("mixed-port".into())));
         for k in [
             "tun",
             "profile",
@@ -576,8 +586,8 @@ proxies:
     #[test]
     fn strip_is_idempotent_on_clean_config() {
         let yaml = "mode: rule\nlog-level: info\n";
-        let once = strip_listener_fields(yaml).expect("strip ok");
-        let twice = strip_listener_fields(&once).expect("strip ok");
+        let once = prepare_ios_config(yaml).expect("strip ok");
+        let twice = prepare_ios_config(&once).expect("strip ok");
         assert_eq!(once, twice);
     }
 
@@ -675,7 +685,7 @@ mod config_parse_tests {
     fn fixture_parses_with_all_proxies_and_groups() {
         // Strip listener keys via the production helper (value-based) so the
         // regression test also exercises the strip path.
-        let stripped = super::strip_listener_fields(FIXTURE).expect("strip ok");
+        let stripped = super::prepare_ios_config(FIXTURE).expect("strip ok");
         let rt = tokio::runtime::Runtime::new().expect("tokio rt");
         let cfg = rt
             .block_on(meow_config::load_config_from_str(&stripped))

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -3,26 +3,20 @@
 //! `MeowCore.xcframework`.
 //!
 //! Embeds the meow-rs proxy engine and the tun2socks layer in one static
-//! library. Both TCP and UDP flows are dispatched in-process:
+//! library. TCP and non-DNS UDP flows now go through the same local mixed
+//! listener that LAN clients use:
 //!
-//!   NEPacketTunnelFlow ⇆ mpsc ⇆ netstack-smoltcp ⇆ meow_tunnel::{tcp,udp}::handle_*
-//!                                                              ↓
-//!                                          rules / proxies / DNS / REST API
+//!   NEPacketTunnelFlow ⇆ mpsc ⇆ netstack-smoltcp ⇆ SOCKS5 loopback ⇆ meow-listener
+//!                                                                          ↓
+//!                                                      rules / proxies / DNS / REST API
 //!
-//! No SOCKS5 loopback sits between tun2socks and the engine; the staticlib
-//! owns separate tokio runtimes for the packet/netstack driver and for meow
-//! engine work so lwIP backpressure cannot starve the REST/API/proxy workers.
-//! DNS is delegated end-to-end to meow's resolver running in fake-IP mode: the
-//! tun2socks
-//! UDP/53 intercept answers AAAA queries NOERROR-empty itself (forcing
-//! clients onto the proxied IPv4 fake-IP path) and hands A queries straight
-//! to `meow_dns::DnsServer::handle_query`, which synthesises the fake-IP,
-//! owns the reverse mapping, and answers hosts / NXDOMAIN consistently.
-//! The TCP and UDP dispatch paths then pass the literal fake-IP destination
-//! to `meow_tunnel`, whose `pre_handle_metadata` reverses it back to the
-//! original hostname before rule matching. The FFI no longer carries its
-//! own fake-IP pool, china-DNS split-horizon, CN-IP table, DoH cache, or
-//! in-FFI TCP-DNS client.
+//! The staticlib owns separate tokio runtimes for the packet/netstack driver
+//! and for meow engine work so lwIP backpressure cannot starve the
+//! REST/API/proxy workers. DNS is delegated to a local meow-dns UDP listener
+//! running in fake-IP mode: the tun2socks UDP/53 path still answers AAAA and
+//! HTTP/3-blocked HTTPS/SVCB queries NOERROR-empty itself, then sends other DNS
+//! queries to the listener. The FFI no longer carries its own fake-IP pool,
+//! china-DNS split-horizon, CN-IP table, DoH cache, or in-FFI TCP-DNS client.
 
 mod diagnostics;
 mod engine;
@@ -611,8 +605,9 @@ fn random_port() -> u16 {
 // ---------------------------------------------------------------------------
 
 /// Patch a Clash YAML config for iOS: strips `dns` and `subscriptions`;
-/// pins `mixed-port`; injects a hardened `external-controller` (random
-/// loopback port) + random bearer `secret`; injects `geox-url` when absent.
+/// pins `mixed-port`, `allow-lan`, listener bind address, and DNS listen
+/// socket; injects a hardened `external-controller` (random loopback port)
+/// + random bearer `secret`; injects `geox-url` when absent.
 /// Writes NUL-terminated UTF-8 into `out`/`out_cap`. Returns bytes needed (excl
 /// NUL) on success; callers allocate `ret + 1` and retry if `ret >= out_cap`.
 /// Returns -1 on error (inspect `meow_core_last_error`).
@@ -624,6 +619,8 @@ fn random_port() -> u16 {
 pub unsafe extern "C" fn meow_patch_config(
     source_yaml: *const c_char,
     mixed_port: c_int,
+    allow_lan: c_int,
+    dns_port: c_int,
     out: *mut c_char,
     out_cap: c_int,
 ) -> c_int {
@@ -658,9 +655,50 @@ pub unsafe extern "C" fn meow_patch_config(
     } else {
         7890
     };
+    let dns_port = if dns_port > 0 { dns_port as i64 } else { 1053 };
+    let bind_addr = if allow_lan != 0 {
+        "0.0.0.0"
+    } else {
+        "127.0.0.1"
+    };
     root.insert(
         serde_yaml::Value::String("mixed-port".into()),
         serde_yaml::Value::Number(port.into()),
+    );
+    root.insert(
+        serde_yaml::Value::String("allow-lan".into()),
+        serde_yaml::Value::Bool(allow_lan != 0),
+    );
+    root.insert(
+        serde_yaml::Value::String("bind-address".into()),
+        serde_yaml::Value::String(bind_addr.into()),
+    );
+
+    let mut dns = serde_yaml::Mapping::new();
+    for (k, v) in [
+        ("enable", serde_yaml::Value::Bool(true)),
+        (
+            "listen",
+            serde_yaml::Value::String(format!("{bind_addr}:{dns_port}")),
+        ),
+        ("enhanced-mode", serde_yaml::Value::String("fake-ip".into())),
+        (
+            "fake-ip-range",
+            serde_yaml::Value::String("28.0.0.0/8".into()),
+        ),
+    ] {
+        dns.insert(serde_yaml::Value::String(k.into()), v);
+    }
+    dns.insert(
+        serde_yaml::Value::String("nameserver".into()),
+        serde_yaml::Value::Sequence(vec![
+            serde_yaml::Value::String("119.29.29.29".into()),
+            serde_yaml::Value::String("223.5.5.5".into()),
+        ]),
+    );
+    root.insert(
+        serde_yaml::Value::String("dns".into()),
+        serde_yaml::Value::Mapping(dns),
     );
 
     // Harden the meow external-controller. It binds on loopback, but iOS
@@ -720,7 +758,7 @@ pub unsafe extern "C" fn meow_patch_config(
 }
 
 // ---------------------------------------------------------------------------
-// tun2socks (NEPacketTunnelFlow bridge) — dispatches in-process into engine
+// tun2socks (NEPacketTunnelFlow bridge) — dispatches through local listeners
 // ---------------------------------------------------------------------------
 
 /// C-compatible egress callback. Called from the tun2socks tokio runtime
@@ -819,9 +857,8 @@ pub extern "C" fn meow_tun_close_all_tcp_flows() -> c_int {
 /// Set the TCP accept-side cap. Bounds the number of concurrent
 /// `dispatch_tcp` tasks live at once, which is the dominant factor in
 /// peak FFI RSS under burst (1000+ concurrent dispatches each carrying
-/// per-flow Metadata, Box<dyn ProxyConn>, meow outbound dial state,
-/// and netstack ring buffers can push the extension past the 50 MiB
-/// jetsam cap). Default 128.
+/// SOCKS5 loopback streams, meow listener handler state, and netstack ring
+/// buffers can push the extension past the 50 MiB jetsam cap). Default 128.
 ///
 /// Takes effect on the next `meow_tun_start`. Calls during a live
 /// tunnel are accepted but do not resize the running semaphore.
@@ -978,4 +1015,68 @@ pub extern "C" fn meow_tun_block_http3() -> c_int {
 #[no_mangle]
 pub extern "C" fn meow_resident_bytes() -> u64 {
     rss::resident_bytes().unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::meow_patch_config;
+    use std::ffi::CString;
+
+    fn patch_config(yaml: &str, mixed_port: i32, allow_lan: i32, dns_port: i32) -> String {
+        let source = CString::new(yaml).expect("fixture yaml has no nul");
+        let needed = unsafe {
+            meow_patch_config(
+                source.as_ptr(),
+                mixed_port,
+                allow_lan,
+                dns_port,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        assert!(needed > 0);
+        let mut out = vec![0i8; needed as usize + 1];
+        let wrote = unsafe {
+            meow_patch_config(
+                source.as_ptr(),
+                mixed_port,
+                allow_lan,
+                dns_port,
+                out.as_mut_ptr(),
+                out.len() as i32,
+            )
+        };
+        assert_eq!(wrote, needed);
+        let bytes = out
+            .into_iter()
+            .take(wrote as usize)
+            .map(|b| b as u8)
+            .collect::<Vec<_>>();
+        String::from_utf8(bytes).expect("patched yaml is utf8")
+    }
+
+    #[test]
+    fn patch_config_pins_lan_mixed_and_dns_listener() {
+        let patched = patch_config(
+            r#"
+mixed-port: 1
+allow-lan: false
+bind-address: 127.0.0.1
+dns:
+  enable: false
+subscriptions:
+  old: {}
+rules:
+  - MATCH,DIRECT
+"#,
+            7899,
+            1,
+            1054,
+        );
+        assert!(patched.contains("mixed-port: 7899"));
+        assert!(patched.contains("allow-lan: true"));
+        assert!(patched.contains("bind-address: 0.0.0.0"));
+        assert!(patched.contains("listen: 0.0.0.0:1054"));
+        assert!(!patched.contains("subscriptions:"));
+    }
 }

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -1,60 +1,47 @@
 //! tun2socks using netstack-smoltcp: Swift pushes raw IP packets in via
 //! [`ingest`], netstack terminates TCP and UDP sessions in a userspace
-//! smoltcp stack, and each flow dispatches directly into
-//! `meow_tunnel::{tcp,udp}::handle_*` — no SOCKS5 loopback, no cross-process
-//! hop.
+//! smoltcp stack, and each flow dispatches through the local mixed / DNS
+//! listeners owned by the embedded engine.
 //!
 //! Egress packets (netstack output) are handed back to Swift via a C
 //! callback registered in [`start`]. No file descriptors cross the FFI.
 //!
-//! DNS: A (1), HTTPS (65) and SVCB (64) queries are delegated to meow's
-//! resolver (`DnsServer::handle_query`). A gets fake-IP synthesis; HTTPS/SVCB
-//! take meow-dns's generic-forward path, which in fake-IP mode strips the
-//! ipv4hint/ipv6hint SvcParams from the answer (meow-rs #215) so an HTTP/3
-//! client can't read the origin's real IP out of the HTTPS record and connect
-//! QUIC straight there, bypassing the fake-IP mapping the tunnel routes on.
-//! AAAA (28) queries are answered NOERROR-empty by the intercept itself,
+//! DNS: A (1), TXT (16), MX (15), PTR (12), and other non-blocked queries are
+//! sent as raw UDP packets to the local meow-dns listener. A gets fake-IP
+//! synthesis there; generic qtypes get meow-dns's upstream-forward behavior.
+//! AAAA (28) queries are answered NOERROR-empty by the FFI itself,
 //! unconditionally — only the IPv4 fake-IP path is proxied, so stripping AAAA
 //! forces every client onto it instead of leaking (or black-holing)
-//! connections over v6. Anything else (TXT=16, MX=15, PTR=12, …) is forwarded
-//! as a raw UDP packet to the pinned upstream pool and the response is injected
-//! straight back. meow's DnsServer returns NXDOMAIN for those, which kills
-//! modern iOS connection setup (DNS-SD, mDNS-fallback) — the passthrough path
-//! lets them get a real answer instead.
+//! connections over v6. When "block HTTP/3" is enabled, HTTPS/SVCB (65/64)
+//! queries also get NOERROR-empty so clients cannot discover QUIC hints.
 //!
 //! NEDNSSettings advertises a TUN-subnet address as the system resolver, so
-//! every UDP DNS query arrives as an in-TUN IP packet; the ingress loop below
-//! intercepts it pre-stack, branches on qtype, and injects the reply back
-//! into the egress channel with src/dst + ports swapped. No UDP listener
-//! socket exists — there's nothing for one to listen on. The resolver itself
-//! owns fake-IP synthesis, reverse mapping, AAAA / hosts / NXDOMAIN
-//! semantics, and TTL handling for A/AAAA; the FFI owns only the qtype
-//! peek + the upstream forward.
+//! every UDP DNS query arrives as an in-TUN IP packet. netstack turns that into
+//! a UDP payload, the FFI branches on qtype, and non-blocked queries go to the
+//! local DNS listener with the reply injected back through netstack. The
+//! resolver owns fake-IP synthesis, reverse mapping, hosts / NXDOMAIN
+//! semantics, and TTL handling; the FFI owns only the qtype peek plus the
+//! blocked-query short-circuit.
 //!
 //! TCP/UDP destination IPs come back as fake-IPs from meow's resolver pool.
-//! `dispatch_tcp` and `dispatch_udp` pass the literal `dst.ip()` to
-//! `meow_tunnel`, whose `pre_handle_metadata` reverses any fake-IP back to
-//! the original qname before rule matching — so the rule / proxy chain still
-//! sees the hostname rather than the synthetic IP, without the FFI keeping
-//! its own pool.
+//! `dispatch_tcp` and `dispatch_udp` pass the literal destination to the
+//! mixed listener via SOCKS5; meow's normal inbound path reverses fake-IPs back
+//! to the original qname before rule matching.
 
 use crate::logging;
 use futures::{SinkExt, StreamExt};
-use meow_common::{ConnType, Metadata, Network, ProxyConn};
-use meow_dns::DnsServer;
-use meow_tunnel::tunnel::TunnelInner;
-use meow_tunnel::udp::UdpSession;
 use parking_lot::Mutex;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::io;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::os::raw::c_void;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::net::{TcpStream, UdpSocket};
 use tokio::sync::{mpsc, Notify, OwnedSemaphorePermit, Semaphore};
 use tokio_util::task::TaskTracker;
 use tracing::{info, trace, warn};
@@ -62,6 +49,7 @@ use tracing::{info, trace, warn};
 type UdpMsg = (Vec<u8>, SocketAddr, SocketAddr);
 type AnyIpPktFrame = Vec<u8>;
 type NetstackTcpStream = lwip::TcpStream;
+type UdpSessionKey = (SocketAddr, SocketAddr);
 
 /// Matches the cbindgen-emitted typedef in `meow_core.h`: Rust calls this
 /// whenever netstack or DNS produces an egress packet bound for the utun.
@@ -114,10 +102,10 @@ fn run_handle_slot() -> &'static Mutex<Option<tokio::task::JoinHandle<()>>> {
 // spawns a `dispatch_tcp` task immediately — and under a real burst (e.g.
 // loading a content-rich CN homepage that fans out to 50+ subdomains in
 // the first second), 1000+ concurrent dispatch tasks each hold their own
-// per-flow state (Metadata, Box<dyn ProxyConn>, meow's outbound dial
-// buffers, the netstack stream's tx/rx ring). The 10-min VM stress run
-// peaked at 440 MiB of RSS in the first ~10 s of load — 8.8× the on-device
-// 50 MB jetsam cap — almost entirely from the size of this in-flight set.
+// per-flow state (SOCKS5 loopback stream, meow listener handler state, and
+// the netstack stream's tx/rx ring). The 10-min VM stress run peaked at
+// 440 MiB of RSS in the first ~10 s of load — 8.8× the on-device 50 MB
+// jetsam cap — almost entirely from the size of this in-flight set.
 //
 // Tunable at runtime via [`set_accept_cap`] / `meow_tun_set_accept_cap`.
 // The atomic is sampled at `start()` to size the per-tunnel semaphore;
@@ -135,10 +123,10 @@ fn run_handle_slot() -> &'static Mutex<Option<tokio::task::JoinHandle<()>>> {
 // The cap, not the underlying allocator or per-flow buffer size, was
 // the dominant lever. The accept-side semaphore caps the in-flight
 // dispatch task population, which directly bounds the per-flow state
-// (Metadata + Box<dyn ProxyConn> + outbound dial buffers + the
-// netstack stream's tx/rx ring) the runtime ever holds at once. At
-// cap=32 the working set is ~4 × per-flow, comfortably below iOS NE's
-// 50 MB jetsam cap with substantial headroom for spikes.
+// (SOCKS5 loopback stream + meow listener handler state + the netstack
+// stream's tx/rx ring) the runtime ever holds at once. At cap=32 the working
+// set is ~4 × per-flow, comfortably below iOS NE's 50 MB jetsam cap with
+// substantial headroom for spikes.
 //
 // Throughput tradeoff: ~25% of the cap=128 conn/s rate (56/s vs
 // 147/s in the same stress harness). Acceptable for the foreground
@@ -381,9 +369,8 @@ struct FlowState {
 }
 
 /// Registry entry for one in-flight TCP flow. Aborting `abort` drops the
-/// `dispatch_tcp` future, which closes both halves of the relay — the
-/// netstack stream side and the in-process meow dispatch (whichever
-/// outbound the rule engine selected: proxy, direct, or reject).
+/// `dispatch_tcp` future, which closes both halves of the relay — the netstack
+/// stream side and the SOCKS5 loopback connection into meow-listener.
 struct FlowRecord {
     state: Arc<FlowState>,
     abort: tokio::task::AbortHandle,
@@ -525,9 +512,10 @@ fn ingress_slot() -> &'static Mutex<Option<mpsc::Sender<Vec<u8>>>> {
 /// only by `debug_counts`.
 #[allow(clippy::type_complexity)]
 fn reply_readers_slot(
-) -> &'static Mutex<Option<std::sync::Weak<Mutex<HashSet<(SocketAddr, SocketAddr)>>>>> {
-    static S: OnceLock<Mutex<Option<std::sync::Weak<Mutex<HashSet<(SocketAddr, SocketAddr)>>>>>> =
-        OnceLock::new();
+) -> &'static Mutex<Option<std::sync::Weak<Mutex<HashMap<UdpSessionKey, Arc<Socks5UdpSession>>>>>> {
+    static S: OnceLock<
+        Mutex<Option<std::sync::Weak<Mutex<HashMap<UdpSessionKey, Arc<Socks5UdpSession>>>>>>,
+    > = OnceLock::new();
     S.get_or_init(|| Mutex::new(None))
 }
 
@@ -706,14 +694,11 @@ async fn run_tun2socks(
     let (udp_write, mut udp_read) = udp_socket.split();
 
     let (udp_reply_tx, mut udp_reply_rx) = mpsc::channel::<UdpMsg>(256);
-    // NAT key mirrors meow-tunnel's `NatTable = DashMap<(SocketAddr, SocketAddr), Arc<UdpSession>>`
-    // post-ADR-0008 Direction-A refactor. We must key reader spawns on the
-    // same tuple meow-tunnel uses, or dedupe breaks and we leak readers.
-    let reply_readers: Arc<Mutex<HashSet<(SocketAddr, SocketAddr)>>> =
-        Arc::new(Mutex::new(HashSet::new()));
+    let udp_sessions: Arc<Mutex<HashMap<UdpSessionKey, Arc<Socks5UdpSession>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
     // Publish a weak handle so `debug_counts()` (harness RSS monitor) can
     // sample this set's size without owning it.
-    *reply_readers_slot().lock() = Some(Arc::downgrade(&reply_readers));
+    *reply_readers_slot().lock() = Some(Arc::downgrade(&udp_sessions));
 
     let (stack_ingress_tx, mut stack_ingress_rx) = mpsc::channel::<AnyIpPktFrame>(256);
     let (egress_tx, mut egress_rx) = mpsc::channel::<Vec<u8>>(1024);
@@ -883,25 +868,38 @@ async fn run_tun2socks(
     let tcp_idle_sweeper_handle = tokio::spawn(run_tcp_idle_sweeper());
 
     let udp_reply_tx_accept = udp_reply_tx.clone();
-    let reply_readers_accept = reply_readers.clone();
+    let udp_sessions_accept = udp_sessions.clone();
     let udp_sem_accept = udp_sem.clone();
+    let dns_sem_accept = dns_sem.clone();
     let engine_handle_for_udp = crate::get_engine_runtime().handle().clone();
     let udp_accept_handle = tokio::spawn(async move {
         while let Some((payload, src, dst)) = udp_read.next().await {
-            let permit = match udp_sem_accept.clone().try_acquire_owned() {
+            let sem = if dst.port() == 53 {
+                dns_sem_accept.clone()
+            } else {
+                udp_sem_accept.clone()
+            };
+            let permit = match sem.try_acquire_owned() {
                 Ok(p) => p,
                 Err(_) => {
-                    warn_capped(
-                        &UDP_CAP_LOG_LAST_MS,
-                        "tun2socks: UDP live-session cap reached, dropping datagram",
-                    );
+                    if dst.port() == 53 {
+                        warn_capped(
+                            &DNS_CAP_LOG_LAST_MS,
+                            "tun2socks: DNS burst cap reached, dropping query",
+                        );
+                    } else {
+                        warn_capped(
+                            &UDP_CAP_LOG_LAST_MS,
+                            "tun2socks: UDP live-session cap reached, dropping datagram",
+                        );
+                    }
                     continue;
                 }
             };
             let reply_tx = udp_reply_tx_accept.clone();
-            let readers = reply_readers_accept.clone();
+            let sessions = udp_sessions_accept.clone();
             engine_handle_for_udp.spawn(async move {
-                dispatch_udp(payload, src, dst, reply_tx, readers, permit).await;
+                dispatch_udp(payload, src, dst, reply_tx, sessions, permit).await;
             });
         }
     });
@@ -909,155 +907,6 @@ async fn run_tun2socks(
     while let Some(ip_data) = ingress_rx.recv().await {
         if !TUN2SOCKS_RUNNING.load(Ordering::SeqCst) {
             break;
-        }
-
-        // Fake-IP mode: NEDNSSettings advertises a TUN-subnet IP
-        // (172.19.0.2) as the system DNS server, so every UDP DNS query
-        // arrives here as an in-TUN IP packet. Branch on qtype:
-        //
-        //   * AAAA (28)          → NOERROR-empty, unconditionally. Only the
-        //     IPv4 fake-IP path is intercepted and proxied; stripping AAAA
-        //     forces every client onto it.
-        //   * A (1) / SVCB (64)  → meow's `DnsServer::handle_query`. A gets
-        //     / HTTPS (65)         fake-IP synthesis; SVCB/HTTPS take the
-        //                          generic-forward path which strips the
-        //                          ipv4hint/ipv6hint SvcParams in fake-IP mode
-        //                          (meow-rs #215), keeping HTTP/3 origins on
-        //                          the fake-IP A record instead of letting the
-        //                          client connect direct to the real IP.
-        //   * anything else      → raw UDP forward to the pinned upstream
-        //     pool (TXT, MX, PTR, …). meow's DnsServer
-        //     synthesises NXDOMAIN for non-A/AAAA, which kills iOS's
-        //     HTTPS-record probe + ECH + Safari's modern connect path; the
-        //     passthrough route lets those queries reach a real resolver.
-        //
-        // Never let the DNS packet touch the smoltcp stack — the
-        // destination IP isn't a real host on the inside, and we'd just
-        // create an orphan session.
-        if parse_udp_packet(&ip_data).is_some_and(|p| p.dst_port == 53) {
-            let permit = match dns_sem.clone().try_acquire_owned() {
-                Ok(p) => p,
-                Err(_) => {
-                    warn_capped(
-                        &DNS_CAP_LOG_LAST_MS,
-                        "tun2socks: DNS burst cap reached, dropping query",
-                    );
-                    continue;
-                }
-            };
-            let request = ip_data;
-            let egress = egress_tx.clone();
-            crate::get_engine_runtime().spawn(async move {
-                let _permit = permit;
-                let work = async {
-                    let Some(parsed) = parse_udp_packet(&request) else {
-                        return;
-                    };
-                    let qtype = parse_dns_qtype(parsed.payload);
-
-                    let response_payload = if qtype == Some(28) {
-                        // AAAA is always answered NOERROR-empty without
-                        // consulting the resolver, forcing every client onto
-                        // A / fake-IPv4 — the only family the intercept
-                        // actually proxies (the ::/0 claim is a deliberate
-                        // sinkhole, not a working v6 path). The resolver's
-                        // v4-only fake-IP pool already suppresses most AAAA,
-                        // but its `hosts:` table is consulted before that
-                        // suppression and can hand out real v6 addresses
-                        // that would then bypass interception or fail to
-                        // dial. Empty-answer (not a silent drop) so clients
-                        // fall back to A immediately instead of waiting out
-                        // resolver timeouts.
-                        let Some(bytes) = dns_empty_response(parsed.payload) else {
-                            return;
-                        };
-                        bytes
-                    } else if block_http3() && matches!(qtype, Some(64) | Some(65)) {
-                        // "Block HTTP/3 (QUIC)" toggle ON: answer SVCB (64) /
-                        // HTTPS (65) NOERROR-empty by the intercept itself,
-                        // exactly like the AAAA arm above, instead of delegating
-                        // to meow-dns. The record's mere existence advertises h3
-                        // capability (its `alpn`/SvcParams carry the HTTP/3
-                        // hints), so hiding it entirely — not just stripping the
-                        // ipv4hint/ipv6hint as the meow-dns path does — drives the
-                        // client onto the A / fake-IPv4 + TCP path. Pairs with the
-                        // UDP/443 egress drop so any QUIC that still attempts is
-                        // also killed.
-                        let Some(bytes) = dns_empty_response(parsed.payload) else {
-                            return;
-                        };
-                        bytes
-                    } else if matches!(qtype, Some(1) | Some(64) | Some(65)) {
-                        // A (1) + SVCB (64) / HTTPS (65) → meow's resolver
-                        // pipeline. A gets fake-IP synthesis; SVCB/HTTPS take
-                        // meow-dns's generic-forward path, which (meow-rs #215,
-                        // fake-IP mode) strips the ipv4hint/ipv6hint SvcParams
-                        // from the answer. Without that strip an HTTP/3 client
-                        // reads the origin's real IP out of the HTTPS record and
-                        // connects QUIC straight there — bypassing the fake-IP
-                        // mapping, so domain routing / sniffing / proxy-select
-                        // silently break for exactly the dual-stack HTTP/3
-                        // origins (Xiaohongshu et al.). With the hints gone the
-                        // client falls back to the A / fake-IPv4 record and the
-                        // flow rides the proxy. On upstream failure handle_query
-                        // returns SERVFAIL, which also drives the client to the
-                        // A path — strictly better than the old plaintext-UDP/53
-                        // passthrough, which left the real-IP hints intact AND
-                        // stalled ~2 s on censored type-65 lookups.
-                        let Some(tunnel) = crate::engine::tunnel() else {
-                            trace!("tun2socks: UDP/53 query dropped — engine not yet running");
-                            return;
-                        };
-                        let resolver = tunnel.resolver().clone();
-                        match DnsServer::handle_query(parsed.payload, &resolver).await {
-                            Ok(bytes) => bytes,
-                            Err(e) => {
-                                trace!("tun2socks: DnsServer::handle_query error: {}", e);
-                                return;
-                            }
-                        }
-                    } else {
-                        // Remaining non-address qtypes (TXT, MX, PTR, …):
-                        // forward verbatim to the upstream pool, first response
-                        // wins. Falls through to a dropped reply if every
-                        // upstream times out — the client retries on its own.
-                        match forward_dns_to_upstream(
-                            parsed.payload,
-                            DNS_PASSTHROUGH_UPSTREAMS,
-                            DNS_PASSTHROUGH_TIMEOUT,
-                        )
-                        .await
-                        {
-                            Some(bytes) => bytes,
-                            None => {
-                                trace!("tun2socks: DNS passthrough timed out (qtype={:?})", qtype);
-                                return;
-                            }
-                        }
-                    };
-                    let Some(reply_pkt) = build_udp_reply(&request, &response_payload) else {
-                        return;
-                    };
-                    // Match the rest of this file's "log, don't swallow" policy:
-                    // a send error here means egress_rx was dropped (tunnel
-                    // teardown), so the reply is lost. Surface it at trace so a
-                    // shutdown-time DNS stall has an on-device signal instead of
-                    // a silent discard.
-                    if let Err(e) = egress.send(reply_pkt).await {
-                        trace!(
-                            "tun2socks: DNS reply egress send failed (egress closed?): {}",
-                            e
-                        );
-                    }
-                };
-                if tokio::time::timeout(DNS_TASK_TIMEOUT, work).await.is_err() {
-                    trace!(
-                        "tun2socks: DNS task exceeded {:?}, aborting",
-                        DNS_TASK_TIMEOUT
-                    );
-                }
-            });
-            continue;
         }
 
         match stack_ingress_tx.try_send(ip_data) {
@@ -1138,102 +987,54 @@ async fn dispatch_tcp(
     state: Arc<FlowState>,
 ) {
     let _active = ActiveTcpGuard::new();
-    let Some(tunnel) = crate::engine::tunnel() else {
-        logging::bridge_log("tun2socks: engine not running, dropping TCP flow");
+    let Some(mixed_addr) = crate::engine::mixed_dial_addr() else {
+        logging::bridge_log("tun2socks: mixed listener not running, dropping TCP flow");
         return;
     };
 
-    // No FFI-side fake-IP reverse: hand `dst.ip()` straight to meow with
-    // an empty host. `meow_tunnel::tcp::handle_tcp` calls
-    // `pre_handle_metadata` first, which consults the resolver's fake-IP
-    // reverse table — if `dst.ip()` is inside the resolver's pool the
-    // metadata is rewritten in place to `(host: <qname>, dst_ip: None)`
-    // before rule matching, and if it isn't (literal-IP dial, fallback
-    // answer, etc.) the rule engine matches on the literal IP. Either way
-    // the FFI does not need its own pool.
-    let metadata = Metadata {
-        network: Network::Tcp,
-        conn_type: ConnType::Inner,
-        src_ip: Some(src.ip()),
-        src_port: src.port(),
-        dst_ip: Some(dst.ip()),
-        dst_port: dst.port(),
-        host: String::new().into(),
-        ..Default::default()
-    };
-
-    // Snapshot the FlowState's accept-time stamp before the relay future
-    // even runs. `IdleTracking::touch` rewrites `last_active_ms` on the
-    // first successful poll, which only happens after
-    // `meow_tunnel::tcp::handle_tcp` → `pre_handle_metadata` →
-    // `pre_resolve` → `proxy.dial_tcp` returns and `copy_bidirectional_buf`
-    // starts reading. So "`last_active_ms` is still equal to the snapshot"
-    // is a precise proxy for "the dial hasn't completed yet."
     let accepted_at_ms = state.last_active_ms.load(Ordering::Relaxed);
     let dial_deadline = DIAL_DEADLINE_MS.load(Ordering::Relaxed);
     let watchdog_state = state.clone();
 
     let local_eof = Arc::new(Notify::new());
-    let conn: Box<dyn ProxyConn> = Box::new(IdleTracking {
-        inner: NetstackConn(stream),
+    let mut local = IdleTracking {
+        inner: stream,
         state,
         local_eof: local_eof.clone(),
         eof_fired: AtomicBool::new(false),
-    });
+    };
 
-    // Race the normal relay against a local-FIN watcher. The relay
-    // (`meow_tunnel::tcp::handle_tcp` → `copy_bidirectional_buf`)
-    // already RFC-correctly half-closes: on local EOF it calls
-    // `poll_shutdown` on the proxy outbound (sending FIN upstream) and
-    // then waits for the upstream to FIN back to terminate.  That wait
-    // hangs forever for long-poll / SSE / dead-peer flows and leaves
-    // the proxy session, rustls state, NAT entry, and our task stack
-    // alive until cap-pressure eviction picks it as the longest-idle flow.
-    //
-    // Instead: once the local read returns EOF, give the relay a brief
-    // grace window to flush its outbound `poll_shutdown` cleanly, then
-    // drop the future.  Dropping calls each transport layer's `Drop`,
-    // which is what closes rustls (sends close_notify alert), tears
-    // down the WebSocket framing, and drops the upstream TCP — clean
-    // close semantics on every layer, just not waiting for the peer.
-    //
-    // `Statistics.connections` stays in sync because meow-tunnel's
-    // `ConnectionGuard` is RAII and runs on the dropped future.
-    let fut = meow_tunnel::tcp::handle_tcp(tunnel.inner(), conn, metadata);
-    tokio::pin!(fut);
+    let mut proxy = match TcpStream::connect(mixed_addr).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("tun2socks: connect mixed listener {mixed_addr} failed for {src} -> {dst}: {e}");
+            return;
+        }
+    };
+    if let Err(e) = socks5_connect(&mut proxy, dst).await {
+        warn!("tun2socks: SOCKS5 CONNECT {src} -> {dst} failed: {e}");
+        return;
+    }
 
-    // Dial-deadline watchdog (see DIAL_DEADLINE_MS docs above and
-    // `run_dial_watchdog` for the actual polling logic).
-    // `watchdog_state` is moved into the watchdog; keep a handle to the same
-    // FlowState so the local-FIN arm can watch download progress via
-    // `last_active_ms` (bumped by `IdleTracking::poll_write` on each
-    // downstream byte).
+    local
+        .state
+        .last_active_ms
+        .store(now_ms().max(accepted_at_ms + 1), Ordering::Relaxed);
+
     let eof_state = watchdog_state.clone();
     let dial_watchdog = run_dial_watchdog(watchdog_state, accepted_at_ms, dial_deadline);
     tokio::pin!(dial_watchdog);
+    let relay = tokio::io::copy_bidirectional(&mut local, &mut proxy);
+    tokio::pin!(relay);
 
     tokio::select! {
         biased;
-        _ = &mut fut => {}
+        _ = &mut relay => {}
         _ = local_eof.notified() => {
-            // The app sent FIN. `handle_tcp` already half-closes correctly
-            // (poll_shutdown upstream) and keeps the DOWNLOAD direction alive,
-            // but then waits forever for the peer's FIN — which wedges
-            // long-poll / SSE / dead-peer flows. Don't truncate a still-
-            // flowing download with a fixed window (the old 250 ms drop):
-            // extend the grace as long as downstream bytes keep arriving, and
-            // give up only once the download side has been quiet for
-            // HALF_CLOSE_IDLE_GRACE. A wedged/dead peer is dropped ~2 s after
-            // FIN; a slow large response drains in full.
             loop {
                 let before = eof_state.last_active_ms.load(Ordering::Relaxed);
-                match tokio::time::timeout(HALF_CLOSE_IDLE_GRACE, &mut fut).await {
-                    // Relay finished (peer FIN'd / closed) — clean done.
+                match tokio::time::timeout(HALF_CLOSE_IDLE_GRACE, &mut relay).await {
                     Ok(_) => break,
-                    // No completion within the window. If a downstream byte
-                    // landed (last_active_ms advanced) the response is still
-                    // draining, so loop and extend; otherwise it's quiet —
-                    // drop the future (RAII close on every layer).
                     Err(_) => {
                         if eof_state.last_active_ms.load(Ordering::Relaxed) == before {
                             break;
@@ -1244,7 +1045,7 @@ async fn dispatch_tcp(
         }
         _ = &mut dial_watchdog => {
             warn!(
-                "tun2socks: dial deadline exceeded for {} -> {} after {} ms; dropping flow",
+                "tun2socks: mixed-listener dial deadline exceeded for {} -> {} after {} ms; dropping flow",
                 src, dst, dial_deadline,
             );
         }
@@ -1299,45 +1100,83 @@ async fn run_dial_watchdog(state: Arc<FlowState>, accepted_at_ms: u64, dial_dead
 }
 
 // ---------------------------------------------------------------------------
-// ProxyConn newtype wrapper — orphan rules force a local impl for the netstack
-// TCP stream. The wrapper only forwards AsyncRead / AsyncWrite; everything
-// else takes the trait's defaults.
+// SOCKS5 loopback helpers.
 // ---------------------------------------------------------------------------
 
-struct NetstackConn(NetstackTcpStream);
+const SOCKS5_VERSION: u8 = 0x05;
+const SOCKS5_NO_AUTH: u8 = 0x00;
+const SOCKS5_CMD_CONNECT: u8 = 0x01;
+const SOCKS5_CMD_UDP_ASSOCIATE: u8 = 0x03;
+const SOCKS5_ATYP_IPV4: u8 = 0x01;
+const SOCKS5_ATYP_DOMAIN: u8 = 0x03;
+const SOCKS5_ATYP_IPV6: u8 = 0x04;
 
-impl AsyncRead for NetstackConn {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_read(cx, buf)
+async fn socks5_negotiate(stream: &mut TcpStream) -> io::Result<()> {
+    stream
+        .write_all(&[SOCKS5_VERSION, 1, SOCKS5_NO_AUTH])
+        .await?;
+    let mut resp = [0u8; 2];
+    stream.read_exact(&mut resp).await?;
+    if resp != [SOCKS5_VERSION, SOCKS5_NO_AUTH] {
+        return Err(io::Error::other(format!(
+            "SOCKS5 no-auth rejected: {resp:?}"
+        )));
     }
+    Ok(())
 }
 
-impl AsyncWrite for NetstackConn {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.0).poll_write(cx, buf)
+fn encode_socks5_addr(out: &mut Vec<u8>, addr: SocketAddr) {
+    match addr.ip() {
+        IpAddr::V4(ip) => {
+            out.push(SOCKS5_ATYP_IPV4);
+            out.extend_from_slice(&ip.octets());
+        }
+        IpAddr::V6(ip) => {
+            out.push(SOCKS5_ATYP_IPV6);
+            out.extend_from_slice(&ip.octets());
+        }
     }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_flush(cx)
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_shutdown(cx)
-    }
+    out.extend_from_slice(&addr.port().to_be_bytes());
 }
 
-impl ProxyConn for NetstackConn {
-    fn remote_destination(&self) -> String {
-        String::new()
+async fn read_socks5_reply_addr(stream: &mut TcpStream) -> io::Result<SocketAddr> {
+    let mut head = [0u8; 4];
+    stream.read_exact(&mut head).await?;
+    if head[0] != SOCKS5_VERSION || head[1] != 0 {
+        return Err(io::Error::other(format!("SOCKS5 reply failure: {head:?}")));
     }
+    let ip = match head[3] {
+        SOCKS5_ATYP_IPV4 => {
+            let mut octets = [0u8; 4];
+            stream.read_exact(&mut octets).await?;
+            IpAddr::from(octets)
+        }
+        SOCKS5_ATYP_IPV6 => {
+            let mut octets = [0u8; 16];
+            stream.read_exact(&mut octets).await?;
+            IpAddr::from(octets)
+        }
+        SOCKS5_ATYP_DOMAIN => {
+            let mut len = [0u8; 1];
+            stream.read_exact(&mut len).await?;
+            let mut name_buf = vec![0u8; len[0] as usize];
+            stream.read_exact(&mut name_buf).await?;
+            IpAddr::from([0, 0, 0, 0])
+        }
+        atyp => return Err(io::Error::other(format!("SOCKS5 reply atyp {atyp}"))),
+    };
+    let mut port = [0u8; 2];
+    stream.read_exact(&mut port).await?;
+    Ok(SocketAddr::new(ip, u16::from_be_bytes(port)))
+}
+
+async fn socks5_connect(stream: &mut TcpStream, dst: SocketAddr) -> io::Result<()> {
+    socks5_negotiate(stream).await?;
+    let mut req = vec![SOCKS5_VERSION, SOCKS5_CMD_CONNECT, 0];
+    encode_socks5_addr(&mut req, dst);
+    stream.write_all(&req).await?;
+    let _ = read_socks5_reply_addr(stream).await?;
+    Ok(())
 }
 
 /// Wraps an `AsyncRead + AsyncWrite` to bump `FlowState::last_active_ms` on
@@ -1346,11 +1185,9 @@ impl ProxyConn for NetstackConn {
 /// `poll_write` (bytes from the upstream peer) on the same wrapper.
 /// Pending / would-block polls are intentionally not counted as activity.
 ///
-/// Generic over the inner stream so the idle-tracking semantics apply to
-/// the meow path (`IdleTracking<NetstackConn>`, served as a
-/// `Box<dyn ProxyConn>` to `meow_tunnel::tcp::handle_tcp`). Every TCP
-/// flow goes through `meow_tunnel::tcp::handle_tcp`; there is no
-/// alternate FFI-side bypass relay any more.
+/// Generic over the inner stream so the idle-tracking semantics stay local to
+/// the netstack side while the other half of the relay is the SOCKS5 loopback
+/// connection into meow-listener.
 struct IdleTracking<T> {
     inner: T,
     state: Arc<FlowState>,
@@ -1432,24 +1269,8 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for IdleTracking<T> {
     }
 }
 
-// `ProxyConn` only matters on the meow path (the trait is consumed by
-// `meow_tunnel::tcp::handle_tcp`); scope the impl to the netstack flavor
-// so other future `IdleTracking<_>` instantiations don't have to invent a
-// `remote_destination()` they wouldn't use.
-impl ProxyConn for IdleTracking<NetstackConn> {
-    fn remote_destination(&self) -> String {
-        self.inner.remote_destination()
-    }
-}
-
 // ---------------------------------------------------------------------------
-// In-process UDP dispatch into meow_tunnel
-//
-// `meow_tunnel::udp::handle_udp` installs the outbound session into the NAT
-// table on the first packet of a flow but does not drive the reply side — the
-// caller owns the reader loop. We key replies on the same NAT key
-// meow-tunnel uses internally (`"{src}:{remote_address}"`) so reader
-// spawns stay deduped without a second source of truth.
+// UDP dispatch through DNS listener / SOCKS5 UDP ASSOCIATE.
 // ---------------------------------------------------------------------------
 
 async fn dispatch_udp(
@@ -1457,20 +1278,15 @@ async fn dispatch_udp(
     src: SocketAddr,
     dst: SocketAddr,
     reply_tx: mpsc::Sender<UdpMsg>,
-    reply_readers: Arc<Mutex<HashSet<(SocketAddr, SocketAddr)>>>,
+    udp_sessions: Arc<Mutex<HashMap<UdpSessionKey, Arc<Socks5UdpSession>>>>,
     permit: OwnedSemaphorePermit,
 ) {
-    let Some(tunnel) = crate::engine::tunnel() else {
-        logging::bridge_log("tun2socks: engine not running, dropping UDP datagram");
+    if dst.port() == 53 {
+        let _permit = permit;
+        dispatch_dns_udp(payload, src, dst, reply_tx).await;
         return;
-    };
+    }
 
-    // "Block HTTP/3 (QUIC)" toggle: drop outbound UDP to port 443 (QUIC's
-    // transport). `dst` is still the fake-IP:port from the tun (pre-rewrite),
-    // but `dst.port()` is the real app-intended port, so port-only matching is
-    // correct and address-independent. Returning here drops the datagram and
-    // lets `permit` fall out of scope, releasing its `udp_sem` slot — no live
-    // session is created, matching every other early-return path below.
     if block_http3() && dst.port() == 443 {
         warn_capped(
             &BLOCK_HTTP3_DROP_LOG_LAST_MS,
@@ -1479,78 +1295,42 @@ async fn dispatch_udp(
         return;
     }
 
-    // No FFI-side fake-IP reverse: pass `dst.ip()` through and let meow's
-    // `pre_handle_metadata` rewrite to the qname when the destination is
-    // inside the resolver's fake-IP pool, exactly like the TCP path.
-    let mut metadata = Metadata {
-        network: Network::Udp,
-        conn_type: ConnType::Inner,
-        src_ip: Some(src.ip()),
-        src_port: src.port(),
-        dst_ip: Some(dst.ip()),
-        dst_port: dst.port(),
-        host: String::new().into(),
-        ..Default::default()
-    };
-
-    // Mirror `handle_udp`'s prologue so the NAT key we compute here matches
-    // exactly what handle_udp will insert into `nat_table`:
-    //
-    //   1. `pre_handle_metadata` — if `dst.ip()` is a fake-IP, this rewrites
-    //      metadata to `(host: <qname>, dst_ip: None)`.
-    //   2. `pre_resolve` — re-resolves the host (if any) through the engine
-    //      resolver and re-populates `dst_ip` with the real upstream IP.
-    //
-    // Hold the `udp_sem` permit across the whole flow lifetime, not just the
-    // dispatch window. `udp_sem` is a true *live-session* cap: it bounds the
-    // number of simultaneously-live UDP flows (NAT entry + reply_readers entry
-    // + reader task, each holding an `Arc<UdpSession>` + a 4 KiB buffer). The
-    // idle-TTL sweeper only reaps flows that go quiet > 60 s; it does NOT bound
-    // the count of *active* flows (QUIC, WebRTC, games, DNS fan-out, or a
-    // source-port-fanning app), so without a count cap a workload that keeps N
-    // flows each ≥1 datagram/idle-window alive grows monotonically toward the
-    // ~50 MB jetsam cap. The permit is therefore MOVED into the reply-reader
-    // task below and released only when that task exits and clears its NAT +
-    // reply_readers state — so the permit population tracks the live-session
-    // population exactly. On every early-return path here (resolve failure,
-    // handle_udp bail, dedup hit) `permit` drops at end of scope, which is
-    // correct: those paths create no live session.
-    //
-    // Both pre_* calls are idempotent — handle_udp invokes them again
-    // internally and they short-circuit on the already-populated metadata.
-    // The round-trip is unavoidable on this side because we need the
-    // resolved SocketAddr to key the reply-reader registry.
-    tunnel.inner().pre_handle_metadata(&mut metadata);
-    tunnel.inner().pre_resolve(&mut metadata).await;
-    let Some(resolved_ip) = metadata.dst_ip else {
-        // Resolution failed — handle_udp will also bail, nothing to dispatch.
-        return;
-    };
-    let key = (src, SocketAddr::new(resolved_ip, metadata.dst_port));
-
-    meow_tunnel::udp::handle_udp(tunnel.inner(), &payload, src, metadata).await;
-
-    if !reply_readers.lock().insert(key) {
+    let key = (src, dst);
+    let existing = { udp_sessions.lock().get(&key).cloned() };
+    if let Some(session) = existing {
+        if let Err(e) = send_socks5_udp(&session, dst, &payload).await {
+            warn!("tun2socks: SOCKS5 UDP send failed for {src} -> {dst}: {e}");
+            udp_sessions.lock().remove(&key);
+        }
+        drop(permit);
         return;
     }
 
-    let inner = tunnel.inner().clone();
-    let Some(session) = inner.nat_table.get(&key).map(|r| r.value().clone()) else {
-        // handle_udp bailed before NAT insert (no matching rule / dial error).
-        reply_readers.lock().remove(&key);
+    let Some(mixed_addr) = crate::engine::mixed_dial_addr() else {
+        logging::bridge_log("tun2socks: mixed listener not running, dropping UDP datagram");
         return;
     };
+    let session = match open_socks5_udp_session(mixed_addr).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("tun2socks: SOCKS5 UDP ASSOCIATE failed for {src} -> {dst}: {e}");
+            return;
+        }
+    };
 
-    spawn_udp_reply_reader(
+    udp_sessions.lock().insert(key, session.clone());
+    spawn_socks5_udp_reply_reader(
         key,
-        session,
+        session.clone(),
         src,
         dst,
         reply_tx,
-        reply_readers,
-        inner,
+        udp_sessions,
         permit,
     );
+    if let Err(e) = send_socks5_udp(&session, dst, &payload).await {
+        warn!("tun2socks: initial SOCKS5 UDP send failed for {src} -> {dst}: {e}");
+    }
 }
 
 /// Poll cadence for the post-first-reply UDP reply reader. Short so the reader
@@ -1588,44 +1368,118 @@ fn forward_udp_reply(reply_tx: &mpsc::Sender<UdpMsg>, msg: UdpMsg) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn spawn_udp_reply_reader(
-    key: (SocketAddr, SocketAddr),
-    session: Arc<UdpSession>,
+struct Socks5UdpSession {
+    udp: Arc<UdpSocket>,
+    relay_addr: SocketAddr,
+    control_abort: tokio::task::AbortHandle,
+    last_activity_ms: AtomicU64,
+}
+
+impl Drop for Socks5UdpSession {
+    fn drop(&mut self) {
+        self.control_abort.abort();
+    }
+}
+
+async fn open_socks5_udp_session(mixed_addr: SocketAddr) -> io::Result<Arc<Socks5UdpSession>> {
+    let mut control = TcpStream::connect(mixed_addr).await?;
+    socks5_negotiate(&mut control).await?;
+    control
+        .write_all(&[
+            SOCKS5_VERSION,
+            SOCKS5_CMD_UDP_ASSOCIATE,
+            0,
+            SOCKS5_ATYP_IPV4,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ])
+        .await?;
+    let relay_addr = read_socks5_reply_addr(&mut control).await?;
+    let local_ip = match relay_addr.ip() {
+        IpAddr::V4(_) => IpAddr::from([127, 0, 0, 1]),
+        IpAddr::V6(_) => IpAddr::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+    };
+    let udp = Arc::new(UdpSocket::bind(SocketAddr::new(local_ip, 0)).await?);
+    let control_task = tokio::spawn(async move {
+        let mut buf = [0u8; 16];
+        loop {
+            match control.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    });
+    let control_abort = control_task.abort_handle();
+    Ok(Arc::new(Socks5UdpSession {
+        udp,
+        relay_addr,
+        control_abort,
+        last_activity_ms: AtomicU64::new(now_ms()),
+    }))
+}
+
+fn encode_socks5_udp_header(out: &mut Vec<u8>, addr: SocketAddr) {
+    out.extend_from_slice(&[0, 0, 0]);
+    encode_socks5_addr(out, addr);
+}
+
+fn socks5_udp_payload_offset(buf: &[u8]) -> Option<usize> {
+    if buf.len() < 4 || buf[2] != 0 {
+        return None;
+    }
+    let mut pos = 4usize;
+    match buf[3] {
+        SOCKS5_ATYP_IPV4 => pos = pos.checked_add(4)?,
+        SOCKS5_ATYP_IPV6 => pos = pos.checked_add(16)?,
+        SOCKS5_ATYP_DOMAIN => {
+            let len = *buf.get(pos)? as usize;
+            pos = pos.checked_add(1 + len)?;
+        }
+        _ => return None,
+    }
+    pos.checked_add(2).filter(|off| *off <= buf.len())
+}
+
+async fn send_socks5_udp(
+    session: &Socks5UdpSession,
+    dst: SocketAddr,
+    payload: &[u8],
+) -> io::Result<()> {
+    let mut packet = Vec::with_capacity(10 + payload.len());
+    encode_socks5_udp_header(&mut packet, dst);
+    packet.extend_from_slice(payload);
+    session
+        .udp
+        .send_to(&packet, session.relay_addr)
+        .await
+        .map(|_| ())?;
+    session.last_activity_ms.store(now_ms(), Ordering::Relaxed);
+    Ok(())
+}
+
+fn spawn_socks5_udp_reply_reader(
+    key: UdpSessionKey,
+    session: Arc<Socks5UdpSession>,
     app_src: SocketAddr,
     app_dst: SocketAddr,
     reply_tx: mpsc::Sender<UdpMsg>,
-    reply_readers: Arc<Mutex<HashSet<(SocketAddr, SocketAddr)>>>,
-    tunnel_inner: Arc<TunnelInner>,
+    udp_sessions: Arc<Mutex<HashMap<UdpSessionKey, Arc<Socks5UdpSession>>>>,
     permit: OwnedSemaphorePermit,
 ) {
     crate::get_engine_runtime().spawn(async move {
-        // Hold the `udp_sem` permit for the entire reader lifetime so the
-        // semaphore caps live sessions, not just the dispatch window. Released
-        // (along with this flow's NAT + reply_readers entries) only when the
-        // loop below breaks and the task returns.
         let _permit = permit;
-        // Per-session reply buffer. Sized for the iOS TUN MTU (1500) plus
-        // headroom for the rare oversized UDP datagram that survives path
-        // fragmentation. Was 64 KiB — at N concurrent UDP sessions (DNS,
-        // QUIC, NAT-traversal probes) that sums to N * 64 KiB pinned for
-        // each session's idle lifetime, blowing past the 50 MB jetsam cap
-        // long before meow's NAT timeout reaps the session. 4 KiB covers
-        // every UDP datagram that can actually round-trip through a
-        // 1500-MTU tun without fragmentation; oversized datagrams are
-        // truncated at the read, which matches the on-wire reality.
         let mut buf = vec![0u8; 4 * 1024];
-        // First-reply deadline: see UDP_FIRST_REPLY_DEADLINE_MS docs.
-        // Only the *first* read is bounded — once a reply has come back
-        // we know the route is alive and we don't want to evict an
-        // active session on quiet idle periods (long-poll, NAT keepalive).
         let first_reply_deadline_ms = UDP_FIRST_REPLY_DEADLINE_MS.load(Ordering::Relaxed);
         let mut had_first_reply = false;
         'reader: loop {
             let read = if !had_first_reply && first_reply_deadline_ms > 0 {
                 match tokio::time::timeout(
                     std::time::Duration::from_millis(first_reply_deadline_ms),
-                    session.conn.read_packet(&mut buf),
+                    session.udp.recv_from(&mut buf),
                 )
                 .await
                 {
@@ -1664,13 +1518,15 @@ fn spawn_udp_reply_reader(
                 loop {
                     match tokio::time::timeout(
                         UDP_REPLY_POLL_INTERVAL,
-                        session.conn.read_packet(&mut buf),
+                        session.udp.recv_from(&mut buf),
                     )
                     .await
                     {
                         Ok(res) => break res,
                         Err(_) => {
-                            if session.idle_for() >= UDP_REPLY_IDLE_TTL {
+                            let idle_ms = now_ms()
+                                .saturating_sub(session.last_activity_ms.load(Ordering::Relaxed));
+                            if idle_ms >= UDP_REPLY_IDLE_TTL.as_millis() as u64 {
                                 info!(
                                     "UDP reply reader idle (both directions) > {}s for {:?}; evicting session",
                                     UDP_REPLY_IDLE_TTL.as_secs(),
@@ -1687,16 +1543,11 @@ fn spawn_udp_reply_reader(
             match read {
                 Ok((n, _from)) => {
                     had_first_reply = true;
-                    // Inbound traffic is activity too: refresh the shared NAT
-                    // idle clock so neither the sweeper nor the backstop above
-                    // evicts a receive-active / send-quiet session while data
-                    // is still arriving.
-                    session.touch();
-                    // Reply injection: the IP frame handed back to the app
-                    // must look like it came FROM the external peer (app_dst)
-                    // TO the app (app_src). netstack's Sink builds the header
-                    // from (src, dst) in that argument order.
-                    let msg: UdpMsg = (buf[..n].to_vec(), app_dst, app_src);
+                    session.last_activity_ms.store(now_ms(), Ordering::Relaxed);
+                    let Some(off) = socks5_udp_payload_offset(&buf[..n]) else {
+                        continue;
+                    };
+                    let msg: UdpMsg = (buf[off..n].to_vec(), app_dst, app_src);
                     forward_udp_reply(&reply_tx, msg);
                 }
                 Err(e) => {
@@ -1705,29 +1556,69 @@ fn spawn_udp_reply_reader(
                 }
             }
         }
-        tunnel_inner.nat_table.remove(&key);
-        reply_readers.lock().remove(&key);
+        udp_sessions.lock().remove(&key);
     });
 }
 
 // ---------------------------------------------------------------------------
-// DNS passthrough — for qtypes meow's resolver doesn't synthesise (anything
-// other than A / AAAA) we forward the raw query to one of the pinned
-// upstream resolvers and inject the reply back. Mirrors the upstream pool in
-// `engine::pinned_dns_block` (CN-side, no anycast) so that split-horizon
-// answers are consistent across the A/AAAA and HTTPS/SVCB/TXT paths.
+// DNS dispatch — block selected qtypes locally, otherwise forward the raw
+// query to the local meow-dns listener and inject the reply back through
+// netstack.
 // ---------------------------------------------------------------------------
 
-/// Pinned UDP/53 upstream pool used for non-A/AAAA passthrough. Kept in
-/// sync with `engine::pinned_dns_block`'s nameserver list; if you add or
-/// remove a CN nameserver there, mirror it here.
-const DNS_PASSTHROUGH_UPSTREAMS: &[&str] = &["119.29.29.29:53", "223.5.5.5:53"];
+async fn dispatch_dns_udp(
+    payload: Vec<u8>,
+    src: SocketAddr,
+    dst: SocketAddr,
+    reply_tx: mpsc::Sender<UdpMsg>,
+) {
+    let qtype = parse_dns_qtype(&payload);
+    let response_payload =
+        if qtype == Some(28) || (block_http3() && matches!(qtype, Some(64) | Some(65))) {
+            match dns_empty_response(&payload) {
+                Some(bytes) => bytes,
+                None => return,
+            }
+        } else if let Some(dns_addr) = crate::engine::dns_dial_addr() {
+            match query_dns_listener(&payload, dns_addr).await {
+                Some(bytes) => bytes,
+                None => {
+                    trace!("tun2socks: DNS listener timed out (qtype={:?})", qtype);
+                    return;
+                }
+            }
+        } else {
+            trace!(
+                "tun2socks: DNS listener not running, dropping qtype={:?}",
+                qtype
+            );
+            return;
+        };
+    forward_udp_reply(&reply_tx, (response_payload, dst, src));
+}
 
-/// Per-attempt deadline before we give up on the whole upstream pool. iOS
-/// clients retry on their own when no reply comes back — we'd rather drop
-/// the response than hold a `tokio::spawn` task open indefinitely against
-/// a dead upstream.
-const DNS_PASSTHROUGH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+async fn query_dns_listener(query: &[u8], dns_addr: SocketAddr) -> Option<Vec<u8>> {
+    if query.len() < 2 {
+        return None;
+    }
+    let query_id = u16::from_be_bytes([query[0], query[1]]);
+    let bind_addr = match dns_addr {
+        SocketAddr::V4(_) => SocketAddr::from(([127, 0, 0, 1], 0)),
+        SocketAddr::V6(_) => {
+            SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], 0))
+        }
+    };
+    let socket = UdpSocket::bind(bind_addr).await.ok()?;
+    socket.send_to(query, dns_addr).await.ok()?;
+    let mut buf = [0u8; 4096];
+    let recv = tokio::time::timeout(DNS_TASK_TIMEOUT, socket.recv_from(&mut buf)).await;
+    let (n, _from) = recv.ok()?.ok()?;
+    if n >= 2 && u16::from_be_bytes([buf[0], buf[1]]) == query_id {
+        Some(buf[..n].to_vec())
+    } else {
+        None
+    }
+}
 
 /// Read the qtype from the first question of a DNS query payload. Returns
 /// `None` for malformed packets (truncation, missing terminator). Handles
@@ -1814,6 +1705,7 @@ pub(crate) fn dns_empty_response(query: &[u8]) -> Option<Vec<u8>> {
 /// bypass the tunnel by default so the dial reaches the real upstream
 /// over the device's underlying network interface rather than looping
 /// back into the tun's UDP/53 intercept.
+#[cfg(test)]
 pub(crate) async fn forward_dns_to_upstream(
     query: &[u8],
     upstreams: &[&str],
@@ -1872,6 +1764,7 @@ pub(crate) async fn forward_dns_to_upstream(
 /// addresses + ports, drop in `reply_payload`, leave the UDP checksum at 0
 /// (legal for IPv4, per RFC 768) and recompute the IPv4 header checksum.
 /// Returns `None` if the input isn't a parseable IPv4/UDP packet.
+#[cfg(test)]
 fn build_udp_reply(orig_ip_data: &[u8], reply_payload: &[u8]) -> Option<Vec<u8>> {
     if orig_ip_data.len() < 28 || (orig_ip_data[0] >> 4) != 4 || orig_ip_data[9] != 17 {
         return None;
@@ -1914,6 +1807,7 @@ fn build_udp_reply(orig_ip_data: &[u8], reply_payload: &[u8]) -> Option<Vec<u8>>
 
 /// One's-complement sum over a 20-byte IPv4 header. Caller has already
 /// zeroed the checksum field at bytes 10..12.
+#[cfg(test)]
 fn ipv4_header_checksum(header: &[u8]) -> u16 {
     let mut sum: u32 = 0;
     for chunk in header.chunks_exact(2) {
@@ -1930,6 +1824,7 @@ fn ipv4_header_checksum(header: &[u8]) -> u16 {
 /// avoid the positional-tuple footgun that hid the `from_ne_bytes` bug in
 /// FI-1: the UDP/53 intercept only consumed `dst_port`, so an endian flip in
 /// the IP fields wasn't visible at the call site.
+#[cfg(test)]
 struct ParsedUdp<'a> {
     #[allow(dead_code)] // reserved for future callers (NAT-style src logging)
     src_ip: u32,
@@ -1941,6 +1836,7 @@ struct ParsedUdp<'a> {
     payload: &'a [u8],
 }
 
+#[cfg(test)]
 fn parse_udp_packet(ip_data: &[u8]) -> Option<ParsedUdp<'_>> {
     if ip_data.len() < 28 {
         return None;


### PR DESCRIPTION
## Summary
- update meow-rs to 7e47ce60b65fb30837670e84d05bdcde8bf4813b and add meow-listener
- run local mixed and DNS listeners from the FFI engine, with tun2socks dialing the mixed listener via SOCKS5 CONNECT / UDP ASSOCIATE
- pin allow-lan, bind-address, mixed-port, and DNS listen settings so LAN clients can use the same listener path
- add Rust and Swift coverage for listener creation, DNS listener startup, and config patching

## Local-CI-green attestation
- [x] `swiftformat --lint .` -> 0/91 files require formatting
- [x] `swiftlint --strict` -> 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17'` -> **TEST SUCCEEDED**\n- [x] `scripts/build-rust.sh` -> device and simulator Rust builds succeeded; xcframework regenerated\n- [x] `cargo test` in `core/rust/meow-ios-ffi/` -> 51 unit tests + 2 stress tests passed\n- [x] `cargo fmt --check` in `core/rust/meow-ios-ffi/` -> passed\n- [x] `git diff origin/main...HEAD --stat` verified before PR: 13 intended files, 829 insertions, 731 deletions\n- [x] main CI baseline checked with `gh run list --branch main --workflow=ci.yml --limit=1`: latest main CI succeeded\n\n## Device validation\n- [x] `xcodebuild -project meow-ios.xcodeproj -scheme meow-ios -configuration Release -destination 'generic/platform=iOS' -derivedDataPath build/DerivedData DEVELOPMENT_TEAM=32B45SMMQL build` -> **BUILD SUCCEEDED**\n- [x] Installed current Release build on Max Lv’s iPhone with `xcrun devicectl device install app --device 00008150-001614340CEA401C build/DerivedData/Build/Products/Release-iphoneos/meow-ios.app`\n