### PR TITLE
fix(ffi): run REST control API on its own runtime (fixes open-app engine freeze)

### DIFF
--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -366,7 +366,11 @@ pub fn start(config_path: &str) -> Result<()> {
             rule_providers,
             listeners,
         );
-        crate::get_engine_runtime().spawn(async move {
+        // Spawn on the dedicated API runtime, NOT the engine runtime: a burst
+        // of REST calls (e.g. the host app's per-stage `/proxies` + `/configs`
+        // wave) must not be able to starve the data-path relay / DNS tasks that
+        // share the engine workers. See `get_api_runtime`.
+        crate::get_api_runtime().spawn(async move {
             if let Err(e) = api_server.run().await {
                 error!("API server error: {}", e);
             }
@@ -401,9 +405,12 @@ pub fn stop() {
     // actually happen before `stop()` returns — without it, a rapid
     // start → stop → start cycle observed `EADDRINUSE` on the REST bind.
     let runtime = crate::get_engine_runtime();
+    // The API task lives on its own runtime (see `get_api_runtime`), so its
+    // abort/join must be driven by that runtime — `block_on` only awaits tasks
+    // belonging to the runtime it's called on.
     if let Some(h) = state.api_task {
         h.abort();
-        let _ = runtime.block_on(h);
+        let _ = crate::get_api_runtime().block_on(h);
     }
     for h in state.listener_tasks {
         h.abort();

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -47,8 +47,15 @@ use std::time::Duration;
 
 static ENGINE_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 static TUN2SOCKS_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+static API_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 const TOKIO_RUNTIME_WORKERS: usize = 2;
+/// The REST control API serves a bursty, host-app-driven workload (a wave of
+/// `/proxies` + `/configs` requests on every connection-stage transition) and
+/// is otherwise idle. One worker is plenty — its only job is to keep that
+/// burst OFF the engine runtime so a synchronous `/proxies` serialization
+/// cannot starve the data-path relay / DNS tasks.
+const TOKIO_API_RUNTIME_WORKERS: usize = 1;
 const TOKIO_RUNTIME_STACK_SIZE: usize = 1024 * 1024;
 
 fn build_runtime(
@@ -79,6 +86,25 @@ pub(crate) fn get_engine_runtime() -> &'static tokio::runtime::Runtime {
         build_runtime(
             "meow-engine",
             TOKIO_RUNTIME_WORKERS,
+            TOKIO_RUNTIME_STACK_SIZE,
+        )
+    })
+}
+
+pub(crate) fn get_api_runtime() -> &'static tokio::runtime::Runtime {
+    API_RUNTIME.get_or_init(|| {
+        // The REST/external-controller server runs on its OWN runtime, isolated
+        // from both the engine workers (proxy dials, DNS, relay) and the
+        // tun2socks workers (lwIP / packet I/O). Before this split, a burst of
+        // REST calls on app foreground — `get_proxies` is a no-`await`
+        // synchronous CPU sink that builds + serialises the whole proxy table —
+        // could peg both engine workers and stall packet forwarding (the
+        // "open app → engine freeze" report). Keeping the API on a separate
+        // single-worker pool means a REST burst can no longer steal CPU from
+        // the data path.
+        build_runtime(
+            "meow-api",
+            TOKIO_API_RUNTIME_WORKERS,
             TOKIO_RUNTIME_STACK_SIZE,
         )
     })


### PR DESCRIPTION
## Problem

Opening the app could freeze meow-engine: packet forwarding stops while the NE process stays alive.

**Root cause — REST burst starves the data path.** The external-controller (REST/Clash API) was spawned on `get_engine_runtime()`, the same **2-worker** tokio pool that also hosts the SOCKS5 data-path listener, the meow-dns server, and the proxy-dial/relay tasks (`engine.rs` spawns + `lib.rs:51 TOKIO_RUNTIME_WORKERS = 2`).

On app foreground the host app fires a burst of `/proxies` + `/configs` on **every** NEVPNStatus stage transition:
- `HomeView` fires `getProxies + getConfigs` on both `.task(id: vpnManager.stage)` **and** `.task(id: appModel.replayGeneration)`,
- `ProxyGroupsView` fires a third `getProxies` on its own `.task(id: stage)`.

`get_proxies` (meow-api `routes.rs:291`) is a **no-`await` synchronous CPU sink**: `route_snapshot` → build a `HashMap` → `ProxyInfo::from_proxy` per node (which emits a `debug!` per node) → serde-serialize the whole map. Two–three concurrent calls peg **both** engine workers, starving the relay/accept/DNS tasks on the same runtime → packets stop. New flows can't resolve DNS (also on the starved runtime), so the stall compounds, and per-stage-flip re-firing prevents catch-up.

(The `b2278de` fake-IP reverse-map fix already removed the older `relay error: unexpected end of file` aggravator, leaving this worker-starvation as the dominant trigger.)

## Fix

Spawn the `ApiServer` on a **dedicated single-worker runtime** (`get_api_runtime`) instead of the engine runtime, so a REST burst can no longer steal CPU from the data path. `stop()` joins the API task on that runtime (`block_on` only awaits tasks belonging to the runtime it runs on). The data path itself is fully cooperative (awaits at every I/O point), so isolating the bursty API workload is sufficient.

Scope intentionally minimal — repo-local FFI change only, no meow-rs bump:
- **Not changing** the Swift double-fetch (HomeView stage + replayGeneration): intentional, guards a documented replay race, and harmless now that the API is isolated.
- **Follow-up (separate meow-rs PR):** drop the per-node `debug!` in `from_proxy` — pure efficiency, no longer a freeze cause.

## Path B — local CI attestation (Rust/FFI change; no Swift/YAML touched)

- [x] `cargo fmt --all -- --check` → clean
- [x] `cargo clippy --all-targets -- -D warnings` (in `core/rust/meow-ios-ffi/`) → 0 warnings
- [x] `cargo test --lib` (in `core/rust/meow-ios-ffi/`) → **52 passed, 0 failed**
- [x] `scripts/build-rust.sh` → aarch64-apple-ios + -sim release builds clean, xcframework written
- [x] `git diff origin/main...HEAD --stat` verified → only `core/rust/meow-ios-ffi/src/{engine.rs,lib.rs}`, no accidental additions
- swiftlint/swiftformat: N/A — no Swift files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)