### PR TITLE
feat(ffi): cap loopback meow-listener connections at 256

### DIFF
--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -34,6 +34,16 @@ use tracing_subscriber::prelude::*;
 
 use crate::logging::LogForwardLayer;
 
+/// Connection cap applied to the loopback SOCKS5/mixed listener that lwIP
+/// dials. The meow-config default is `0` (unlimited); on iOS we bound it so a
+/// burst of new flows can't spawn unbounded per-connection handler state on
+/// the engine runtime. Sized to match `tun2socks::TCP_ACCEPT_CAP_DEFAULT`
+/// (256) — the tun2socks side already caps in-flight flows there, so the
+/// listener will rarely hit this, but it backstops the case where a client
+/// other than our own tun2socks dials the loopback port. An explicit
+/// `max-connections` in the config still wins.
+const LOOPBACK_LISTENER_MAX_CONNECTIONS: usize = 256;
+
 fn loopback_addr(port: u16) -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
 }
@@ -321,10 +331,17 @@ pub fn start(config_path: &str) -> Result<()> {
             meow_config::ListenerType::Mixed
             | meow_config::ListenerType::Http
             | meow_config::ListenerType::Socks5 => {
+                // Config default is 0 (unlimited); apply the iOS loopback cap
+                // unless the config set an explicit per-listener/global value.
+                let max_connections = if nl.max_connections == 0 {
+                    LOOPBACK_LISTENER_MAX_CONNECTIONS
+                } else {
+                    nl.max_connections
+                };
                 let listener = MixedListener::new(tunnel.clone(), addr, nl.name.clone())
                     .with_sniffer(sniffer_runtime.clone())
                     .with_auth(auth.clone())
-                    .with_max_connections(nl.max_connections);
+                    .with_max_connections(max_connections);
                 listener_tasks.push(crate::get_engine_runtime().spawn(async move {
                     if let Err(e) = listener.run().await {
                         error!("Mixed listener error: {}", e);


### PR DESCRIPTION
## What

The MixedListener (the loopback SOCKS5/mixed listener that lwIP dials) ran with **no connection cap**. meow-config's `DEFAULT_MAX_CONNECTIONS` is `0` (= unlimited / no semaphore), the iOS effective config sets no `max-connections`, and `nl.max_connections` falls back to the global `0` — so `MixedListener` created no connection semaphore at all.

This applies a **256** cap when the config leaves it unlimited, sized to match `tun2socks::TCP_ACCEPT_CAP_DEFAULT` (256). An explicit per-listener or global `max-connections` in the config still takes precedence.

The tun2socks side already bounds in-flight flows at 256, so in normal operation the listener rarely approaches this — it backstops the case where something other than our own tun2socks dials the loopback port.

## Path B — local CI attestation (Rust/FFI change; no Swift/YAML touched)

- [x] `cargo fmt --all -- --check` → clean
- [x] `cargo clippy --all-targets -- -D warnings` → 0 warnings
- [x] `cargo test --lib` → 52 passed, 0 failed
- [x] `scripts/build-rust.sh` → aarch64-apple-ios + -sim release builds clean, xcframework written
- [x] `git diff origin/main...HEAD --stat` → only `core/rust/meow-ios-ffi/src/engine.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)