### PR TITLE
Bump meow-rs to b2278de: fake-IP reverse-map on SOCKS5 TCP path

### DIFF
--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "axum",
  "base64",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "base64",
  "libc",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1956,16 +1956,17 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=fabcac15fcd9d17d80f209c2dff55dc3820106e6#fabcac15fcd9d17d80f209c2dff55dc3820106e6"
+source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
 dependencies = [
  "arc-swap",
  "async-trait",
  "dashmap 6.2.1",
+ "ipnet",
  "itoa",
  "meow-common",
  "meow-dns",
@@ -1973,6 +1974,7 @@ dependencies = [
  "meow-rules",
  "meow-trie",
  "parking_lot",
+ "regex",
  "serde",
  "smallvec",
  "smol_str",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,9 +68,9 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: fabcac15 — improve direct-outbound hostname fallback on top of the
-# cross-platform HostResolver + system-DNS cache for upstream dials (meow-rs#228).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
+# HEAD: b2278de — SOCKS5 TCP path reverse-maps fake-IP → host before rule
+# matching (meow-rs#233) on top of the direct-outbound hostname fallback.
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -78,12 +78,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d1
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "fabcac15fcd9d17d80f209c2dff55dc3820106e6" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
 
 [build-dependencies]
 cbindgen = "0.28"


### PR DESCRIPTION
## What

Bump the embedded meow-rs engine `fabcac15` → `b2278de` (current `madeye/meow-rs` main, **#233**):

- **SOCKS5 TCP path now reverse-maps fake-IP → host before rule matching.** `handle_socks5_inner` was matching rules (and dialing) on the raw `28.x`/`198.18.x` placeholder that tun2socks hands the listener, so every fake-IP'd TCP flow matched no `DOMAIN`/`GEOSITE`/`GEOIP` rule and fell through to `MATCH()` → final (and dialed the dead fake IP when SNI/Host sniffing didn't recover a host — the `relay error: unexpected end of file` lines). It now calls `pre_handle_metadata` + `pre_resolve` like the canonical TCP handler and the UDP path.

Pure dependency bump — only `Cargo.toml` + `Cargo.lock`. No meow-ios FFI source change (cbindgen regenerated `meow_core.h` identically; xcframework rebuilt clean).

Diagnosed from a device log (`tun2socks hangs` report); this fixes the fake-IP→Final routing correctness. (Separate from the data-path livelock, which still wants a watchdog.)

## Path B attestation (code PR, admin rebase-merge)

1. `swiftformat --lint .` (repo root) → **0 violations**
2. `swiftlint --strict` (repo root) → **0 violations** (82 files)
3. Tests matching the diff (Rust/FFI):
   - `cargo build` / `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` — clean
   - `cargo test --lib` in `core/rust/meow-ios-ffi/` → **52 passed**
   - `scripts/build-rust.sh` → all 3 iOS targets built, `MeowCore.xcframework` written, header regenerated unchanged
4. `git diff origin/main...HEAD --stat` verified — 2 files (`Cargo.toml`, `Cargo.lock`), no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
