### PR TITLE
feat(dns): drop fake-IP for normal/redir-host mode + opt-in IPv6

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -162,6 +162,8 @@
 "settings.toggle.onDemand" = "Connect On Demand";
 "settings.toggle.blockHTTP3" = "Block HTTP/3 (QUIC)";
 "settings.toggle.blockHTTP3.footer" = "Drops UDP traffic to port 443 and SVCB/HTTPS DNS records to force TCP/HTTP2.";
+"settings.toggle.ipv6" = "Enable IPv6";
+"settings.toggle.ipv6.footer" = "Resolves AAAA records and routes IPv6 traffic through the tunnel. When off, the tunnel is IPv4-only and AAAA queries are dropped.";
 "settings.picker.logLevel" = "Log Level";
 "settings.logLevel.debug" = "Debug";
 "settings.logLevel.info" = "Info";
@@ -285,6 +287,7 @@
 "a11y.settings.allowLan.hint" = "Allows other devices on your local network to connect through the proxy.";
 "a11y.settings.onDemand.hint" = "Automatically starts the tunnel when network activity requires it.";
 "a11y.settings.blockHTTP3.hint" = "Blocks HTTP/3 and QUIC by dropping UDP traffic to port 443 and SVCB/HTTPS DNS records, forcing connections onto TCP and HTTP/2.";
+"a11y.settings.ipv6.hint" = "Enables IPv6 by resolving AAAA records and routing IPv6 traffic through the tunnel. When off, the tunnel is IPv4-only and AAAA queries are dropped.";
 "a11y.settings.exportLogs.hint" = "Saves the last hour of app logs to a file.";
 "a11y.settings.exportLogs.inProgress" = "Export in progress";
 "a11y.settings.memory.unavailable" = "Unavailable";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -168,6 +168,8 @@
 "settings.toggle.onDemand" = "按需自动连接";
 "settings.toggle.blockHTTP3" = "屏蔽 HTTP/3 (QUIC)";
 "settings.toggle.blockHTTP3.footer" = "丢弃发往 443 端口的 UDP 流量及 SVCB/HTTPS DNS 记录，强制使用 TCP/HTTP2。";
+"settings.toggle.ipv6" = "启用 IPv6";
+"settings.toggle.ipv6.footer" = "解析 AAAA 记录并将 IPv6 流量路由经过隧道。关闭时隧道仅使用 IPv4，AAAA 查询将被丢弃。";
 "settings.picker.logLevel" = "日志级别";
 "settings.logLevel.debug" = "调试";
 "settings.logLevel.info" = "信息";
@@ -291,6 +293,7 @@
 "a11y.settings.allowLan.hint" = "允许局域网内的其他设备通过代理连接。";
 "a11y.settings.onDemand.hint" = "在需要网络连接时自动启动隧道。";
 "a11y.settings.blockHTTP3.hint" = "通过丢弃发往 443 端口的 UDP 流量及 SVCB/HTTPS DNS 记录来屏蔽 HTTP/3 和 QUIC，强制连接使用 TCP 和 HTTP/2。";
+"a11y.settings.ipv6.hint" = "通过解析 AAAA 记录并将 IPv6 流量路由经过隧道来启用 IPv6。关闭时隧道仅使用 IPv4，AAAA 查询将被丢弃。";
 "a11y.settings.exportLogs.hint" = "将最近一小时的应用日志保存为文件。";
 "a11y.settings.exportLogs.inProgress" = "正在导出";
 "a11y.settings.memory.unavailable" = "不可用";

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -35,6 +35,15 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                         .accessibilityHidden(true)
                 }
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("settings.toggle.ipv6", isOn: binding(\.ipv6Enabled))
+                        .accessibilityIdentifier("settings.toggle.ipv6")
+                        .accessibilityHint(Text("a11y.settings.ipv6.hint"))
+                    Text("settings.toggle.ipv6.footer")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
                 Picker("settings.picker.logLevel", selection: binding(\.logLevel)) {
                     Text("settings.logLevel.debug").tag("debug")
                     Text("settings.logLevel.info").tag("info")
@@ -110,6 +119,7 @@ struct SettingsView: View {
         #endif
             .onChange(of: preferences.allowLan) { _, _ in persist() }
             .onChange(of: preferences.blockHTTP3) { _, _ in persist() }
+            .onChange(of: preferences.ipv6Enabled) { _, _ in persist() }
             .onChange(of: preferences.logLevel) { _, _ in persist() }
             .onChange(of: preferences.onDemand) { _, _ in
                 persist()

--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -350,6 +350,30 @@ int meow_tun_set_block_http3(int enabled);
 int meow_tun_block_http3(void);
 
 /**
+ * Enable or disable IPv6. Default OFF (0): current behaviour is preserved —
+ * the tunnel is IPv4-only and AAAA (28) DNS queries are answered NOERROR-empty
+ * from the intercept so clients fall back to the IPv4 path. When enabled
+ * (non-zero), AAAA queries are forwarded to the meow-dns listener like A
+ * queries (the resolver returns real upstream IPv6 addresses). The caller MUST
+ * also configure the TUN with an IPv6 address + default route (see
+ * `MWTunnelSettings`) so those v6 connections enter the netstack; otherwise
+ * they black-hole.
+ *
+ * At the FFI layer the new value applies immediately to subsequent DNS
+ * queries (the backing flag is a plain atomic). The meow-ios app only invokes
+ * this at tunnel start, so toggling the user preference applies on the next
+ * tunnel (re)connect — same as allowLan / blockHTTP3.
+ *
+ * Returns 0 unconditionally.
+ */
+int meow_tun_set_ipv6_enabled(int enabled);
+
+/**
+ * Read whether IPv6 is currently enabled. Returns 1 if enabled, 0 otherwise.
+ */
+int meow_tun_ipv6_enabled(void);
+
+/**
  * Resident memory size of the FFI's containing process, in bytes. Same
  * number macOS jetsam compares against the 50 MiB PacketTunnel cap, so
  * Swift can poll this to chart the on-device RSS curve during a stress

--- a/MeowIntegrationTests/VPNLifecycle/TunnelSettings.swift
+++ b/MeowIntegrationTests/VPNLifecycle/TunnelSettings.swift
@@ -32,7 +32,18 @@ enum TunnelSettings {
         ]
     }
 
-    static func make(serverAddress: String) -> NEPacketTunnelNetworkSettings {
+    /// IPv6 LAN exclusions, mirrored from MWTunnelSettings.ipv6LanExcludedRoutes:
+    /// keep link-local, unique-local (ULA, incl. the TUN's own fd6d:6577::/64),
+    /// and multicast off the ::/0 default route, mirroring the IPv4 policy.
+    static var ipv6LanExcludedRoutes: [NEIPv6Route] {
+        [
+            route6(address: "fe80::", prefix: 10), // link-local
+            route6(address: "fc00::", prefix: 7), // unique local (ULA)
+            route6(address: "ff00::", prefix: 8), // multicast
+        ]
+    }
+
+    static func make(serverAddress: String, ipv6Enabled: Bool = false) -> NEPacketTunnelNetworkSettings {
         let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: serverAddress)
 
         let ipv4 = NEIPv4Settings(addresses: ["172.19.0.1"], subnetMasks: ["255.255.255.252"])
@@ -40,9 +51,17 @@ enum TunnelSettings {
         ipv4.excludedRoutes = ipv4LanExcludedRoutes
         settings.ipv4Settings = ipv4
 
-        // IPv4-only tunnel: ipv6Settings is intentionally left nil so the TUN
-        // claims no IPv6 address and installs no IPv6 routes. Mirrors
-        // MWTunnelSettings.makeWithServerAddress:.
+        // IPv6 is configured only when enabled in app settings (mirrors
+        // MWTunnelSettings.makeWithServerAddress:ipv6Enabled:). When off, the
+        // TUN claims no IPv6 address/routes and the FFI drops AAAA so the tunnel
+        // is IPv4-only. When on, claim a ULA address + ::/0 default route so
+        // real-IPv6 destinations enter the tunnel instead of leaking natively.
+        if ipv6Enabled {
+            let ipv6 = NEIPv6Settings(addresses: ["fd6d:6577::1"], networkPrefixLengths: [64])
+            ipv6.includedRoutes = [NEIPv6Route.default()]
+            ipv6.excludedRoutes = ipv6LanExcludedRoutes
+            settings.ipv6Settings = ipv6
+        }
 
         let dns = NEDNSSettings(servers: ["172.19.0.2"])
         // Leaving matchDomains at its default (nil) — see NEDNSSettings.h,
@@ -57,5 +76,9 @@ enum TunnelSettings {
 
     private static func route(address: String, mask: String) -> NEIPv4Route {
         NEIPv4Route(destinationAddress: address, subnetMask: mask)
+    }
+
+    private static func route6(address: String, prefix: Int) -> NEIPv6Route {
+        NEIPv6Route(destinationAddress: address, networkPrefixLength: NSNumber(value: prefix))
     }
 }

--- a/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
+++ b/MeowIntegrationTests/VPNLifecycle/TunnelSettingsLANExclusionTests.swift
@@ -93,11 +93,42 @@ final class TunnelSettingsLANExclusionTests: XCTestCase {
         )
     }
 
-    /// The tunnel is IPv4-only: ipv6Settings must be left nil so the TUN
-    /// claims no IPv6 address and installs no IPv6 routes.
-    func testMakeConfiguresNoIPv6() {
+    /// IPv6 disabled (the default): ipv6Settings must be left nil so the TUN
+    /// claims no IPv6 address and installs no IPv6 routes — the tunnel is
+    /// IPv4-only and the FFI drops AAAA.
+    func testMakeConfiguresNoIPv6WhenDisabled() {
         let settings = TunnelSettings.make(serverAddress: "192.0.2.1")
-        XCTAssertNil(settings.ipv6Settings, "tunnel must be IPv4-only; ipv6Settings must stay nil")
+        XCTAssertNil(settings.ipv6Settings, "ipv6Settings must stay nil when IPv6 is disabled")
+    }
+
+    /// IPv6 enabled: the TUN must claim a ULA address and a ::/0 default route
+    /// (so real-IPv6 destinations are proxied instead of leaking natively),
+    /// with link-local / ULA / multicast excluded — mirroring the IPv4 policy.
+    func testMakeConfiguresIPv6WhenEnabled() {
+        let settings = TunnelSettings.make(serverAddress: "192.0.2.1", ipv6Enabled: true)
+        let ipv6 = settings.ipv6Settings
+        XCTAssertNotNil(ipv6, "ipv6Settings must be configured when IPv6 is enabled")
+        XCTAssertEqual(ipv6?.addresses, ["fd6d:6577::1"], "expected the ULA tunnel address")
+
+        let included = ipv6?.includedRoutes ?? []
+        XCTAssertEqual(included.count, 1, "catch-all v6 default route should be present")
+        XCTAssertEqual(included.first?.destinationAddress, "::")
+
+        let expectedExclusions: [(String, NSNumber)] = [
+            ("fe80::", 10),
+            ("fc00::", 7),
+            ("ff00::", 8),
+        ]
+        let excluded = ipv6?.excludedRoutes ?? []
+        XCTAssertEqual(excluded.count, expectedExclusions.count, "v6 excludedRoutes count mismatch")
+        for (index, (address, prefix)) in expectedExclusions.enumerated() {
+            XCTAssertEqual(excluded[index].destinationAddress, address, "index \(index) v6 destinationAddress")
+            XCTAssertEqual(
+                excluded[index].destinationNetworkPrefixLength,
+                prefix,
+                "index \(index) v6 prefix length",
+            )
+        }
     }
 
     func testMakeStillRoutesAllTrafficByDefault() {

--- a/MeowShared/Sources/MeowModels/Preferences.swift
+++ b/MeowShared/Sources/MeowModels/Preferences.swift
@@ -9,6 +9,7 @@ public enum PreferenceKey {
     public static let allowLan = "com.meow.allowLan"
     public static let onDemand = "com.meow.onDemand"
     public static let blockHTTP3 = "com.meow.blockHTTP3"
+    public static let ipv6Enabled = "com.meow.ipv6Enabled"
     public static let pendingIntent = "com.meow.pendingIntent"
     public static let selectedProfileID = "com.meow.selectedProfileID"
 }
@@ -19,6 +20,7 @@ public enum PreferenceDefaults {
     public static let allowLan: Bool = false
     public static let onDemand: Bool = false
     public static let blockHTTP3: Bool = false
+    public static let ipv6Enabled: Bool = false
 }
 
 public struct Preferences: Sendable {
@@ -27,6 +29,7 @@ public struct Preferences: Sendable {
     public var allowLan: Bool
     public var onDemand: Bool
     public var blockHTTP3: Bool
+    public var ipv6Enabled: Bool
 
     public init(
         mixedPort: Int = PreferenceDefaults.mixedPort,
@@ -34,12 +37,14 @@ public struct Preferences: Sendable {
         allowLan: Bool = PreferenceDefaults.allowLan,
         onDemand: Bool = PreferenceDefaults.onDemand,
         blockHTTP3: Bool = PreferenceDefaults.blockHTTP3,
+        ipv6Enabled: Bool = PreferenceDefaults.ipv6Enabled,
     ) {
         self.mixedPort = mixedPort
         self.logLevel = logLevel
         self.allowLan = allowLan
         self.onDemand = onDemand
         self.blockHTTP3 = blockHTTP3
+        self.ipv6Enabled = ipv6Enabled
     }
 
     public static func load(from defaults: UserDefaults) -> Preferences {
@@ -57,6 +62,9 @@ public struct Preferences: Sendable {
         if defaults.object(forKey: PreferenceKey.blockHTTP3) != nil {
             prefs.blockHTTP3 = defaults.bool(forKey: PreferenceKey.blockHTTP3)
         }
+        if defaults.object(forKey: PreferenceKey.ipv6Enabled) != nil {
+            prefs.ipv6Enabled = defaults.bool(forKey: PreferenceKey.ipv6Enabled)
+        }
         return prefs
     }
 
@@ -66,5 +74,6 @@ public struct Preferences: Sendable {
         defaults.set(allowLan, forKey: PreferenceKey.allowLan)
         defaults.set(onDemand, forKey: PreferenceKey.onDemand)
         defaults.set(blockHTTP3, forKey: PreferenceKey.blockHTTP3)
+        defaults.set(ipv6Enabled, forKey: PreferenceKey.ipv6Enabled)
     }
 }

--- a/MeowShared/Tests/MeowSharedTests/PreferencesTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/PreferencesTests.swift
@@ -13,6 +13,7 @@ struct PreferencesTests {
         #expect(prefs.logLevel == PreferenceDefaults.logLevel)
         #expect(prefs.allowLan == false)
         #expect(prefs.blockHTTP3 == false)
+        #expect(prefs.ipv6Enabled == false)
     }
 
     @Test
@@ -23,10 +24,12 @@ struct PreferencesTests {
         prefs.mixedPort = 9999
         prefs.allowLan = true
         prefs.blockHTTP3 = true
+        prefs.ipv6Enabled = true
         prefs.save(to: defaults)
         let loaded = Preferences.load(from: defaults)
         #expect(loaded.mixedPort == 9999)
         #expect(loaded.allowLan == true)
         #expect(loaded.blockHTTP3 == true)
+        #expect(loaded.ipv6Enabled == true)
     }
 }

--- a/PacketTunnel/Sources/MWPreferences.h
+++ b/PacketTunnel/Sources/MWPreferences.h
@@ -6,6 +6,7 @@ extern NSString *const MWPrefKeyMixedPort;
 extern NSString *const MWPrefKeyLogLevel;
 extern NSString *const MWPrefKeyAllowLan;
 extern NSString *const MWPrefKeyBlockHTTP3;
+extern NSString *const MWPrefKeyIPv6Enabled;
 extern NSString *const MWPrefKeyPendingIntent;
 
 @interface MWPreferences : NSObject
@@ -13,5 +14,6 @@ extern NSString *const MWPrefKeyPendingIntent;
 @property (nonatomic, copy)   NSString *logLevel;
 @property (nonatomic, assign) BOOL allowLan;
 @property (nonatomic, assign) BOOL blockHTTP3;
+@property (nonatomic, assign) BOOL ipv6Enabled;
 + (instancetype)loadFromDefaults:(NSUserDefaults *)defaults;
 @end

--- a/PacketTunnel/Sources/MWPreferences.m
+++ b/PacketTunnel/Sources/MWPreferences.m
@@ -4,6 +4,7 @@ NSString *const MWPrefKeyMixedPort     = @"com.meow.mixedPort";
 NSString *const MWPrefKeyLogLevel      = @"com.meow.logLevel";
 NSString *const MWPrefKeyAllowLan      = @"com.meow.allowLan";
 NSString *const MWPrefKeyBlockHTTP3    = @"com.meow.blockHTTP3";
+NSString *const MWPrefKeyIPv6Enabled   = @"com.meow.ipv6Enabled";
 NSString *const MWPrefKeyPendingIntent = @"com.meow.pendingIntent";
 
 @implementation MWPreferences
@@ -11,10 +12,11 @@ NSString *const MWPrefKeyPendingIntent = @"com.meow.pendingIntent";
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _mixedPort  = 7890;
-        _logLevel   = @"info";
-        _allowLan   = NO;
-        _blockHTTP3 = NO;
+        _mixedPort   = 7890;
+        _logLevel    = @"info";
+        _allowLan    = NO;
+        _blockHTTP3  = NO;
+        _ipv6Enabled = NO;
     }
     return self;
 }
@@ -29,6 +31,8 @@ NSString *const MWPrefKeyPendingIntent = @"com.meow.pendingIntent";
         p.allowLan = [defaults boolForKey:MWPrefKeyAllowLan];
     if ([defaults objectForKey:MWPrefKeyBlockHTTP3])
         p.blockHTTP3 = [defaults boolForKey:MWPrefKeyBlockHTTP3];
+    if ([defaults objectForKey:MWPrefKeyIPv6Enabled])
+        p.ipv6Enabled = [defaults boolForKey:MWPrefKeyIPv6Enabled];
     return p;
 }
 

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -118,6 +118,13 @@ static const int kLocalDNSPort                 = 1053;
     // behavior is unchanged.
     meow_tun_set_block_http3(prefs.blockHTTP3 ? 1 : 0);
 
+    // Apply the IPv6 toggle before starting the tun (same static-state
+    // mechanism as block_http3). Off (default) keeps the AAAA strip so the
+    // tunnel stays IPv4-only; on forwards AAAA so meow-dns returns real v6
+    // addresses. Must stay consistent with the TUN's IPv6 route configuration
+    // applied in MWTunnelSettings (PacketTunnelProvider reads the same pref).
+    meow_tun_set_ipv6_enabled(prefs.ipv6Enabled ? 1 : 0);
+
     rc = meow_tun_start(_writerCtx, meowPacketWriterCB);
     if (rc != 0) {
         NSString *msg = [self lastRustError] ?: @"tun start failed";

--- a/PacketTunnel/Sources/MWTunnelSettings.h
+++ b/PacketTunnel/Sources/MWTunnelSettings.h
@@ -3,5 +3,6 @@
 #import <NetworkExtension/NetworkExtension.h>
 
 @interface MWTunnelSettings : NSObject
-+ (NEPacketTunnelNetworkSettings *)makeWithServerAddress:(NSString *)serverAddress;
++ (NEPacketTunnelNetworkSettings *)makeWithServerAddress:(NSString *)serverAddress
+                                             ipv6Enabled:(BOOL)ipv6Enabled;
 @end

--- a/PacketTunnel/Sources/MWTunnelSettings.m
+++ b/PacketTunnel/Sources/MWTunnelSettings.m
@@ -2,7 +2,8 @@
 
 @implementation MWTunnelSettings
 
-+ (NEPacketTunnelNetworkSettings *)makeWithServerAddress:(NSString *)serverAddress {
++ (NEPacketTunnelNetworkSettings *)makeWithServerAddress:(NSString *)serverAddress
+                                             ipv6Enabled:(BOOL)ipv6Enabled {
     NEPacketTunnelNetworkSettings *settings =
         [[NEPacketTunnelNetworkSettings alloc] initWithTunnelRemoteAddress:serverAddress];
 
@@ -14,19 +15,32 @@
     ipv4.excludedRoutes = [self ipv4LanExcludedRoutes];
     settings.IPv4Settings = ipv4;
 
-    // IPv6 — intentionally NOT configured. This tunnel is IPv4-only:
-    // settings.IPv6Settings is left nil, so the TUN claims no IPv6 address
-    // and installs no IPv6 routes.
+    // IPv6 — configured only when the user enables IPv6 in app settings. When
+    // off (the default), settings.IPv6Settings is left nil so the TUN claims no
+    // IPv6 address and installs no v6 routes, and the FFI answers AAAA queries
+    // NOERROR-empty (meow_tun_set_ipv6_enabled(0)) so clients fall back to the
+    // IPv4 path. This keeps the tunnel IPv4-only by default.
     //
-    // Leak-around note: with no ::/0 route claimed, apps on a v6-capable
-    // network could in principle reach the internet natively over IPv6,
-    // bypassing the proxy. In practice meow-dns strips AAAA unconditionally
-    // (fake-IP runs a v4-only pool), so clients fall back to A / fake-v4 and
-    // the proxy connects by hostname. The residual surface is hardcoded v6
-    // literals (rare), which simply fail to reach the proxy.
+    // When on, we claim a private (ULA) v6 address and a ::/0 default route so
+    // real-IPv6 destinations (meow-dns now returns AAAA) enter the netstack and
+    // are proxied, instead of leaking natively over a v6-capable network. The
+    // FFI is told to forward AAAA via meow_tun_set_ipv6_enabled(1) in
+    // MWTunnelEngine — the two must stay in sync (both read the same pref).
+    //
+    // Leak-around note: hardcoded v6 literals (no DNS) are now proxied too via
+    // the default route; only the explicitly excluded LAN/link-local ranges
+    // bypass the tunnel, mirroring the IPv4 LAN-exclusion policy.
     //
     // IPv4↔IPv6 path transitions are handled by the path monitor's
     // address-family restart in PacketTunnelProvider.
+    if (ipv6Enabled) {
+        NEIPv6Settings *ipv6 = [[NEIPv6Settings alloc]
+            initWithAddresses:@[@"fd6d:6577::1"]
+            networkPrefixLengths:@[@64]];
+        ipv6.includedRoutes = @[[NEIPv6Route defaultRoute]];
+        ipv6.excludedRoutes = [self ipv6LanExcludedRoutes];
+        settings.IPv6Settings = ipv6;
+    }
 
     // DNS
     NEDNSSettings *dns = [[NEDNSSettings alloc] initWithServers:@[@"172.19.0.2"]];
@@ -64,6 +78,17 @@
         // 127/8 intentionally omitted — iOS rejects loopback and drops the whole excludedRoutes payload
         [[NEIPv4Route alloc] initWithDestinationAddress:@"224.0.0.0"     subnetMask:@"240.0.0.0"],
         [[NEIPv4Route alloc] initWithDestinationAddress:@"255.255.255.255" subnetMask:@"255.255.255.255"],
+    ];
+}
+
++ (NSArray<NEIPv6Route *> *)ipv6LanExcludedRoutes {
+    // Mirror the IPv4 LAN-exclusion policy for v6: keep link-local, unique
+    // local (ULA, incl. the TUN's own fd6d:6577::/64), and multicast off the
+    // ::/0 default route so local/link traffic bypasses the tunnel.
+    return @[
+        [[NEIPv6Route alloc] initWithDestinationAddress:@"fe80::" networkPrefixLength:@10], // link-local
+        [[NEIPv6Route alloc] initWithDestinationAddress:@"fc00::" networkPrefixLength:@7],  // unique local (ULA)
+        [[NEIPv6Route alloc] initWithDestinationAddress:@"ff00::" networkPrefixLength:@8],  // multicast
     ];
 }
 

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -1,6 +1,8 @@
 #import "PacketTunnelProvider.h"
 #import "MWTunnelEngine.h"
 #import "MWTunnelSettings.h"
+#import "MWAppGroup.h"
+#import "MWPreferences.h"
 #import "MWIPCListener.h"
 #import "MWSharedStore.h"
 #import "MWDarwinBridge.h"
@@ -83,7 +85,12 @@ static const NSTimeInterval kEngineRestartDebounceS = 3.0;
 
     NSString *server  = self.protocolConfiguration.serverAddress ?: @"192.0.2.1";
     NSString *profileID = (NSString *)options[@"profileID"];
-    NEPacketTunnelNetworkSettings *settings = [MWTunnelSettings makeWithServerAddress:server];
+    // The IPv6 route configuration must match the FFI's AAAA-forwarding toggle
+    // (set from the same pref in MWTunnelEngine). Read it here so the TUN claims
+    // a v6 address + ::/0 route only when the user enabled IPv6.
+    BOOL ipv6Enabled = [[MWAppGroup defaults] boolForKey:MWPrefKeyIPv6Enabled];
+    NEPacketTunnelNetworkSettings *settings =
+        [MWTunnelSettings makeWithServerAddress:server ipv6Enabled:ipv6Enabled];
 
     __weak __typeof__(self) weak = self;
     [self setTunnelNetworkSettings:settings completionHandler:^(NSError *settingsErr) {

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1701,8 +1701,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "axum",
  "base64",
@@ -1733,8 +1733,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1755,8 +1755,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1788,8 +1788,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1852,8 +1852,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "base64",
  "libc",
@@ -1867,8 +1867,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1909,8 +1909,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1926,8 +1926,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1955,13 +1955,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.14.0"
-source = "git+https://github.com/madeye/meow-rs?rev=b2278de499339880ed4635556b709bf44ae0c89a#b2278de499339880ed4635556b709bf44ae0c89a"
+version = "0.15.0"
+source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,9 +68,15 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: b2278de — SOCKS5 TCP path reverse-maps fake-IP → host before rule
-# matching (meow-rs#233) on top of the direct-outbound hostname fallback.
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
+# HEAD: f6ba61f (meow-rs 0.15.0) — meow-dns runs in normal/Mapping
+# (redir-host) mode: the resolver returns real upstream IPs and keeps an
+# IP → host reverse cache (decoupled from the DNS TTL via REVERSE_TTL_FLOOR,
+# meow-rs#240) so `pre_handle_metadata` recovers the hostname for domain-rule
+# matching. The FFI config parser pins `enhanced-mode: redir-host` (no
+# fake-ip-range); fake-IP is no longer used. Bump from b2278de (0.14.0) also
+# picks up #234 (v0.15.0), #235 (wildcard-glob), #236 (probe concurrency),
+# #237 (MetaCube rules).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -78,12 +84,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "b2278de4993398
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "b2278de499339880ed4635556b709bf44ae0c89a" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -2,10 +2,11 @@
 //! DNS listeners that `tun2socks` dials through loopback.
 //!
 //! DNS is delegated end-to-end to meow's resolver. The pinned `dns:` block from
-//! `meow_patch_config` puts the resolver in fake-IP mode with the FFI's chosen
-//! CIDR (`28.0.0.0/8`) and a local DNS listen socket. The tun2socks UDP/53
-//! path sends non-blocked DNS queries to that listener, so synthesis and
-//! fake-IP reverse mapping stay owned by meow-dns.
+//! `meow_patch_config` puts the resolver in `redir-host` (normal) mode with a
+//! local DNS listen socket — no fake-ip pool is installed. The tun2socks
+//! UDP/53 path sends non-blocked DNS queries to that listener, which returns
+//! real upstream IPs and self-populates its IP->host reverse cache so meow's
+//! inbound path can recover the hostname for domain-rule matching.
 //!
 //! Lifecycle: `start(config_path)` spawns the REST API on the meow-engine
 //! tokio runtime and keeps its `JoinHandle` in `EngineState`. `stop()` aborts
@@ -83,8 +84,8 @@ fn prepare_ios_config(yaml: &str) -> Result<String> {
             "tproxy-port",
             "listeners",
             // Drop the entire `sniffer:` block. meow's
-            // `pre_handle_metadata` reverses each fake-IP destination back
-            // to the qname recorded by the resolver before rule matching,
+            // `pre_handle_metadata` reverse-looks-up each real destination IP
+            // back to the qname recorded by the resolver before rule matching,
             // so SNI/ALPN sniffing is redundant — and when enabled it would
             // overwrite the resolver-derived hostname based on whatever the
             // sniffer parses out of the first TLS / HTTP record, which is a
@@ -248,8 +249,8 @@ pub fn start(config_path: &str) -> Result<()> {
     // 2-worker engine runtime (data path + REST API both freeze). The meow-dns
     // resolver resolves async, coalesces concurrent lookups, and caches —
     // collapsing the burst to one lookup. `resolve_ip` returns real addresses
-    // (fake-IP synthesis lives only in the DNS-server `lookup_ipv4/6` path), so
-    // the upstream never resolves to a 28.x fake IP. Android installs the same
+    // (in redir-host / normal mode the resolver never synthesizes; A queries
+    // resolve to the real upstream IP). Android installs the same
     // hook plus a `SocketProtector` via its JNI bridge; iOS needs only the hook
     // (the NE process's own sockets already bypass its tunnel).
     meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(resolver.clone())));
@@ -351,8 +352,8 @@ pub fn start(config_path: &str) -> Result<()> {
     let log_tx = log_broadcast_tx().clone();
 
     // No FFI-side fake-IP pool, no FFI-side CN-IP table, no resolver hand-off:
-    // meow's own fake-IP pool owns synthesis + reverse mapping behind the DNS
-    // listener that tun2socks dials.
+    // meow's own resolver (redir-host / normal mode) owns resolution +
+    // IP->host reverse mapping behind the DNS listener that tun2socks dials.
 
     let api_task = cfg.api.external_controller.map(|addr| {
         let api_server = ApiServer::new(
@@ -530,8 +531,7 @@ bind-address: 0.0.0.0
 dns:
   enable: true
   listen: 0.0.0.0:1053
-  enhanced-mode: fake-ip
-  fake-ip-range: 28.0.0.0/8
+  enhanced-mode: redir-host
   nameserver:
     - 119.29.29.29
 rules:

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -13,10 +13,12 @@
 //! The staticlib owns separate tokio runtimes for the packet/netstack driver
 //! and for meow engine work so lwIP backpressure cannot starve the
 //! REST/API/proxy workers. DNS is delegated to a local meow-dns UDP listener
-//! running in fake-IP mode: the tun2socks UDP/53 path still answers AAAA and
-//! HTTP/3-blocked HTTPS/SVCB queries NOERROR-empty itself, then sends other DNS
-//! queries to the listener. The FFI no longer carries its own fake-IP pool,
-//! china-DNS split-horizon, CN-IP table, DoH cache, or in-FFI TCP-DNS client.
+//! running in `redir-host` (normal) mode: the tun2socks UDP/53 path still
+//! answers AAAA and HTTP/3-blocked HTTPS/SVCB queries NOERROR-empty itself,
+//! then sends other DNS queries to the listener, which returns real upstream
+//! IPs and self-populates its IP->host reverse cache. The FFI no longer
+//! carries its own fake-IP pool, china-DNS split-horizon, CN-IP table, DoH
+//! cache, or in-FFI TCP-DNS client.
 
 mod diagnostics;
 mod engine;
@@ -691,8 +693,12 @@ pub unsafe extern "C" fn meow_patch_config(
         return -1;
     };
 
-    // Strip `dns` (iOS pins its own resolver block) and `subscriptions`
-    // (handled app-side). `secret` is intentionally NOT stripped here — we
+    // Strip `dns` (iOS pins its own resolver block — see below: the resolver
+    // is pinned to `redir-host` (normal) mode, NOT fake-ip, so meow-dns
+    // returns real upstream IPs and self-populates its IP->host reverse cache
+    // for domain-rule matching; no fake-ip-range is installed) and
+    // `subscriptions` (handled app-side). `secret` is intentionally NOT
+    // stripped here — we
     // overwrite it below with a per-install random token so the REST API on
     // loopback is authenticated rather than open.
     for key in ["dns", "subscriptions"] {
@@ -730,10 +736,9 @@ pub unsafe extern "C" fn meow_patch_config(
             "listen",
             serde_yaml::Value::String(format!("{bind_addr}:{dns_port}")),
         ),
-        ("enhanced-mode", serde_yaml::Value::String("fake-ip".into())),
         (
-            "fake-ip-range",
-            serde_yaml::Value::String("28.0.0.0/8".into()),
+            "enhanced-mode",
+            serde_yaml::Value::String("redir-host".into()),
         ),
     ] {
         dns.insert(serde_yaml::Value::String(k.into()), v);

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -1030,6 +1030,33 @@ pub extern "C" fn meow_tun_block_http3() -> c_int {
     c_int::from(tun2socks::block_http3())
 }
 
+/// Enable or disable IPv6. Default OFF (0): current behaviour is preserved —
+/// the tunnel is IPv4-only and AAAA (28) DNS queries are answered NOERROR-empty
+/// from the intercept so clients fall back to the IPv4 path. When enabled
+/// (non-zero), AAAA queries are forwarded to the meow-dns listener like A
+/// queries (the resolver returns real upstream IPv6 addresses). The caller MUST
+/// also configure the TUN with an IPv6 address + default route (see
+/// `MWTunnelSettings`) so those v6 connections enter the netstack; otherwise
+/// they black-hole.
+///
+/// At the FFI layer the new value applies immediately to subsequent DNS
+/// queries (the backing flag is a plain atomic). The meow-ios app only invokes
+/// this at tunnel start, so toggling the user preference applies on the next
+/// tunnel (re)connect — same as allowLan / blockHTTP3.
+///
+/// Returns 0 unconditionally.
+#[no_mangle]
+pub extern "C" fn meow_tun_set_ipv6_enabled(enabled: c_int) -> c_int {
+    tun2socks::set_ipv6_enabled(enabled != 0);
+    0
+}
+
+/// Read whether IPv6 is currently enabled. Returns 1 if enabled, 0 otherwise.
+#[no_mangle]
+pub extern "C" fn meow_tun_ipv6_enabled() -> c_int {
+    c_int::from(tun2socks::ipv6_enabled())
+}
+
 /// Resident memory size of the FFI's containing process, in bytes. Same
 /// number macOS jetsam compares against the 50 MiB PacketTunnel cap, so
 /// Swift can poll this to chart the on-device RSS curve during a stress

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -11,10 +11,13 @@
 //! (normal) mode the listener resolves A queries to the real upstream IP and
 //! records the IP->host mapping in its reverse cache; generic qtypes get
 //! meow-dns's upstream-forward behavior.
-//! AAAA (28) queries are answered NOERROR-empty by the FFI itself,
-//! unconditionally — the tunnel is IPv4-only (the TUN advertises no v6 route),
-//! so stripping AAAA forces every client onto the v4 path instead of leaking
-//! (or black-holing) connections over v6. When "block HTTP/3" is enabled,
+//! AAAA (28) queries are answered NOERROR-empty by the FFI itself when IPv6 is
+//! disabled in app settings (the default) — the tunnel is then IPv4-only (the
+//! TUN advertises no v6 route), so stripping AAAA forces every client onto the
+//! v4 path instead of leaking (or black-holing) connections over v6. When IPv6
+//! is enabled, AAAA queries are forwarded to meow-dns like A queries (real v6
+//! addresses) and the Swift TUN advertises an IPv6 address + default route so
+//! those connections enter the netstack. When "block HTTP/3" is enabled,
 //! HTTPS/SVCB (65/64) queries also get NOERROR-empty so clients cannot
 //! discover QUIC hints.
 //!
@@ -209,6 +212,25 @@ pub fn set_block_http3(on: bool) {
 /// Read whether the "block HTTP/3 (QUIC)" behaviour is currently enabled.
 pub fn block_http3() -> bool {
     BLOCK_HTTP3.load(Ordering::Relaxed)
+}
+
+/// Whether IPv6 is enabled in app settings. Default OFF — the tunnel is
+/// IPv4-only unless the user opts in. When OFF, AAAA (qtype 28) queries are
+/// answered NOERROR-empty locally so clients fall back to the IPv4 path. When
+/// ON, AAAA queries are forwarded to the meow-dns listener like A queries (the
+/// resolver returns real upstream IPv6 addresses), and the Swift TUN is
+/// configured with an IPv6 address + default route so those connections enter
+/// the netstack. Stored Relaxed — a stale read for one datagram is harmless.
+static IPV6_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable or disable IPv6. Default OFF. See [`IPV6_ENABLED`].
+pub fn set_ipv6_enabled(on: bool) {
+    IPV6_ENABLED.store(on, Ordering::Relaxed);
+}
+
+/// Read whether IPv6 is currently enabled.
+pub fn ipv6_enabled() -> bool {
+    IPV6_ENABLED.load(Ordering::Relaxed)
 }
 
 // Per-TCP-flow idle TTL. Closes the wedge the dial deadline can't reach:
@@ -1476,27 +1498,28 @@ async fn dispatch_dns_udp(
     reply_tx: mpsc::Sender<UdpMsg>,
 ) {
     let qtype = parse_dns_qtype(&payload);
-    let response_payload =
-        if qtype == Some(28) || (block_http3() && matches!(qtype, Some(64) | Some(65))) {
-            match dns_empty_response(&payload) {
-                Some(bytes) => bytes,
-                None => return,
+    let response_payload = if (qtype == Some(28) && !ipv6_enabled())
+        || (block_http3() && matches!(qtype, Some(64) | Some(65)))
+    {
+        match dns_empty_response(&payload) {
+            Some(bytes) => bytes,
+            None => return,
+        }
+    } else if let Some(dns_addr) = crate::engine::dns_dial_addr() {
+        match query_dns_listener(&payload, dns_addr).await {
+            Some(bytes) => bytes,
+            None => {
+                trace!("tun2socks: DNS listener timed out (qtype={:?})", qtype);
+                return;
             }
-        } else if let Some(dns_addr) = crate::engine::dns_dial_addr() {
-            match query_dns_listener(&payload, dns_addr).await {
-                Some(bytes) => bytes,
-                None => {
-                    trace!("tun2socks: DNS listener timed out (qtype={:?})", qtype);
-                    return;
-                }
-            }
-        } else {
-            trace!(
-                "tun2socks: DNS listener not running, dropping qtype={:?}",
-                qtype
-            );
-            return;
-        };
+        }
+    } else {
+        trace!(
+            "tun2socks: DNS listener not running, dropping qtype={:?}",
+            qtype
+        );
+        return;
+    };
     forward_udp_reply(&reply_tx, (response_payload, dst, src));
 }
 

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -7,26 +7,33 @@
 //! callback registered in [`start`]. No file descriptors cross the FFI.
 //!
 //! DNS: A (1), TXT (16), MX (15), PTR (12), and other non-blocked queries are
-//! sent as raw UDP packets to the local meow-dns listener. A gets fake-IP
-//! synthesis there; generic qtypes get meow-dns's upstream-forward behavior.
+//! sent as raw UDP packets to the local meow-dns listener. In `redir-host`
+//! (normal) mode the listener resolves A queries to the real upstream IP and
+//! records the IP->host mapping in its reverse cache; generic qtypes get
+//! meow-dns's upstream-forward behavior.
 //! AAAA (28) queries are answered NOERROR-empty by the FFI itself,
-//! unconditionally — only the IPv4 fake-IP path is proxied, so stripping AAAA
-//! forces every client onto it instead of leaking (or black-holing)
-//! connections over v6. When "block HTTP/3" is enabled, HTTPS/SVCB (65/64)
-//! queries also get NOERROR-empty so clients cannot discover QUIC hints.
+//! unconditionally — the tunnel is IPv4-only (the TUN advertises no v6 route),
+//! so stripping AAAA forces every client onto the v4 path instead of leaking
+//! (or black-holing) connections over v6. When "block HTTP/3" is enabled,
+//! HTTPS/SVCB (65/64) queries also get NOERROR-empty so clients cannot
+//! discover QUIC hints.
 //!
 //! NEDNSSettings advertises a TUN-subnet address as the system resolver, so
 //! every UDP DNS query arrives as an in-TUN IP packet. netstack turns that into
 //! a UDP payload, the FFI branches on qtype, and non-blocked queries go to the
 //! local DNS listener with the reply injected back through netstack. The
-//! resolver owns fake-IP synthesis, reverse mapping, hosts / NXDOMAIN
+//! resolver owns resolution, reverse (IP->host) mapping, hosts / NXDOMAIN
 //! semantics, and TTL handling; the FFI owns only the qtype peek plus the
 //! blocked-query short-circuit.
 //!
-//! TCP/UDP destination IPs come back as fake-IPs from meow's resolver pool.
-//! `dispatch_tcp` and `dispatch_udp` pass the literal destination to the
-//! mixed listener via SOCKS5; meow's normal inbound path reverses fake-IPs back
-//! to the original qname before rule matching.
+//! TCP/UDP destination IPs are the real upstream IPs returned by meow's
+//! resolver. `dispatch_tcp` and `dispatch_udp` pass the literal destination to
+//! the mixed listener via SOCKS5; meow's normal inbound path reverse-looks-up
+//! the IP back to the original qname (from the resolver's reverse cache) before
+//! rule matching. (Real upstream IPs reach the TUN because the Swift
+//! NEPacketTunnelProvider already advertises the IPv4 default route — see
+//! `MWTunnelSettings.m`, `ipv4.includedRoutes = defaultRoute` with RFC1918
+//! LAN exclusions — so no routing change was needed for the fake-IP drop.)
 
 use crate::logging;
 use futures::{SinkExt, StreamExt};


### PR DESCRIPTION
Two related commits.

## 1. Drop fake-IP, run meow-dns in redir-host (normal) mode (`1993a98`)

The config parser (`meow_patch_config`) now pins the resolver to `enhanced-mode: redir-host` instead of `fake-ip` and no longer injects `fake-ip-range`. In redir-host (normal/Mapping) mode meow-dns returns **real upstream IPs** and keeps an IP→host reverse cache; meow-tunnel's `pre_handle_metadata` reverse-looks-up the real destination IP back to the qname before rule matching, so domain rules still match without fake-IP synthesis.

- Pairs with **meow-rs#240** (merged, `f6ba61f`): `REVERSE_TTL_FLOOR` so reverse (IP→host) entries outlive a short DNS TTL until the inbound connection is matched.
- Bumps the seven `meow-*` git pins `b2278de` (0.14.0) → `f6ba61f` (0.15.0); the range also picks up #234/#235/#236/#237.
- tun2socks/engine logic unchanged: AAAA still NOERROR-emptied (IPv4-only by default), Swift TUN already routes `defaultRoute` so no routing change needed.

## 2. Opt-in IPv6 (`95d5b70`)

A user-facing **"Enable IPv6"** toggle (default **OFF**, preserving IPv4-only behaviour), wired end-to-end like `blockHTTP3`:

- FFI `meow_tun_set_ipv6_enabled` / `meow_tun_ipv6_enabled` (atomic). AAAA is dropped only when IPv6 is off; when on, AAAA forwards to meow-dns (real v6 addrs). cbindgen header regenerated.
- NE: `MWPreferences.ipv6Enabled`; `MWTunnelEngine` calls the setter at start; `PacketTunnelProvider` passes the pref to `MWTunnelSettings`.
- TUN routing: when on, claims ULA `fd6d:6577::1/64` + `::/0` default route with `fe80::/10` / `fc00::/7` / `ff00::/8` excluded (mirrors v4 LAN policy); when off, `IPv6Settings` stays nil. The lwIP fork has `LWIP_IPV6` and tun2socks encodes v6 SOCKS destinations, so the data path handles v6.
- App: Settings toggle + footer + a11y hint (en + zh-Hans); shared `Preferences`.
- Tests: `PreferencesTests` round-trips `ipv6Enabled`; the `TunnelSettings` mirror + LAN-exclusion tests cover v6-enabled (ULA + `::/0` + exclusions) and v6-disabled (nil).

## Local CI attestation (Path B)

- [x] `cargo fmt -- --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test --lib` (50) in `core/rust/meow-ios-ffi`
- [x] `scripts/build-rust.sh` → xcframework rebuilt; new C symbols present in `MeowCore/include/meow_core.h`
- [x] `swiftformat --lint .` → 0 violations
- [x] `swiftlint --strict` → 0 violations
- [x] `xcodebuild test` on iPhone 17 Pro (iOS 26): `MeowSharedTests` (2), `MeowIntegrationTests/TunnelSettingsLANExclusionTests` (7), `MeowTests` (132)
- [x] `git diff origin/main...HEAD --stat` verified — FFI Rust + Cargo pins, ObjC NE, Swift app/Settings, localized strings, tests; xcframework is a gitignored CI artifact

Note: on-device smoke pending — confirm domain rules match in normal mode, and that toggling IPv6 on routes v6 through the tunnel with no native v6 leak when off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)