### PR TITLE
Bump meow-rs to latest (fabcac15): improve direct hostname fallback

### DIFF
--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "axum",
  "base64",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "base64",
  "libc",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1956,12 +1956,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=370dce39c20ca86a8a61ec82194bc90164fb3418#370dce39c20ca86a8a61ec82194bc90164fb3418"
+source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,9 +68,9 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 370dce39 — cross-platform HostResolver + system-DNS cache for upstream
-# dials (meow-rs#228) plus rule-matching allocation-pressure fix.
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "370dce39c20ca86a8a61ec82194bc90164fb3418" }
+# HEAD: fabcac15 — improve direct-outbound hostname fallback on top of the
+# cross-platform HostResolver + system-DNS cache for upstream dials (meow-rs#228).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -78,12 +78,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "370dce39c20ca8
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "370dce39c20ca86a8a61ec82194bc90164fb3418", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "370dce39c20ca86a8a61ec82194bc90164fb3418" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "370dce39c20ca86a8a61ec82194bc90164fb3418" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "370dce39c20ca86a8a61ec82194bc90164fb3418", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "370dce39c20ca86a8a61ec82194bc90164fb3418" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "370dce39c20ca86a8a61ec82194bc90164fb3418" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
 
 [build-dependencies]
 cbindgen = "0.28"


### PR DESCRIPTION
## What

Bump the embedded meow-rs engine `370dce39` → `fabcac15` (current `madeye/meow-rs` main):

- **"Improve direct hostname fallback"** — touches the host-resolver hook, direct-outbound path, and `socket_protect`. Builds on the cross-platform `HostResolver` + system-DNS cache for upstream dials (#228) that landed in the previous bump (#251).

Pure dependency bump — only `Cargo.toml` + `Cargo.lock`. No meow-ios FFI source change (cbindgen regenerated `meow_core.h` identically; xcframework rebuilt clean).

## Path B attestation (code PR, admin rebase-merge)

1. `swiftformat --lint .` (repo root) → **0 violations**
2. `swiftlint --strict` (repo root) → **0 violations** (82 files)
3. Tests matching the diff (Rust/FFI):
   - `cargo build` clean; `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean
   - `cargo test --lib` in `core/rust/meow-ios-ffi/` → **52 passed**
   - `scripts/build-rust.sh` → all 3 iOS targets (device + 2 sim) built, `MeowCore.xcframework` written, header regenerated unchanged
4. `git diff origin/main...HEAD --stat` verified — 2 files (`Cargo.toml`, `Cargo.lock`), no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
