### PR TITLE
[codex] Harden REST API credentials

### DIFF
--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -38,13 +38,11 @@ final class AppModel {
         vpnManager = VpnManager()
         // REST-API port + secret are minted by the engine (Rust
         // `meow_patch_config`) and shared via the App Group, so the loopback
-        // control plane is authenticated on a non-well-known port rather than
-        // open on 9090. Until the extension has patched a config once (no
-        // tunnel has ever started), the file is absent — fall back to the
-        // legacy 9090/empty pair so the pre-connect UI doesn't crash; the
-        // creds are refreshed on connect (see `refreshAPICredentials`).
+        // control plane is authenticated on a non-well-known port. Until the
+        // extension has patched a config once (no tunnel has ever started),
+        // the file is absent; keep the client unconfigured until connect.
         let creds = AppGroup.apiCredentials()
-        meowAPI = MeowAPI(port: creds?.port ?? 9090, secret: creds?.secret ?? "")
+        meowAPI = MeowAPI(port: creds?.port ?? 0, secret: creds?.secret ?? "")
         subscriptionService = SubscriptionService(
             modelContext: AppModelContainer.shared.container.mainContext,
         )
@@ -88,10 +86,9 @@ final class AppModel {
         let api = meowAPI
         // Retarget the client at the credentials the extension minted while
         // bringing the tunnel up. On a fresh install the credential file was
-        // absent at `init`, so `api` still holds the 9090/empty fallback; the
-        // extension has now written `api-credentials.json`, so pick it up
-        // before the probe below or every request would hit the wrong port /
-        // fail auth.
+        // absent at `init`, so `api` is still unconfigured; the extension has
+        // now written `api-credentials.json`, so pick it up before the probe
+        // below or every request would hit the wrong port / fail auth.
         if let creds = AppGroup.apiCredentials() {
             api.updateCredentials(port: creds.port, secret: creds.secret)
         }

--- a/App/Sources/Services/MeowAPI.swift
+++ b/App/Sources/Services/MeowAPI.swift
@@ -4,8 +4,8 @@ import NetworkExtension
 import os
 
 /// REST client for the meow external-controller that runs inside the
-/// packet-tunnel extension on `127.0.0.1:9090`. The URLSession requests are
-/// issued from the main app process; iOS routes loopback traffic correctly
+/// packet-tunnel extension on a random loopback port. The URLSession requests
+/// are issued from the main app process; iOS routes loopback traffic correctly
 /// even when the tunnel is active.
 @Observable
 final class MeowAPI: @unchecked Sendable {
@@ -36,7 +36,7 @@ final class MeowAPI: @unchecked Sendable {
     }
 
     init(
-        port: Int = 9090,
+        port: Int = 0,
         secret: String = "",
         session: URLSession = .shared,
     ) {
@@ -48,7 +48,7 @@ final class MeowAPI: @unchecked Sendable {
     /// Point the client at the port/secret the engine actually bound. On a
     /// fresh install the credential file doesn't exist when this client is
     /// first constructed (no tunnel has started), so the initial instance
-    /// holds the 9090/empty fallback; once the extension mints credentials on
+    /// is intentionally unconfigured; once the extension mints credentials on
     /// connect, the app calls this to retarget before issuing requests.
     /// No-op when `port`/`secret` are unchanged.
     func updateCredentials(port: Int, secret: String) {

--- a/App/Sources/Services/RulesYAMLEditor.swift
+++ b/App/Sources/Services/RulesYAMLEditor.swift
@@ -4,9 +4,9 @@ import Yams
 /// Read + write the `rules:` block of a Clash YAML config without touching
 /// any other top-level keys, comments aside (Yams round-trips through a
 /// model so trailing-comment fidelity is lost — that's a documented
-/// limitation, not unique to this editor; `EffectiveConfigWriter` already
-/// performs the same Yams round-trip on the same source YAML and the
-/// shipping behaviour treats that as acceptable).
+/// limitation, not unique to this editor; the config patcher already performs
+/// the same YAML round-trip on the same source YAML and the shipping behaviour
+/// treats that as acceptable).
 ///
 /// Each rule in the YAML is a single string, either:
 ///
@@ -41,8 +41,8 @@ enum RulesYAMLEditor {
     /// the rewritten YAML. Other top-level keys are preserved.
     ///
     /// Stable key ordering (`sortKeys: true`) matches what
-    /// `EffectiveConfigWriter.patch` already does so the on-disk effective
-    /// config diffs cleanly across edits.
+    /// the config patcher already does so the on-disk effective config diffs
+    /// cleanly across edits.
     static func apply(_ rules: [EditableRule], to sourceYAML: String) throws -> String {
         let loaded = try Yams.load(yaml: sourceYAML)
         var root: [String: Any] = (loaded as? [String: Any]) ?? [:]

--- a/App/Sources/Views/RulesEditorView.swift
+++ b/App/Sources/Views/RulesEditorView.swift
@@ -5,9 +5,8 @@ import SwiftUI
 /// Structured rules editor. Presented as a sheet from `RulesView`.
 ///
 /// Reads the `rules:` block out of the active `Profile.yamlContent` (the
-/// source of truth — what the engine actually loads via
-/// `EffectiveConfigWriter`), exposes Add / Delete / Reorder / per-row
-/// editing, validates the rewritten YAML through the FFI's
+/// source of truth before the extension patches it for engine startup),
+/// exposes Add / Delete / Reorder / per-row editing, validates the rewritten YAML through the FFI's
 /// `MeowConfigValidator`, persists back to the Profile, and writes the
 /// active config so the engine picks it up on next start.
 ///

--- a/MeowIntegrationTests/EngineIntegration/EngineBootTests.swift
+++ b/MeowIntegrationTests/EngineIntegration/EngineBootTests.swift
@@ -116,8 +116,7 @@ extension Tag {
 /// Scratch directory + minimal valid Clash YAML for boot tests. Uses
 /// non-default ports to avoid colliding with a real meow instance on
 /// the same host; `mixed-port` and `external-controller` are both
-/// picked well outside the 7890/9090 defaults the extension uses in
-/// production.
+/// picked well outside the extension-patched production ranges.
 private struct EngineFixture {
     let homeDir: String
     let configPath: String

--- a/MeowShared/Sources/MeowIPC/ProxyControlIPC.swift
+++ b/MeowShared/Sources/MeowIPC/ProxyControlIPC.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Payload used between the app and the PacketTunnel extension's
 /// `handleAppMessage` for proxy-control mutations that today round-trip
-/// through `PUT http://127.0.0.1:9090/proxies/{group}`. Routing the call
+/// through `PUT /proxies/{group}` on the loopback REST API. Routing the call
 /// through `sendProviderMessage` lets the extension invoke the
 /// `meow_proxy_select` FFI directly against meow-rs's `SelectorGroup`
 /// in-process, which:
@@ -10,10 +10,10 @@ import Foundation
 ///   1. eliminates the loopback HTTP hop and the URL percent-encoding /
 ///      Unicode-normalization step that breaks emoji-named groups (e.g.
 ///      `🚀 节点选择`),
-///   2. removes the need to expose meow's `external-controller` on
-///      `127.0.0.1:9090` solely for the picker, and
-///   3. drops the apiSecret as the only thing standing between any
-///      process on-device and a privileged mutation.
+///   2. removes the need to use meow's `external-controller` solely for the
+///      picker, and
+///   3. avoids treating the REST bearer token as the only thing standing
+///      between any process on-device and a privileged mutation.
 ///
 /// Tag dispatch matches the `DiagnosticsIPC` convention — the extension
 /// has a single `handleAppMessage` entry point, so the first byte routes

--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -6,13 +6,11 @@ import Yams
 ///
 ///   1. Remove user-managed `dns:` and `subscriptions:` blocks — the extension
 ///      owns DNS (fake-ip + local listener) and the app owns subscription fetching.
-///   2. Strip `secret:` so the REST API runs open on loopback — the app talks
-///      to the engine via `MeowAPI(secret: "")` and would 401 if the user's
-///      profile happened to ship a token.
+///   2. Override `secret:` with the random bearer token minted for this install.
 ///   3. Pin `mixed-port` (defaults to 7890), `allow-lan`, `bind-address`, and
 ///      a DNS listener so tun2socks and LAN clients can use meow's listeners.
-///   4. Pin `external-controller: 127.0.0.1:9090` so the app can talk to the
-///      engine's REST API over loopback.
+///   4. Pin `external-controller` to the random loopback port minted for this
+///      install so the app can talk to the engine's REST API over loopback.
 ///   5. Inject a `geox-url:` block (jsDelivr-hosted) when the user didn't
 ///      provide one, so the engine has somewhere to fetch geoip/geosite from.
 ///
@@ -21,7 +19,16 @@ import Yams
 public enum EffectiveConfigWriter {
     public static let defaultMixedPort = 7890
     public static let defaultDNSPort = 1053
-    public static let defaultExternalController = "127.0.0.1:9090"
+
+    public struct APICredentials: Sendable, Equatable {
+        public let port: Int
+        public let secret: String
+
+        public init(port: Int, secret: String) {
+            self.port = port
+            self.secret = secret
+        }
+    }
 
     /// Matches the Android client's jsDelivr mirrors of the MetaCubeX databases.
     /// `asn` is included so subscriptions with `IP-ASN,<num>,<group>` rules work
@@ -38,8 +45,13 @@ public enum EffectiveConfigWriter {
         sourceYAML: String,
         to destination: URL,
         prefs: Preferences,
+        apiCredentials: APICredentials,
     ) throws {
-        let effective = try patch(sourceYAML: sourceYAML, prefs: prefs)
+        let effective = try patch(
+            sourceYAML: sourceYAML,
+            prefs: prefs,
+            apiCredentials: apiCredentials,
+        )
         try FileManager.default.createDirectory(
             at: destination.deletingLastPathComponent(),
             withIntermediateDirectories: true,
@@ -48,13 +60,16 @@ public enum EffectiveConfigWriter {
     }
 
     /// Pure patcher — exposed for unit tests. Returns the effective YAML text.
-    public static func patch(sourceYAML: String, prefs: Preferences) throws -> String {
+    public static func patch(
+        sourceYAML: String,
+        prefs: Preferences,
+        apiCredentials: APICredentials,
+    ) throws -> String {
         let loaded = try Yams.load(yaml: sourceYAML)
         var root: [String: Any] = (loaded as? [String: Any]) ?? [:]
 
         root.removeValue(forKey: "dns")
         root.removeValue(forKey: "subscriptions")
-        root.removeValue(forKey: "secret")
 
         let mixedPort = prefs.mixedPort > 0 ? prefs.mixedPort : defaultMixedPort
         let bindAddress = prefs.allowLan ? "0.0.0.0" : "127.0.0.1"
@@ -71,7 +86,8 @@ public enum EffectiveConfigWriter {
                 "223.5.5.5",
             ],
         ]
-        root["external-controller"] = defaultExternalController
+        root["external-controller"] = "127.0.0.1:\(apiCredentials.port)"
+        root["secret"] = apiCredentials.secret
 
         if root["geox-url"] == nil {
             root["geox-url"] = defaultGeoXURL

--- a/MeowShared/Sources/MeowModels/Preferences.swift
+++ b/MeowShared/Sources/MeowModels/Preferences.swift
@@ -11,7 +11,6 @@ public enum PreferenceKey {
     public static let blockHTTP3 = "com.meow.blockHTTP3"
     public static let pendingIntent = "com.meow.pendingIntent"
     public static let selectedProfileID = "com.meow.selectedProfileID"
-    public static let apiSecret = "com.meow.apiSecret"
 }
 
 public enum PreferenceDefaults {

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -5,6 +5,19 @@ import Yams
 
 @Suite("EffectiveConfigWriter")
 struct EffectiveConfigWriterTests {
+    private static let apiCredentials = EffectiveConfigWriter.APICredentials(
+        port: 54321,
+        secret: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    )
+
+    private func patch(_ sourceYAML: String, prefs: Preferences = Preferences()) throws -> String {
+        try EffectiveConfigWriter.patch(
+            sourceYAML: sourceYAML,
+            prefs: prefs,
+            apiCredentials: Self.apiCredentials,
+        )
+    }
+
     @Test
     func `replaces dns and strips subscriptions top-level block`() throws {
         let source = """
@@ -22,7 +35,7 @@ struct EffectiveConfigWriterTests {
             cipher: aes-256-gcm
             password: p
         """
-        let out = try EffectiveConfigWriter.patch(sourceYAML: source, prefs: Preferences())
+        let out = try patch(source)
         #expect(!out.contains("subscriptions:"))
         #expect(out.contains("proxies:"))
         let parsed = try Yams.load(yaml: out) as? [String: Any]
@@ -32,7 +45,7 @@ struct EffectiveConfigWriterTests {
     }
 
     @Test
-    func `strips secret so REST API runs open on loopback`() throws {
+    func `overrides secret so REST API requires bearer token`() throws {
         let source = """
         secret: "deadbeef-token"
         proxies:
@@ -43,9 +56,9 @@ struct EffectiveConfigWriterTests {
             cipher: aes-256-gcm
             password: p
         """
-        let out = try EffectiveConfigWriter.patch(sourceYAML: source, prefs: Preferences())
+        let out = try patch(source)
         let parsed = try Yams.load(yaml: out) as? [String: Any]
-        #expect(parsed?["secret"] == nil)
+        #expect(parsed?["secret"] as? String == Self.apiCredentials.secret)
         #expect(out.contains("proxies:"))
     }
 
@@ -54,7 +67,7 @@ struct EffectiveConfigWriterTests {
         let source = "proxies: []\n"
         var prefs = Preferences()
         prefs.mixedPort = 17890
-        let out = try EffectiveConfigWriter.patch(sourceYAML: source, prefs: prefs)
+        let out = try patch(source, prefs: prefs)
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         #expect(parsed?["mixed-port"] as? Int == 17890)
     }
@@ -63,7 +76,7 @@ struct EffectiveConfigWriterTests {
     func `pins allow-lan and bind-address from preferences`() throws {
         var prefs = Preferences()
         prefs.allowLan = true
-        let out = try EffectiveConfigWriter.patch(sourceYAML: "proxies: []\n", prefs: prefs)
+        let out = try patch("proxies: []\n", prefs: prefs)
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         let dns = parsed?["dns"] as? [String: Any]
         #expect(parsed?["allow-lan"] as? Bool == true)
@@ -75,21 +88,21 @@ struct EffectiveConfigWriterTests {
     func `defaults mixed-port to 7890 when preference is zero`() throws {
         var prefs = Preferences()
         prefs.mixedPort = 0
-        let out = try EffectiveConfigWriter.patch(sourceYAML: "proxies: []\n", prefs: prefs)
+        let out = try patch("proxies: []\n", prefs: prefs)
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         #expect(parsed?["mixed-port"] as? Int == 7890)
     }
 
     @Test
-    func `pins external-controller to loopback:9090`() throws {
-        let out = try EffectiveConfigWriter.patch(sourceYAML: "proxies: []\n", prefs: Preferences())
+    func `pins external-controller to credential loopback port`() throws {
+        let out = try patch("proxies: []\n")
         let parsed = try Yams.load(yaml: out) as? [String: Any]
-        #expect(parsed?["external-controller"] as? String == "127.0.0.1:9090")
+        #expect(parsed?["external-controller"] as? String == "127.0.0.1:\(Self.apiCredentials.port)")
     }
 
     @Test
     func `injects geox-url when missing`() throws {
-        let out = try EffectiveConfigWriter.patch(sourceYAML: "proxies: []\n", prefs: Preferences())
+        let out = try patch("proxies: []\n")
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         let geo = parsed?["geox-url"] as? [String: String]
         #expect(geo?["geoip"]?.contains("jsdelivr.net") == true)
@@ -106,7 +119,7 @@ struct EffectiveConfigWriterTests {
           geosite: https://example.com/custom.dat
           mmdb: https://example.com/custom.mmdb
         """
-        let out = try EffectiveConfigWriter.patch(sourceYAML: source, prefs: Preferences())
+        let out = try patch(source)
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         let geo = parsed?["geox-url"] as? [String: String]
         #expect(geo?["geoip"] == "https://example.com/custom.metadb")
@@ -115,10 +128,11 @@ struct EffectiveConfigWriterTests {
 
     @Test
     func `empty source yields minimal effective config`() throws {
-        let out = try EffectiveConfigWriter.patch(sourceYAML: "", prefs: Preferences())
+        let out = try patch("")
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         #expect(parsed?["mixed-port"] as? Int == 7890)
-        #expect(parsed?["external-controller"] as? String == "127.0.0.1:9090")
+        #expect(parsed?["external-controller"] as? String == "127.0.0.1:\(Self.apiCredentials.port)")
+        #expect(parsed?["secret"] as? String == Self.apiCredentials.secret)
     }
 
     @Test
@@ -128,10 +142,10 @@ struct EffectiveConfigWriterTests {
         external-controller: 10.0.0.1:9999
         proxies: []
         """
-        let out = try EffectiveConfigWriter.patch(sourceYAML: source, prefs: Preferences())
+        let out = try patch(source)
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         #expect(parsed?["mixed-port"] as? Int == 7890)
-        #expect(parsed?["external-controller"] as? String == "127.0.0.1:9090")
+        #expect(parsed?["external-controller"] as? String == "127.0.0.1:\(Self.apiCredentials.port)")
     }
 
     @Test
@@ -144,6 +158,7 @@ struct EffectiveConfigWriterTests {
             sourceYAML: "proxies: []\n",
             to: tmp,
             prefs: Preferences(),
+            apiCredentials: Self.apiCredentials,
         )
         let written = try String(contentsOf: tmp, encoding: .utf8)
         let parsed = try Yams.load(yaml: written) as? [String: Any]

--- a/MeowTests/API/ConnectionsTests.swift
+++ b/MeowTests/API/ConnectionsTests.swift
@@ -42,7 +42,7 @@ struct ConnectionsTests {
         //   ConnectionsResponse { downloadTotal, uploadTotal, connections: [Connection]? }
         //   Connection { id, metadata: Metadata, upload, download, start, chains, rule, rulePayload }
         //
-        // Stub `http://127.0.0.1:9090/connections` with one entry, assert:
+        // Stub `http://127.0.0.1:<port>/connections` with one entry, assert:
         //   - `resp.connections?.count == 1`
         //   - first connection's `metadata.host` and `metadata.destinationPort` round-trip
         //   - `chains` decodes as ordered array (reversed in the view)

--- a/MeowTests/API/MeowAPITests.swift
+++ b/MeowTests/API/MeowAPITests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Testing
 
-/// Covers the `URLSession`-based client pointed at `http://127.0.0.1:9090`.
+/// Covers the `URLSession`-based client pointed at the engine's loopback REST API.
 /// Tests use `URLProtocolStub` (see `MeowTests/Support/URLProtocolStub.swift`)
 /// to inject canned responses.
 @Suite("MeowAPI REST client", .tags(.api))

--- a/MeowTests/API/RulesTests.swift
+++ b/MeowTests/API/RulesTests.swift
@@ -30,7 +30,7 @@ struct RulesTests {
         //   RulesResponse { rules: [Rule] }
         //   Rule { type, payload, proxy, id: "\(type)\(payload)\(proxy)" }
         //
-        // Stub `http://127.0.0.1:9090/rules` with a three-entry mix of
+        // Stub `http://127.0.0.1:<port>/rules` with a three-entry mix of
         // DOMAIN-SUFFIX / GEOIP / MATCH rules; assert each decodes and
         // `rule.id` is unique across the list (RulesView relies on
         // Identifiable for ForEach).

--- a/MeowTests/Support/URLProtocolStub.swift
+++ b/MeowTests/Support/URLProtocolStub.swift
@@ -8,7 +8,7 @@ import Foundation
 /// ```
 /// let config = URLSessionConfiguration.ephemeral
 /// config.protocolClasses = [URLProtocolStub.self]
-/// URLProtocolStub.responses[URL(string: "http://127.0.0.1:9090/version")!] =
+/// URLProtocolStub.responses[URL(string: "http://127.0.0.1:<port>/version")!] =
 ///     .init(statusCode: 200, body: Data(#"{"version":"test"}"#.utf8))
 /// let session = URLSession(configuration: config)
 /// ```

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -199,7 +199,7 @@ static os_log_t gLog;
     //
     //   { "select": { "group": "🚀 …", "name": "🇭🇰 01" } }
     //
-    // Replaces `PUT http://127.0.0.1:9090/proxies/{group}` with a direct
+    // Replaces `PUT /proxies/{group}` on the loopback REST API with a direct
     // call into the in-process selector — no loopback hop, no URL
     // percent-encoding step that breaks emoji / CJK / space-bearing
     // group names.

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -48,6 +48,9 @@ use std::time::Duration;
 static ENGINE_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 static TUN2SOCKS_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
+const TOKIO_RUNTIME_WORKERS: usize = 2;
+const TOKIO_RUNTIME_STACK_SIZE: usize = 1024 * 1024;
+
 fn build_runtime(
     name: &'static str,
     worker_threads: usize,
@@ -73,7 +76,11 @@ pub(crate) fn get_engine_runtime() -> &'static tokio::runtime::Runtime {
         // so RSS tracks the deepest poll actually executed, not the cap. The
         // deeper real frames are on this runtime: BoringSSL/rustls handshakes
         // inside layered transports plus relay combinator frames.
-        build_runtime("meow-engine", 2, 1024 * 1024)
+        build_runtime(
+            "meow-engine",
+            TOKIO_RUNTIME_WORKERS,
+            TOKIO_RUNTIME_STACK_SIZE,
+        )
     })
 }
 
@@ -82,13 +89,11 @@ pub(crate) fn get_tun2socks_runtime() -> &'static tokio::runtime::Runtime {
         // Tun2socks owns packet ingress/egress, lwIP stack driving, and
         // accept-loop bookkeeping. It deliberately does not run meow proxy
         // dials or REST/API tasks.
-        //
-        // Four worker threads: the lwIP netstack is serialized by a spinning
-        // `LWIP_MUTEX`, and with only two workers a contender that spins on it
-        // can starve the lock holder under a startup connection burst. More
-        // workers widen that window so a stuck pair can't halt all tun2socks
-        // progress.
-        build_runtime("meow-tun2socks", 4, 1024 * 1024)
+        build_runtime(
+            "meow-tun2socks",
+            TOKIO_RUNTIME_WORKERS,
+            TOKIO_RUNTIME_STACK_SIZE,
+        )
     })
 }
 
@@ -556,14 +561,22 @@ fn api_credentials() -> (u16, String) {
         }
     }
 
-    let port = random_port();
-    let secret = random_hex_32();
+    let port = available_loopback_port().unwrap_or_else(random_port);
+    let secret = random_hex_64();
 
     if let Some(ref p) = path {
+        if let Some(parent) = p.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
         let body = serde_json::json!({ "port": port, "secret": secret }).to_string();
-        // Best-effort persist; if it fails we still return the freshly-minted
-        // pair so this engine start is authenticated.
-        let _ = std::fs::write(p, body);
+        let tmp = p.with_extension("json.tmp");
+        // Best-effort atomic persist; if it fails we still return the freshly
+        // minted pair so this engine start is authenticated.
+        if std::fs::write(&tmp, &body).is_ok() {
+            let _ = std::fs::rename(&tmp, p);
+        } else {
+            let _ = std::fs::write(p, body);
+        }
     }
 
     (port, secret)
@@ -579,20 +592,29 @@ fn os_random(buf: &mut [u8]) {
     f.read_exact(buf).expect("/dev/urandom read must succeed");
 }
 
-/// 16 random bytes of OS entropy, hex-encoded — a 128-bit bearer secret.
-fn random_hex_32() -> String {
-    let mut buf = [0u8; 16];
+/// 32 random bytes of OS entropy, hex-encoded — a 256-bit bearer secret.
+fn random_hex_64() -> String {
+    let mut buf = [0u8; 32];
     os_random(&mut buf);
-    let mut s = String::with_capacity(32);
+    let mut s = String::with_capacity(64);
     for b in buf {
         s.push_str(&format!("{b:02x}"));
     }
     s
 }
 
+/// Ask the OS for an available loopback port. The socket is dropped before
+/// meow-api binds, so this is not a hard reservation, but it avoids minting a
+/// credential for a port already in use at patch time.
+fn available_loopback_port() -> Option<u16> {
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).ok()?;
+    listener.local_addr().ok().map(|addr| addr.port())
+}
+
 /// A random port in the IANA dynamic/ephemeral range (49152–65535), drawn from
-/// OS entropy. Persisted, so it's stable across launches but not the
-/// well-known 9090.
+/// OS entropy. Fallback only; normally `available_loopback_port` lets the OS
+/// choose a currently free loopback port. Persisted, so it's stable across
+/// launches but not the well-known 9090.
 fn random_port() -> u16 {
     let mut buf = [0u8; 2];
     os_random(&mut buf);
@@ -1078,5 +1100,40 @@ rules:
         assert!(patched.contains("bind-address: 0.0.0.0"));
         assert!(patched.contains("listen: 0.0.0.0:1054"));
         assert!(!patched.contains("subscriptions:"));
+    }
+
+    #[test]
+    fn patch_config_hardens_rest_api_with_random_port_and_secret() {
+        let patched = patch_config(
+            r#"
+external-controller: 127.0.0.1:9090
+secret: user-provided
+proxies: []
+"#,
+            7890,
+            0,
+            1053,
+        );
+        let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
+        let root = doc.as_mapping().expect("mapping root");
+        let controller = root
+            .get(serde_yaml::Value::String("external-controller".into()))
+            .and_then(serde_yaml::Value::as_str)
+            .expect("external-controller");
+        let port = controller
+            .strip_prefix("127.0.0.1:")
+            .expect("loopback controller")
+            .parse::<u16>()
+            .expect("controller port");
+        assert_ne!(port, 9090);
+        assert!(port > 0);
+
+        let secret = root
+            .get(serde_yaml::Value::String("secret".into()))
+            .and_then(serde_yaml::Value::as_str)
+            .expect("secret");
+        assert_ne!(secret, "user-provided");
+        assert_eq!(secret.len(), 64);
+        assert!(secret.bytes().all(|b| b.is_ascii_hexdigit()));
     }
 }


### PR DESCRIPTION
## Summary
- mint and persist per-install REST API credentials for the meow external-controller
- replace the fixed 9090 controller fallback with a random loopback port plus 256-bit bearer secret
- retarget the app REST client from api-credentials.json after tunnel startup
- keep Tokio runtimes pinned to 2 worker threads

## Local CI attestation
- [x] `swiftformat --lint .` ran locally at the repo root: 0 violations
- [x] `swiftlint --strict` ran locally at the repo root: 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17'` ran locally: passed
- [x] `scripts/build-rust.sh` ran locally: passed
- [x] `cargo test` ran locally in `core/rust/meow-ios-ffi/`: passed
- [x] `git diff origin/main...HEAD --stat` was verified; the diff matches the intended REST API hardening and Tokio worker changes
- [x] `gh run list --branch main --workflow=ci.yml --limit=1` was checked; latest main CI was success

## Additional checks
- [x] `cargo fmt -- --check`
- [x] `git diff --check`