### PR TITLE
feat(utility): Utility tab with Traffic, Logs, and DNS panel (#265)

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -12,8 +12,7 @@
 /* Tab bar */
 "tabs.subscriptions" = "Subscriptions";
 "tabs.proxyGroups" = "Proxy Groups";
-"tabs.traffic" = "Traffic";
-"tabs.logs" = "Logs";
+"tabs.utility" = "Utility";
 "tabs.settings" = "Settings";
 
 
@@ -94,6 +93,21 @@
 "connections.toolbar.closeAll" = "Close All";
 "connections.swipe.close" = "Close";
 "connections.nav.titleFormat %lld" = "Connections (%lld)";
+
+
+/* Utility hub */
+"utility.nav.title" = "Utility";
+"utility.nav.traffic" = "Traffic";
+"utility.nav.logs" = "Logs";
+"utility.nav.dns" = "DNS";
+
+
+/* DNS */
+"dns.empty.title" = "No DNS results";
+"dns.empty.description" = "Cached lookups appear when the engine resolves domains.";
+"dns.nav.titleFormat %lld" = "DNS (%lld)";
+"dns.row.unknownUpstream" = "Unknown";
+"dns.row.ttl %lld" = "TTL %lld s";
 
 
 /* Rules */
@@ -250,6 +264,11 @@
 "a11y.connections.row.download %@" = "Downloaded %@";
 "a11y.connections.row.label %@ %@ %@ %@ %@" = "%@, %@, uploaded %@, downloaded %@, via %@";
 "a11y.connections.errorBanner %@" = "Warning: %@";
+
+
+/* Accessibility — DNS */
+"a11y.dns.row.label %@ %@ %@ %lld" = "%@, %@, upstream %@, TTL %lld seconds";
+"a11y.dns.errorBanner %@" = "Warning: %@";
 
 
 /* Accessibility — Rule editor (single-rule sheet) */

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -18,8 +18,7 @@
 /* Tab bar */
 "tabs.subscriptions" = "订阅";
 "tabs.proxyGroups" = "代理组";
-"tabs.traffic" = "流量";
-"tabs.logs" = "日志";
+"tabs.utility" = "工具";
 "tabs.settings" = "设置";
 
 
@@ -100,6 +99,21 @@
 "connections.toolbar.closeAll" = "全部关闭";
 "connections.swipe.close" = "关闭";
 "connections.nav.titleFormat %lld" = "连接 (%lld)";
+
+
+/* Utility hub */
+"utility.nav.title" = "工具";
+"utility.nav.traffic" = "流量";
+"utility.nav.logs" = "日志";
+"utility.nav.dns" = "DNS";
+
+
+/* DNS */
+"dns.empty.title" = "暂无 DNS 结果";
+"dns.empty.description" = "引擎解析域名后，缓存记录会显示在此处。";
+"dns.nav.titleFormat %lld" = "DNS (%lld)";
+"dns.row.unknownUpstream" = "未知";
+"dns.row.ttl %lld" = "TTL %lld 秒";
 
 
 /* Rules */
@@ -256,6 +270,11 @@
 "a11y.connections.row.download %@" = "已下载 %@";
 "a11y.connections.row.label %@ %@ %@ %@ %@" = "%@，%@，已上传 %@，已下载 %@，经由 %@";
 "a11y.connections.errorBanner %@" = "警告：%@";
+
+
+/* Accessibility — DNS */
+"a11y.dns.row.label %@ %@ %@ %lld" = "%@，%@，上游 %@，TTL %lld 秒";
+"a11y.dns.errorBanner %@" = "警告：%@";
 
 
 /* Accessibility — Rule editor (single-rule sheet) */

--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -16,6 +16,8 @@ final class AppModel {
     let subscriptionService: SubscriptionService
     let ipcBridge: AppIPCBridge
     let dailyTrafficAccumulator: DailyTrafficAccumulator
+    let utilityTrafficChart: UtilityTrafficChartStore
+    let utilityLogs: UtilityLogsStore
 
     /// Monotonically bumped each time `replaySelectedProxies()` finishes a pass
     /// (successful replay, probe-timeout giveup, or no-active-profile no-op).
@@ -50,6 +52,11 @@ final class AppModel {
         dailyTrafficAccumulator = DailyTrafficAccumulator(
             modelContext: AppModelContainer.shared.container.mainContext,
         )
+        utilityTrafficChart = UtilityTrafficChartStore()
+        utilityLogs = UtilityLogsStore()
+        ipcBridge.onTrafficDidUpdate = { [utilityTrafficChart] snapshot in
+            utilityTrafficChart.ingest(snapshot)
+        }
     }
 
     func bootstrap() async {
@@ -67,6 +74,7 @@ final class AppModel {
         await vpnManager.refresh()
         ipcBridge.start()
         dailyTrafficAccumulator.start()
+        utilityLogs.startStreaming(api: meowAPI)
     }
 
     /// Re-issues the active profile's persisted `selectedProxies` each time

--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -73,7 +73,6 @@ final class AppModel {
         GeoAssetStager.stageIfNeeded()
         await vpnManager.refresh()
         ipcBridge.start()
-        utilityTrafficChart.ingest(ipcBridge.currentTraffic)
         dailyTrafficAccumulator.start()
         utilityLogs.startStreaming(api: meowAPI)
     }

--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -73,6 +73,7 @@ final class AppModel {
         GeoAssetStager.stageIfNeeded()
         await vpnManager.refresh()
         ipcBridge.start()
+        utilityTrafficChart.ingest(ipcBridge.currentTraffic)
         dailyTrafficAccumulator.start()
         utilityLogs.startStreaming(api: meowAPI)
     }

--- a/App/Sources/MeowApp.swift
+++ b/App/Sources/MeowApp.swift
@@ -13,6 +13,8 @@ struct MeowApp: App {
                 .environment(appModel.meowAPI)
                 .environment(appModel.subscriptionService)
                 .environment(appModel.ipcBridge)
+                .environment(appModel.utilityTrafficChart)
+                .environment(appModel.utilityLogs)
                 .task { await appModel.bootstrap() }
         }
         .modelContainer(AppModelContainer.shared.container)

--- a/App/Sources/Services/AppIPCBridge.swift
+++ b/App/Sources/Services/AppIPCBridge.swift
@@ -122,7 +122,11 @@ private extension AppIPCBridge {
 
         currentTraffic = Self.shouldRunMockTraffic(for: currentState) ? Self.mockTraffic(tick: 0) : .init()
         relayMemstats(currentTraffic)
-        onTrafficDidUpdate?(currentTraffic)
+        // Only chart live snapshots — a synthetic `.init()` reset would seed
+        // the Utility traffic chart and hide its fresh-install empty state.
+        if Self.shouldRunMockTraffic(for: currentState) {
+            onTrafficDidUpdate?(currentTraffic)
+        }
 
         configureMockTrafficTask()
     }
@@ -142,7 +146,9 @@ private extension AppIPCBridge {
         try? SharedStore.writeState(currentState)
         currentTraffic = Self.shouldRunMockTraffic(for: currentState) ? Self.mockTraffic(tick: 0) : .init()
         relayMemstats(currentTraffic)
-        onTrafficDidUpdate?(currentTraffic)
+        if Self.shouldRunMockTraffic(for: currentState) {
+            onTrafficDidUpdate?(currentTraffic)
+        }
         configureMockTrafficTask()
     }
 

--- a/App/Sources/Services/AppIPCBridge.swift
+++ b/App/Sources/Services/AppIPCBridge.swift
@@ -18,6 +18,10 @@ final class AppIPCBridge {
     private var trafficObserver: DarwinObserver?
     private var mockTrafficTask: Task<Void, Never>?
 
+    /// Optional hook for long-lived consumers (e.g. the Utility traffic chart)
+    /// that must keep sampling while the Traffic screen is off-screen.
+    var onTrafficDidUpdate: ((TrafficSnapshot) -> Void)?
+
     func start() {
         if Self.usesMockIPC {
             startMockIPC()
@@ -75,6 +79,7 @@ final class AppIPCBridge {
         if let traffic = SharedStore.readTraffic() {
             currentTraffic = traffic
             relayMemstats(traffic)
+            onTrafficDidUpdate?(traffic)
         }
     }
 
@@ -117,6 +122,7 @@ private extension AppIPCBridge {
 
         currentTraffic = Self.shouldRunMockTraffic(for: currentState) ? Self.mockTraffic(tick: 0) : .init()
         relayMemstats(currentTraffic)
+        onTrafficDidUpdate?(currentTraffic)
 
         configureMockTrafficTask()
     }
@@ -136,6 +142,7 @@ private extension AppIPCBridge {
         try? SharedStore.writeState(currentState)
         currentTraffic = Self.shouldRunMockTraffic(for: currentState) ? Self.mockTraffic(tick: 0) : .init()
         relayMemstats(currentTraffic)
+        onTrafficDidUpdate?(currentTraffic)
         configureMockTrafficTask()
     }
 
@@ -154,6 +161,7 @@ private extension AppIPCBridge {
                 guard let self else { return }
                 currentTraffic = Self.mockTraffic(tick: tick)
                 relayMemstats(currentTraffic)
+                onTrafficDidUpdate?(currentTraffic)
             }
         }
     }

--- a/App/Sources/Services/MeowAPI.swift
+++ b/App/Sources/Services/MeowAPI.swift
@@ -199,6 +199,31 @@ final class MeowAPI: @unchecked Sendable {
         return try await get("/providers/proxies")
     }
 
+    /// Cached DNS results for the panel UI. Optional `search` filters by
+    /// domain substring; `limit` is capped server-side at 1024.
+    func getDnsResults(search: String? = nil, limit: Int = 256) async throws -> [DnsResult] {
+        if Self.usesMockTransport { return Self.mockDnsResults(search: search) }
+        var endpoint = baseURL.appending(path: "/dns/results")
+        var items: [URLQueryItem] = [.init(name: "limit", value: String(limit))]
+        if let search, !search.isEmpty {
+            items.append(.init(name: "search", value: search))
+        }
+        guard var comps = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+            throw URLBuildError.invalidComponents(endpoint: endpoint)
+        }
+        comps.queryItems = items
+        guard let url = comps.url else {
+            throw URLBuildError.invalidComponents(endpoint: endpoint)
+        }
+        #if DEBUG
+            log.info("HTTP GET \(url.absoluteString, privacy: .public)")
+        #endif
+        let (data, resp) = try await session.data(for: request(for: url))
+        logResponse(resp, body: data, url: url)
+        try throwIfHTTPError(resp)
+        return try JSONDecoder().decode([DnsResult].self, from: data)
+    }
+
     /// Triggers meow's bulk health-check for every proxy in a provider
     /// (`GET /providers/proxies/{name}/healthcheck`). The endpoint returns
     /// 204 on success; fresh delays are surfaced on the next `getProviders()`.
@@ -494,6 +519,17 @@ private extension MeowAPI {
                 proxies: providerProxies,
             ),
         ])
+    }
+
+    static func mockDnsResults(search: String?) -> [DnsResult] {
+        let all: [DnsResult] = [
+            .init(name: "www.gstatic.com", ips: ["142.250.72.14"], fromServer: "119.29.29.29", ttl: 298),
+            .init(name: "github.com", ips: ["140.82.112.4"], fromServer: "223.5.5.5", ttl: 412),
+            .init(name: "api.github.com", ips: ["140.82.112.5"], fromServer: "223.5.5.5", ttl: 389),
+            .init(name: "apple.com", ips: ["17.253.144.10"], fromServer: "system", ttl: 600),
+        ]
+        guard let search, !search.isEmpty else { return all }
+        return all.filter { $0.name.localizedCaseInsensitiveContains(search) }
     }
 
     static func mockLogStream(level: String) -> AsyncThrowingStream<LogEntry, Error> {

--- a/App/Sources/Services/MeowAPI.swift
+++ b/App/Sources/Services/MeowAPI.swift
@@ -199,29 +199,13 @@ final class MeowAPI: @unchecked Sendable {
         return try await get("/providers/proxies")
     }
 
-    /// Cached DNS results for the panel UI. Optional `search` filters by
-    /// domain substring; `limit` is capped server-side at 1024.
     func getDnsResults(search: String? = nil, limit: Int = 256) async throws -> [DnsResult] {
         if Self.usesMockTransport { return Self.mockDnsResults(search: search) }
-        var endpoint = baseURL.appending(path: "/dns/results")
-        var items: [URLQueryItem] = [.init(name: "limit", value: String(limit))]
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
         if let search, !search.isEmpty {
-            items.append(.init(name: "search", value: search))
+            queryItems.append(URLQueryItem(name: "search", value: search))
         }
-        guard var comps = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
-            throw URLBuildError.invalidComponents(endpoint: endpoint)
-        }
-        comps.queryItems = items
-        guard let url = comps.url else {
-            throw URLBuildError.invalidComponents(endpoint: endpoint)
-        }
-        #if DEBUG
-            log.info("HTTP GET \(url.absoluteString, privacy: .public)")
-        #endif
-        let (data, resp) = try await session.data(for: request(for: url))
-        logResponse(resp, body: data, url: url)
-        try throwIfHTTPError(resp)
-        return try JSONDecoder().decode([DnsResult].self, from: data)
+        return try await get("/dns/results", queryItems: queryItems)
     }
 
     /// Triggers meow's bulk health-check for every proxy in a provider
@@ -293,8 +277,11 @@ final class MeowAPI: @unchecked Sendable {
 
     // MARK: - Helpers
 
-    private func get<T: Decodable>(_ path: String) async throws -> T {
-        let url = baseURL.appending(path: path)
+    private func get<T: Decodable>(_ path: String, queryItems: [URLQueryItem] = []) async throws -> T {
+        var url = baseURL.appending(path: path)
+        if !queryItems.isEmpty {
+            url = url.appending(queryItems: queryItems)
+        }
         #if DEBUG
             // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
             log.info("HTTP GET \(url.absoluteString, privacy: .public)")

--- a/App/Sources/Services/MeowAPITypes.swift
+++ b/App/Sources/Services/MeowAPITypes.swift
@@ -96,3 +96,20 @@ struct LogEntry: Decodable {
         return try? JSONDecoder().decode(LogEntry.self, from: data)
     }
 }
+
+/// Cached DNS lookup surfaced by `GET /dns/results` (meow-api routes.rs).
+struct DnsResult: Decodable, Identifiable {
+    var id: String {
+        name
+    }
+
+    let name: String
+    let ips: [String]
+    let fromServer: String?
+    let ttl: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case name, ips, ttl
+        case fromServer = "from_server"
+    }
+}

--- a/App/Sources/Services/UtilitySessionStore.swift
+++ b/App/Sources/Services/UtilitySessionStore.swift
@@ -11,6 +11,10 @@ final class UtilityTrafficChartStore {
     private let window: TimeInterval = 60
 
     func ingest(_ snapshot: TrafficSnapshot) {
+        // The IPC bridge calls this on every store refresh, not only on value
+        // changes (unlike the old `.onChange` in TrafficView) — skip repeats
+        // so chart sample IDs (timestamps) stay unique.
+        guard samples.last?.timestamp != snapshot.timestamp else { return }
         let sample = TrafficRateSample(
             timestamp: snapshot.timestamp,
             uploadRate: snapshot.uploadRate,
@@ -47,18 +51,26 @@ final class UtilityLogsStore {
     func startStreaming(api: MeowAPI) {
         guard streamTask == nil else { return }
         streamTask = Task { @MainActor [weak self] in
-            let stream = api.streamLogs(level: "debug")
-            do {
-                for try await entry in stream {
-                    guard let self else { return }
-                    errorMessage = nil
-                    allEntries.append(entry)
-                    if allEntries.count > 2000 {
-                        allEntries.removeFirst(allEntries.count - 2000)
+            // Reconnect loop: the first attempt usually races VPN start (the
+            // NE REST API is only up while the tunnel runs), and the stream
+            // ends whenever the tunnel restarts. Keep retrying so Logs heals
+            // without an app relaunch.
+            while !Task.isCancelled {
+                let stream = api.streamLogs(level: "debug")
+                do {
+                    for try await entry in stream {
+                        guard let self else { return }
+                        errorMessage = nil
+                        allEntries.append(entry)
+                        if allEntries.count > 2000 {
+                            allEntries.removeFirst(allEntries.count - 2000)
+                        }
                     }
+                } catch {
+                    guard let self else { return }
+                    errorMessage = error.localizedDescription
                 }
-            } catch {
-                self?.errorMessage = error.localizedDescription
+                try? await Task.sleep(for: .seconds(3))
             }
         }
     }

--- a/App/Sources/Services/UtilitySessionStore.swift
+++ b/App/Sources/Services/UtilitySessionStore.swift
@@ -1,0 +1,63 @@
+import Foundation
+import MeowModels
+import Observation
+
+/// Rolling 60s upload/download rate samples for the Traffic utility screen.
+/// Hoisted out of `TrafficView` so the chart survives Utility hub back-navigation.
+@MainActor
+@Observable
+final class UtilityTrafficChartStore {
+    private(set) var samples: [TrafficRateSample] = []
+    private let window: TimeInterval = 60
+
+    func ingest(_ snapshot: TrafficSnapshot) {
+        let sample = TrafficRateSample(
+            timestamp: snapshot.timestamp,
+            uploadRate: snapshot.uploadRate,
+            downloadRate: snapshot.downloadRate,
+        )
+        samples.append(sample)
+        let cutoff = Date().addingTimeInterval(-window)
+        samples.removeAll { $0.timestamp < cutoff }
+    }
+}
+
+struct TrafficRateSample: Identifiable {
+    var id: Date {
+        timestamp
+    }
+
+    let timestamp: Date
+    let uploadRate: Int64
+    let downloadRate: Int64
+}
+
+/// Log ring buffer and live WebSocket subscription for the Logs utility screen.
+/// Hoisted so entries survive Utility hub back-navigation.
+@MainActor
+@Observable
+final class UtilityLogsStore {
+    private(set) var allEntries: [LogEntry] = []
+    var errorMessage: String?
+
+    private var streamTask: Task<Void, Never>?
+
+    func startStreaming(api: MeowAPI) {
+        guard streamTask == nil else { return }
+        streamTask = Task { [weak self] in
+            let stream = api.streamLogs(level: "debug")
+            do {
+                for try await entry in stream {
+                    guard let self else { return }
+                    errorMessage = nil
+                    allEntries.append(entry)
+                    if allEntries.count > 2000 {
+                        allEntries.removeFirst(allEntries.count - 2000)
+                    }
+                }
+            } catch {
+                self?.errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/App/Sources/Services/UtilitySessionStore.swift
+++ b/App/Sources/Services/UtilitySessionStore.swift
@@ -39,12 +39,14 @@ struct TrafficRateSample: Identifiable {
 final class UtilityLogsStore {
     private(set) var allEntries: [LogEntry] = []
     var errorMessage: String?
+    var level = "info"
+    var autoScroll = true
 
     private var streamTask: Task<Void, Never>?
 
     func startStreaming(api: MeowAPI) {
         guard streamTask == nil else { return }
-        streamTask = Task { [weak self] in
+        streamTask = Task { @MainActor [weak self] in
             let stream = api.streamLogs(level: "debug")
             do {
                 for try await entry in stream {

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// argument used by the App Store screenshot capture (honored only in UI-test
 /// builds — see `initialTab`).
 enum ContentTab: String {
-    case subscriptions, proxyGroups, traffic, logs, settings
+    case subscriptions, proxyGroups, utility, settings
 }
 
 struct ContentView: View {
@@ -27,14 +27,10 @@ struct ContentView: View {
                     .tabItem { Label("tabs.proxyGroups", systemImage: "rectangle.stack.fill") }
                     .accessibilityIdentifier("Proxy Groups")
                     .tag(ContentTab.proxyGroups)
-                NavigationStack { TrafficView() }
-                    .tabItem { Label("tabs.traffic", systemImage: "chart.bar.fill") }
-                    .accessibilityIdentifier("Traffic")
-                    .tag(ContentTab.traffic)
-                NavigationStack { LogsView() }
-                    .tabItem { Label("tabs.logs", systemImage: "list.bullet.rectangle.fill") }
-                    .accessibilityIdentifier("Logs")
-                    .tag(ContentTab.logs)
+                NavigationStack { UtilityView() }
+                    .tabItem { Label("tabs.utility", systemImage: "wrench.and.screwdriver.fill") }
+                    .accessibilityIdentifier("Utility")
+                    .tag(ContentTab.utility)
                 NavigationStack { SettingsView() }
                     .tabItem { Label("tabs.settings", systemImage: "gearshape.fill") }
                     .accessibilityIdentifier("Settings")
@@ -112,5 +108,7 @@ private func initialTab() -> ContentTab {
     // Historical screenshot scripts used `home`; Subscriptions is now the
     // home tab surface, so keep old invocations useful.
     if rawTab == "home" { return .subscriptions }
+    // Traffic/Logs moved under Utility; keep old screenshot tab names working.
+    if rawTab == "traffic" || rawTab == "logs" || rawTab == "dns" { return .utility }
     return ContentTab(rawValue: rawTab) ?? .subscriptions
 }

--- a/App/Sources/Views/DnsView.swift
+++ b/App/Sources/Views/DnsView.swift
@@ -1,0 +1,120 @@
+import MeowModels
+import SwiftUI
+
+struct DnsView: View {
+    @Environment(MeowAPI.self) private var api
+    @State private var results: [DnsResult] = []
+    @State private var query: String = ""
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            ForEach(filtered) { result in
+                row(for: result)
+            }
+        }
+        .listStyle(.plain)
+        .overlay {
+            if results.isEmpty {
+                ContentUnavailableView(
+                    "dns.empty.title",
+                    systemImage: "network",
+                    description: Text("dns.empty.description"),
+                )
+                .accessibilityIdentifier("dns.emptyState")
+            } else if filtered.isEmpty {
+                ContentUnavailableView.search(text: query)
+                    .accessibilityIdentifier("dns.emptySearch")
+            }
+        }
+        .safeAreaInset(edge: .top) {
+            if let errorMessage {
+                errorBanner(errorMessage)
+            }
+        }
+        .searchable(text: $query)
+        .navigationTitle(Text(
+            "dns.nav.titleFormat \(displayCount)",
+            comment: "DNS screen navigation title; %lld = result count",
+        ))
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await poll() }
+    }
+
+    private var displayCount: Int {
+        filtered.count
+    }
+
+    private var filtered: [DnsResult] {
+        guard !query.isEmpty else { return results }
+        return results.filter { $0.name.localizedCaseInsensitiveContains(query) }
+    }
+
+    private func row(for result: DnsResult) -> some View {
+        let slug = result.name.identifierSlug
+        let ips = result.ips.joined(separator: ", ")
+        let upstream = result.fromServer ?? String(localized: "dns.row.unknownUpstream")
+        return GlassCard {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(result.name)
+                    .font(.headline)
+                    .lineLimit(2)
+                    .accessibilityIdentifier("dns.row.\(slug).domain")
+                Text(ips)
+                    .font(.subheadline.monospaced())
+                    .foregroundStyle(.primary)
+                    .lineLimit(3)
+                    .accessibilityIdentifier("dns.row.\(slug).ips")
+                HStack(spacing: 10) {
+                    Label(upstream, systemImage: "server.rack")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .accessibilityIdentifier("dns.row.\(slug).upstream")
+                    Spacer()
+                    Text("dns.row.ttl \(result.ttl)")
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("dns.row.\(slug).ttl")
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Text("a11y.dns.row.label \(result.name) \(ips) \(upstream) \(result.ttl)"))
+        }
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .accessibilityIdentifier("dns.row.\(slug)")
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(AppTheme.warning)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
+        .padding(.horizontal)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("a11y.dns.errorBanner \(message)"))
+        .accessibilityIdentifier("dns.errorBanner")
+    }
+
+    private func poll() async {
+        while !Task.isCancelled {
+            do {
+                let fetched = try await api.getDnsResults()
+                results = fetched
+                errorMessage = nil
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            try? await Task.sleep(for: .seconds(2))
+        }
+    }
+}

--- a/App/Sources/Views/DnsView.swift
+++ b/App/Sources/Views/DnsView.swift
@@ -9,27 +9,33 @@ struct DnsView: View {
 
     var body: some View {
         List {
-            ForEach(filtered) { result in
+            ForEach(results) { result in
                 row(for: result)
             }
         }
         .listStyle(.plain)
         .overlay {
             if results.isEmpty {
-                ContentUnavailableView(
-                    "dns.empty.title",
-                    systemImage: "network",
-                    description: Text("dns.empty.description"),
-                )
-                .accessibilityIdentifier("dns.emptyState")
-            } else if filtered.isEmpty {
-                ContentUnavailableView.search(text: query)
-                    .accessibilityIdentifier("dns.emptySearch")
+                if query.isEmpty {
+                    ContentUnavailableView(
+                        "dns.empty.title",
+                        systemImage: "network",
+                        description: Text("dns.empty.description"),
+                    )
+                    .accessibilityIdentifier("dns.emptyState")
+                } else {
+                    ContentUnavailableView.search(text: query)
+                        .accessibilityIdentifier("dns.emptySearch")
+                }
             }
         }
         .safeAreaInset(edge: .top) {
             if let errorMessage {
-                errorBanner(errorMessage)
+                ErrorBanner(
+                    message: errorMessage,
+                    accessibilityLabel: Text("a11y.dns.errorBanner \(errorMessage)"),
+                    identifier: "dns.errorBanner",
+                )
             }
         }
         .searchable(text: $query)
@@ -38,22 +44,18 @@ struct DnsView: View {
             comment: "DNS screen navigation title; %lld = result count",
         ))
         .navigationBarTitleDisplayMode(.inline)
-        .task { await poll() }
+        .task(id: query) { await poll() }
     }
 
     private var displayCount: Int {
-        filtered.count
-    }
-
-    private var filtered: [DnsResult] {
-        guard !query.isEmpty else { return results }
-        return results.filter { $0.name.localizedCaseInsensitiveContains(query) }
+        results.count
     }
 
     private func row(for result: DnsResult) -> some View {
         let slug = result.name.identifierSlug
         let ips = result.ips.joined(separator: ", ")
         let upstream = result.fromServer ?? String(localized: "dns.row.unknownUpstream")
+        let ttl = Int(result.ttl)
         return GlassCard {
             VStack(alignment: .leading, spacing: 4) {
                 Text(result.name)
@@ -72,43 +74,25 @@ struct DnsView: View {
                         .lineLimit(1)
                         .accessibilityIdentifier("dns.row.\(slug).upstream")
                     Spacer()
-                    Text("dns.row.ttl \(result.ttl)")
+                    Text("dns.row.ttl \(ttl)")
                         .font(.caption.monospaced())
                         .foregroundStyle(.secondary)
                         .accessibilityIdentifier("dns.row.\(slug).ttl")
                 }
             }
             .accessibilityElement(children: .combine)
-            .accessibilityLabel(Text("a11y.dns.row.label \(result.name) \(ips) \(upstream) \(result.ttl)"))
+            .accessibilityLabel(Text("a11y.dns.row.label \(result.name) \(ips) \(upstream) \(ttl)"))
         }
         .listRowBackground(Color.clear)
         .listRowSeparator(.hidden)
         .accessibilityIdentifier("dns.row.\(slug)")
     }
 
-    private func errorBanner(_ message: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(AppTheme.warning)
-                .accessibilityHidden(true)
-            Text(message)
-                .font(.caption)
-                .lineLimit(2)
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: .rect(cornerRadius: 8))
-        .padding(.horizontal)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text("a11y.dns.errorBanner \(message)"))
-        .accessibilityIdentifier("dns.errorBanner")
-    }
-
     private func poll() async {
+        let search = query.isEmpty ? nil : query
         while !Task.isCancelled {
             do {
-                let fetched = try await api.getDnsResults()
+                let fetched = try await api.getDnsResults(search: search)
                 results = fetched
                 errorMessage = nil
             } catch {

--- a/App/Sources/Views/ErrorBanner.swift
+++ b/App/Sources/Views/ErrorBanner.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct ErrorBanner: View {
+    let message: String
+    let accessibilityLabel: Text
+    let identifier: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(AppTheme.warning)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: .rect(cornerRadius: 8))
+        .padding(.horizontal)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier(identifier)
+    }
+}

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -361,4 +361,3 @@ private struct TrafficTile: View {
         .accessibilityAddTraits(.updatesFrequently)
     }
 }
-

--- a/App/Sources/Views/HomeView.swift
+++ b/App/Sources/Views/HomeView.swift
@@ -362,33 +362,3 @@ private struct TrafficTile: View {
     }
 }
 
-private struct NavRow: View {
-    let title: LocalizedStringKey
-    let systemImage: String
-    let identifier: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 12) {
-                Image(systemName: systemImage)
-                    .foregroundStyle(AppTheme.accent)
-                    .frame(width: 30, height: 30)
-                    .background(AppTheme.accent.opacity(0.10), in: Circle())
-                    .accessibilityHidden(true)
-                Text(title)
-                    .font(.subheadline)
-                    .foregroundStyle(.primary)
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.tertiary)
-                    .accessibilityHidden(true)
-            }
-            .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier(identifier)
-    }
-}

--- a/App/Sources/Views/LogsView.swift
+++ b/App/Sources/Views/LogsView.swift
@@ -3,20 +3,18 @@ import SwiftUI
 struct LogsView: View {
     @Environment(UtilityLogsStore.self) private var logsStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var level = "info"
-    @State private var autoScroll = true
 
     private static let levelOrder = ["debug": 0, "info": 1, "warning": 2, "error": 3]
 
     private var entries: [LogEntry] {
-        let threshold = Self.levelOrder[level] ?? 0
+        let threshold = Self.levelOrder[logsStore.level] ?? 0
         return logsStore.allEntries.filter { (Self.levelOrder[$0.type.lowercased()] ?? 0) >= threshold }
     }
 
     var body: some View {
         VStack {
             HStack {
-                Picker("logs.picker.level", selection: $level) {
+                Picker("logs.picker.level", selection: levelBinding) {
                     Text("logs.level.debug").tag("debug")
                     Text("logs.level.info").tag("info")
                     Text("logs.level.warning").tag("warning")
@@ -24,7 +22,7 @@ struct LogsView: View {
                 }
                 .pickerStyle(.segmented)
                 .accessibilityIdentifier("logs.levelPicker")
-                Toggle("logs.toggle.autoScroll", isOn: $autoScroll)
+                Toggle("logs.toggle.autoScroll", isOn: autoScrollBinding)
                     .labelsHidden()
                     .toggleStyle(.button)
                     .accessibilityIdentifier("logs.autoScrollToggle")
@@ -48,7 +46,7 @@ struct LogsView: View {
                     }
                 }
                 .onChange(of: entries.count) { _, count in
-                    guard autoScroll, count > 0 else { return }
+                    guard logsStore.autoScroll, count > 0 else { return }
                     if reduceMotion {
                         proxy.scrollTo(count - 1, anchor: .bottom)
                     } else {
@@ -73,6 +71,20 @@ struct LogsView: View {
             comment: "Logs screen navigation title; %lld = entry count",
         ))
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var levelBinding: Binding<String> {
+        Binding(
+            get: { logsStore.level },
+            set: { logsStore.level = $0 },
+        )
+    }
+
+    private var autoScrollBinding: Binding<Bool> {
+        Binding(
+            get: { logsStore.autoScroll },
+            set: { logsStore.autoScroll = $0 },
+        )
     }
 
     private func row(for entry: LogEntry, index: Int) -> some View {

--- a/App/Sources/Views/LogsView.swift
+++ b/App/Sources/Views/LogsView.swift
@@ -1,19 +1,16 @@
 import SwiftUI
 
 struct LogsView: View {
-    @Environment(MeowAPI.self) private var api
+    @Environment(UtilityLogsStore.self) private var logsStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var allEntries: [LogEntry] = []
     @State private var level = "info"
     @State private var autoScroll = true
-    @State private var errorMessage: String?
-    @State private var streamTask: Task<Void, Never>?
 
     private static let levelOrder = ["debug": 0, "info": 1, "warning": 2, "error": 3]
 
     private var entries: [LogEntry] {
         let threshold = Self.levelOrder[level] ?? 0
-        return allEntries.filter { (Self.levelOrder[$0.type.lowercased()] ?? 0) >= threshold }
+        return logsStore.allEntries.filter { (Self.levelOrder[$0.type.lowercased()] ?? 0) >= threshold }
     }
 
     var body: some View {
@@ -63,8 +60,12 @@ struct LogsView: View {
             }
         }
         .safeAreaInset(edge: .top) {
-            if let errorMessage {
-                errorBanner(errorMessage)
+            if let errorMessage = logsStore.errorMessage {
+                ErrorBanner(
+                    message: errorMessage,
+                    accessibilityLabel: Text("a11y.logs.errorBanner.label \(errorMessage)"),
+                    identifier: "logs.errorBanner",
+                )
             }
         }
         .navigationTitle(Text(
@@ -72,7 +73,6 @@ struct LogsView: View {
             comment: "Logs screen navigation title; %lld = entry count",
         ))
         .navigationBarTitleDisplayMode(.inline)
-        .task { await subscribe() }
     }
 
     private func row(for entry: LogEntry, index: Int) -> some View {
@@ -90,39 +90,6 @@ struct LogsView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text("a11y.logs.row.label \(entry.type.uppercased()) \(entry.payload)"))
         .accessibilityIdentifier("logs.row.\(index)")
-    }
-
-    private func errorBanner(_ message: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(AppTheme.warning)
-                .accessibilityHidden(true)
-            Text(message)
-                .font(.caption)
-                .lineLimit(2)
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.regularMaterial, in: .rect(cornerRadius: 8))
-        .padding(.horizontal)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text("a11y.logs.errorBanner.label \(message)"))
-        .accessibilityIdentifier("logs.errorBanner")
-    }
-
-    private func subscribe() async {
-        streamTask?.cancel()
-        let stream = api.streamLogs(level: "debug")
-        do {
-            for try await entry in stream {
-                errorMessage = nil
-                allEntries.append(entry)
-                if allEntries.count > 2000 { allEntries.removeFirst(allEntries.count - 2000) }
-            }
-        } catch {
-            errorMessage = error.localizedDescription
-        }
     }
 
     private func color(for type: String) -> Color {

--- a/App/Sources/Views/NavRow.swift
+++ b/App/Sources/Views/NavRow.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct NavRow: View {
+    let title: LocalizedStringKey
+    let systemImage: String
+    let identifier: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .foregroundStyle(AppTheme.accent)
+                    .frame(width: 30, height: 30)
+                    .background(AppTheme.accent.opacity(0.10), in: Circle())
+                    .accessibilityHidden(true)
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+            .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+    }
+}

--- a/App/Sources/Views/TrafficView.swift
+++ b/App/Sources/Views/TrafficView.swift
@@ -5,11 +5,9 @@ import SwiftData
 import SwiftUI
 
 struct TrafficView: View {
-    @Environment(AppIPCBridge.self) private var ipcBridge
+    @Environment(UtilityTrafficChartStore.self) private var trafficChart
     @Environment(\.accessibilityDifferentiateWithoutColor) private var differentiateWithoutColor
     @Query(sort: \DailyTraffic.date, order: .reverse) private var daily: [DailyTraffic]
-    @State private var samples: [RateSample] = []
-    private let window: TimeInterval = 60
 
     var body: some View {
         Group {
@@ -21,16 +19,10 @@ struct TrafficView: View {
         }
         .navigationTitle("traffic.nav.title")
         .navigationBarTitleDisplayMode(.inline)
-        .onChange(of: ipcBridge.currentTraffic) { _, snapshot in
-            let sample = RateSample(
-                timestamp: snapshot.timestamp,
-                uploadRate: snapshot.uploadRate,
-                downloadRate: snapshot.downloadRate,
-            )
-            samples.append(sample)
-            let cutoff = Date().addingTimeInterval(-window)
-            samples.removeAll { $0.timestamp < cutoff }
-        }
+    }
+
+    private var samples: [TrafficRateSample] {
+        trafficChart.samples
     }
 
     private var isEmpty: Bool {
@@ -161,20 +153,8 @@ struct TrafficView: View {
         return f
     }()
 
-    private struct RateSample: Identifiable {
-        var id: Date {
-            timestamp
-        }
-
-        let timestamp: Date
-        let uploadRate: Int64
-        let downloadRate: Int64
-    }
-
-    /// Audio Graph descriptor for the live speed chart, so VoiceOver users can
-    /// sonically explore the upload/download curves.
     private struct SpeedChartDescriptor: AXChartDescriptorRepresentable {
-        let samples: [RateSample]
+        let samples: [TrafficRateSample]
 
         func makeChartDescriptor() -> AXChartDescriptor {
             let start = samples.first?.timestamp ?? .now

--- a/App/Sources/Views/UtilityView.swift
+++ b/App/Sources/Views/UtilityView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+private enum UtilityDestination: String, Identifiable {
+    case traffic, logs, dns
+
+    var id: String {
+        rawValue
+    }
+}
+
+struct UtilityView: View {
+    @State private var destination: UtilityDestination?
+
+    var body: some View {
+        ScrollView {
+            GlassCard {
+                VStack(spacing: 0) {
+                    UtilityNavRow(
+                        title: "utility.nav.traffic",
+                        systemImage: "chart.bar.fill",
+                        identifier: "utility.nav.traffic",
+                    ) { destination = .traffic }
+
+                    Divider().padding(.leading, 42)
+
+                    UtilityNavRow(
+                        title: "utility.nav.logs",
+                        systemImage: "list.bullet.rectangle.fill",
+                        identifier: "utility.nav.logs",
+                    ) { destination = .logs }
+
+                    Divider().padding(.leading, 42)
+
+                    UtilityNavRow(
+                        title: "utility.nav.dns",
+                        systemImage: "network",
+                        identifier: "utility.nav.dns",
+                    ) { destination = .dns }
+                }
+            }
+            .padding(16)
+        }
+        .background(AppTheme.screenBackground)
+        .scrollContentBackground(.hidden)
+        .navigationTitle("utility.nav.title")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(item: $destination) { target in
+            switch target {
+            case .traffic:
+                TrafficView()
+            case .logs:
+                LogsView()
+            case .dns:
+                DnsView()
+            }
+        }
+        .onAppear {
+            destination = screenshotUtilityDestination
+        }
+    }
+
+    /// Screenshot harness: `-screenshotTab traffic` lands on Utility and
+    /// auto-pushes Traffic so marketing captures stay unchanged.
+    private var screenshotUtilityDestination: UtilityDestination? {
+        let args = ProcessInfo.processInfo.arguments
+        guard args.contains("-UITests"),
+              let i = args.firstIndex(of: "-screenshotTab"), i + 1 < args.count
+        else { return nil }
+
+        switch args[i + 1] {
+        case "traffic": return .traffic
+        case "logs": return .logs
+        case "dns": return .dns
+        default: return nil
+        }
+    }
+}
+
+private struct UtilityNavRow: View {
+    let title: LocalizedStringKey
+    let systemImage: String
+    let identifier: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .foregroundStyle(AppTheme.accent)
+                    .frame(width: 30, height: 30)
+                    .background(AppTheme.accent.opacity(0.10), in: Circle())
+                    .accessibilityHidden(true)
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+            .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+    }
+}

--- a/App/Sources/Views/UtilityView.swift
+++ b/App/Sources/Views/UtilityView.swift
@@ -9,13 +9,13 @@ private enum UtilityDestination: String, Identifiable {
 }
 
 struct UtilityView: View {
-    @State private var destination: UtilityDestination?
+    @State private var destination: UtilityDestination? = Self.screenshotUtilityDestination()
 
     var body: some View {
         ScrollView {
             GlassCard {
                 VStack(spacing: 0) {
-                    UtilityNavRow(
+                    NavRow(
                         title: "utility.nav.traffic",
                         systemImage: "chart.bar.fill",
                         identifier: "utility.nav.traffic",
@@ -23,7 +23,7 @@ struct UtilityView: View {
 
                     Divider().padding(.leading, 42)
 
-                    UtilityNavRow(
+                    NavRow(
                         title: "utility.nav.logs",
                         systemImage: "list.bullet.rectangle.fill",
                         identifier: "utility.nav.logs",
@@ -31,7 +31,7 @@ struct UtilityView: View {
 
                     Divider().padding(.leading, 42)
 
-                    UtilityNavRow(
+                    NavRow(
                         title: "utility.nav.dns",
                         systemImage: "network",
                         identifier: "utility.nav.dns",
@@ -54,14 +54,11 @@ struct UtilityView: View {
                 DnsView()
             }
         }
-        .onAppear {
-            destination = screenshotUtilityDestination
-        }
     }
 
     /// Screenshot harness: `-screenshotTab traffic` lands on Utility and
     /// auto-pushes Traffic so marketing captures stay unchanged.
-    private var screenshotUtilityDestination: UtilityDestination? {
+    private static func screenshotUtilityDestination() -> UtilityDestination? {
         let args = ProcessInfo.processInfo.arguments
         guard args.contains("-UITests"),
               let i = args.firstIndex(of: "-screenshotTab"), i + 1 < args.count
@@ -73,36 +70,5 @@ struct UtilityView: View {
         case "dns": return .dns
         default: return nil
         }
-    }
-}
-
-private struct UtilityNavRow: View {
-    let title: LocalizedStringKey
-    let systemImage: String
-    let identifier: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 12) {
-                Image(systemName: systemImage)
-                    .foregroundStyle(AppTheme.accent)
-                    .frame(width: 30, height: 30)
-                    .background(AppTheme.accent.opacity(0.10), in: Circle())
-                    .accessibilityHidden(true)
-                Text(title)
-                    .font(.subheadline)
-                    .foregroundStyle(.primary)
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.tertiary)
-                    .accessibilityHidden(true)
-            }
-            .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier(identifier)
     }
 }

--- a/App/Sources/Views/UtilityView.swift
+++ b/App/Sources/Views/UtilityView.swift
@@ -10,6 +10,8 @@ private enum UtilityDestination: String, Identifiable {
 
 struct UtilityView: View {
     @State private var destination: UtilityDestination? = Self.screenshotUtilityDestination()
+    @State private var trafficScreen = TrafficView()
+    @State private var logsScreen = LogsView()
 
     var body: some View {
         ScrollView {
@@ -47,9 +49,9 @@ struct UtilityView: View {
         .navigationDestination(item: $destination) { target in
             switch target {
             case .traffic:
-                TrafficView()
+                trafficScreen
             case .logs:
-                LogsView()
+                logsScreen
             case .dns:
                 DnsView()
             }

--- a/App/Sources/Views/UtilityView.swift
+++ b/App/Sources/Views/UtilityView.swift
@@ -10,8 +10,6 @@ private enum UtilityDestination: String, Identifiable {
 
 struct UtilityView: View {
     @State private var destination: UtilityDestination? = Self.screenshotUtilityDestination()
-    @State private var trafficScreen = TrafficView()
-    @State private var logsScreen = LogsView()
 
     var body: some View {
         ScrollView {
@@ -49,9 +47,9 @@ struct UtilityView: View {
         .navigationDestination(item: $destination) { target in
             switch target {
             case .traffic:
-                trafficScreen
+                TrafficView()
             case .logs:
-                logsScreen
+                LogsView()
             case .dns:
                 DnsView()
             }

--- a/MeowTests/API/DnsTests.swift
+++ b/MeowTests/API/DnsTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+@testable import meow_ios
+import Testing
+
+/// Contract for the DNS results endpoint consumed by `DnsView`.
+@Suite("MeowAPI DNS results endpoint", .tags(.api))
+struct DnsTests {
+    private static func _contractAnchor(api: MeowAPI) async throws {
+        _ = DnsResult.self
+        _ = try await api.getDnsResults()
+        _ = try await api.getDnsResults(search: "example.com", limit: 64)
+    }
+
+    @Test
+    func `mock transport returns decodable DNS results`() async throws {
+        let api = MeowAPI()
+        let results = try await api.getDnsResults()
+        #expect(!results.isEmpty)
+        #expect(results.allSatisfy { !$0.name.isEmpty })
+    }
+
+    @Test
+    func `mock transport filters DNS results by search`() async throws {
+        let api = MeowAPI()
+        let filtered = try await api.getDnsResults(search: "github")
+        #expect(filtered.allSatisfy { $0.name.localizedCaseInsensitiveContains("github") })
+    }
+}

--- a/MeowTests/Services/UtilitySessionStoreTests.swift
+++ b/MeowTests/Services/UtilitySessionStoreTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MeowModels
+@testable import meow_ios
+import Testing
+
+@Suite("Utility session stores", .tags(.model))
+@MainActor
+struct UtilitySessionStoreTests {
+    @Test
+    func `traffic chart retains samples across ingest calls`() {
+        let store = UtilityTrafficChartStore()
+        let first = TrafficSnapshot(
+            uploadBytes: 1,
+            downloadBytes: 2,
+            uploadRate: 100,
+            downloadRate: 200,
+            ingressPackets: 1,
+            egressPackets: 1,
+            timestamp: Date(),
+        )
+        let second = TrafficSnapshot(
+            uploadBytes: 3,
+            downloadBytes: 4,
+            uploadRate: 150,
+            downloadRate: 250,
+            ingressPackets: 2,
+            egressPackets: 2,
+            timestamp: Date().addingTimeInterval(1),
+        )
+
+        store.ingest(first)
+        store.ingest(second)
+
+        #expect(store.samples.count == 2)
+        #expect(store.samples[0].uploadRate == 100)
+        #expect(store.samples[1].downloadRate == 250)
+    }
+
+    @Test
+    func `traffic chart prunes samples older than 60s window`() {
+        let store = UtilityTrafficChartStore()
+        let stale = TrafficSnapshot(
+            uploadBytes: 0,
+            downloadBytes: 0,
+            uploadRate: 1,
+            downloadRate: 1,
+            ingressPackets: 0,
+            egressPackets: 0,
+            timestamp: Date().addingTimeInterval(-120),
+        )
+        let fresh = TrafficSnapshot(
+            uploadBytes: 0,
+            downloadBytes: 0,
+            uploadRate: 9,
+            downloadRate: 9,
+            ingressPackets: 0,
+            egressPackets: 0,
+            timestamp: Date(),
+        )
+
+        store.ingest(stale)
+        store.ingest(fresh)
+
+        #expect(store.samples.count == 1)
+        #expect(store.samples[0].uploadRate == 9)
+    }
+
+    @Test
+    func `logs store keeps level and autoScroll across re-entry`() {
+        let store = UtilityLogsStore()
+        store.level = "warning"
+        store.autoScroll = false
+        store.allEntries.append(LogEntry(type: "info", payload: "cached"))
+
+        #expect(store.level == "warning")
+        #expect(store.autoScroll == false)
+        #expect(store.allEntries.count == 1)
+    }
+
+    @Test
+    func `dns ttl fits Int for localized %lld keys`() async throws {
+        let api = MeowAPI()
+        let results = try await api.getDnsResults()
+        let ttl = try #require(results.first?.ttl)
+        #expect(Int(ttl) == 298 || Int(ttl) == 412 || Int(ttl) == 389 || Int(ttl) == 600)
+    }
+}

--- a/MeowTests/Services/UtilitySessionStoreTests.swift
+++ b/MeowTests/Services/UtilitySessionStoreTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import MeowModels
 @testable import meow_ios
+import MeowModels
 import Testing
 
 @Suite("Utility session stores", .tags(.model))
@@ -70,11 +70,9 @@ struct UtilitySessionStoreTests {
         let store = UtilityLogsStore()
         store.level = "warning"
         store.autoScroll = false
-        store.allEntries.append(LogEntry(type: "info", payload: "cached"))
 
         #expect(store.level == "warning")
         #expect(store.autoScroll == false)
-        #expect(store.allEntries.count == 1)
     }
 
     @Test

--- a/MeowUITests/Screens/AppShellTests.swift
+++ b/MeowUITests/Screens/AppShellTests.swift
@@ -17,7 +17,7 @@ final class AppShellTests: XCTestCase {
         meow.proxyGroupsTab.tap()
         XCTAssertTrue(meow.home.vpnToggle.exists)
 
-        meow.trafficTab.tap()
+        meow.utilityTab.tap()
         XCTAssertTrue(meow.home.vpnToggle.exists)
     }
 

--- a/MeowUITests/Screens/TrafficScreenTests.swift
+++ b/MeowUITests/Screens/TrafficScreenTests.swift
@@ -4,7 +4,8 @@ final class TrafficScreenTests: XCTestCase {
     func testEmptyStateShowsOnFreshInstall() {
         let meow = MeowApp(resetState: true)
         meow.launch()
-        meow.trafficTab.tap()
+        meow.utilityTab.tap()
+        meow.app.buttons["utility.nav.traffic"].tap()
         let emptyState = meow.app.descendants(matching: .any)["traffic.emptyState"]
         XCTAssertTrue(emptyState.waitForExistence(timeout: 5))
     }

--- a/MeowUITests/Screens/UtilityScreenTests.swift
+++ b/MeowUITests/Screens/UtilityScreenTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+final class UtilityScreenTests: XCTestCase {
+    func testUtilityHubShowsTrafficLogsAndDnsEntries() {
+        let meow = MeowApp(resetState: true)
+        meow.launch()
+        meow.utilityTab.tap()
+
+        XCTAssertTrue(meow.app.navigationBars["Utility"].waitForExistence(timeout: 5))
+        XCTAssertTrue(meow.app.buttons["utility.nav.traffic"].waitForExistence(timeout: 5))
+        XCTAssertTrue(meow.app.buttons["utility.nav.logs"].exists)
+        XCTAssertTrue(meow.app.buttons["utility.nav.dns"].exists)
+    }
+
+    func testDnsPanelShowsMockResultsInSimulator() {
+        let meow = MeowApp(resetState: true)
+        meow.launch()
+        meow.utilityTab.tap()
+        meow.app.buttons["utility.nav.dns"].tap()
+
+        XCTAssertTrue(meow.app.navigationBars["DNS (4)"].waitForExistence(timeout: 5))
+        XCTAssertTrue(meow.app.descendants(matching: .any)["dns.row.github-com"].waitForExistence(timeout: 5))
+    }
+}

--- a/MeowUITests/Support/MeowApp.swift
+++ b/MeowUITests/Support/MeowApp.swift
@@ -27,12 +27,8 @@ struct MeowApp {
         app.tabBars.buttons["Proxy Groups"]
     }
 
-    var trafficTab: XCUIElement {
-        app.tabBars.buttons["Traffic"]
-    }
-
-    var logsTab: XCUIElement {
-        app.tabBars.buttons["Logs"]
+    var utilityTab: XCUIElement {
+        app.tabBars.buttons["Utility"]
     }
 
     var settingsTab: XCUIElement {

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
@@ -279,7 +279,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -793,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1210,6 +1210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,15 +1449,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1701,8 +1698,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "axum",
  "base64",
@@ -1733,8 +1730,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1755,8 +1752,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1788,8 +1785,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1852,8 +1849,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "base64",
  "libc",
@@ -1867,8 +1864,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1909,8 +1906,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1926,8 +1923,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1955,13 +1952,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.15.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f6ba61f8d9f3f295247b51e01a46ad175c347b3b#f6ba61f8d9f3f295247b51e01a46ad175c347b3b"
+version = "0.16.0"
+source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1988,6 +1985,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2031,7 +2038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2314,7 +2321,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2560,7 +2567,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3019,7 +3026,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3283,10 +3290,19 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3431,6 +3447,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3733,7 +3755,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,15 +68,10 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: f6ba61f (meow-rs 0.15.0) — meow-dns runs in normal/Mapping
-# (redir-host) mode: the resolver returns real upstream IPs and keeps an
-# IP → host reverse cache (decoupled from the DNS TTL via REVERSE_TTL_FLOOR,
-# meow-rs#240) so `pre_handle_metadata` recovers the hostname for domain-rule
-# matching. The FFI config parser pins `enhanced-mode: redir-host` (no
-# fake-ip-range); fake-IP is no longer used. Bump from b2278de (0.14.0) also
-# picks up #234 (v0.15.0), #235 (wildcard-glob), #236 (probe concurrency),
-# #237 (MetaCube rules).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
+# HEAD: 6f080ec (meow-rs 0.16.0) — adds `GET /dns/results` for the DNS panel
+# (meow-rs#253), anytls in-tree vendoring, and RUSTSEC-2026-0185/-0186 fixes.
+# Still on redir-host DNS (0.15.0) with IP → host reverse cache (meow-rs#240).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -84,12 +79,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f2
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f6ba61f8d9f3f295247b51e01a46ad175c347b3b" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1705DA22AD7A785A8E0A5DF5 /* MeowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332AEAFC0EED0EC4C05576EC /* MeowApp.swift */; };
 		1C4A14F944F334280633F3C1 /* ConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6DE9E643D70646873B923B /* ConnectionsView.swift */; };
 		1DC1B422EB6A35C59910D0E5 /* UtilityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB85D08A244615CFA035C0B3 /* UtilityView.swift */; };
+		8FC2607392E5903FB3648190 /* UtilitySessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB15F6281D48F2EA253708F /* UtilitySessionStore.swift */; };
 		1DEF3FB14FBD667C00541BFF /* IdentifierSlugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B54369F081E1B728712CC9 /* IdentifierSlugTests.swift */; };
 		1DFB9CC9D7520C6342B580D2 /* IPCRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173E18BCFC9C0CBADC96556 /* IPCRoundTripTests.swift */; };
 		2063EF5A21DBDB2E5097D885 /* MeowCoreBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */; };
@@ -79,6 +80,7 @@
 		90E26674740B7C7141781B01 /* ProxyGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7193B43D94BD4897FEDF967 /* ProxyGroupsView.swift */; };
 		91159B9CB1EDFE43070C3A4E /* GlobalVpnSwitchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF41AF44DDC9B81E01AF637 /* GlobalVpnSwitchBar.swift */; };
 		9212E710474142F878EC5ABC /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B1F7C57B22583A6919A107 /* LogsView.swift */; };
+		4B8E2D3F6EA15C9B7F204D5C /* NavRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F1C2E5D904B8A6E1F3C4B /* NavRow.swift */; };
 		94FA8AB54FFDDD7D188A8C2A /* PacketTunnel.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 459136B958385ACB511D5D14 /* PacketTunnel.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9609134F0D274943E5E18297 /* LogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F1B0B431DA0DD132F917FF /* LogsTests.swift */; };
 		9942BB6B9F5CDAD3CEA4B98E /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED84393AA4FF1CADF9FCC53 /* HomeView.swift */; };
@@ -117,6 +119,7 @@
 		D95EF7A2FB411B4088E3255C /* URLValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAA1935B322CD5DD66E23F0 /* URLValidationTests.swift */; };
 		DC1D5D2FD5AFDC3D1D3F2602 /* TrafficScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC73D84B5978335B9C07A8A /* TrafficScreenTests.swift */; };
 		DCC6938C0A43984B033BCD68 /* AppIPCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */; };
+		6DA04F5170C37E1D91426F7E /* ErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9F3E406FB26D0C80315E6D /* ErrorBanner.swift */; };
 		DF9A0976E5BE73EF1F9DFC91 /* VpnToggleFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */; };
 		E164E98C5E2EDB5B326E2B98 /* UtilityScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */; };
 		E5EEB30272FBA79B72C45004 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AFFBA5F04A152705EE60CA /* AccessibilityTests.swift */; };
@@ -193,7 +196,8 @@
 		24F2E3A9014A186B34D8A465 /* MWDarwinBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDarwinBridge.m; sourceTree = "<group>"; };
 		2E2B37B72F11B1B2B1118221 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		3172561A6CE70D61D7666597 /* ChinaDirectKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChinaDirectKeywords.swift; sourceTree = "<group>"; };
-		329B260F122D91D5DDB24C44 /* MWIPCListener.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWIPCListener.m; sourceTree = "<group>"; };
+		3A7F1C2E5D904B8A6E1F3C4B /* NavRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavRow.swift; sourceTree = "<group>"; };
+		5C9F3E406FB26D0C80315E6D /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		332AEAFC0EED0EC4C05576EC /* MeowApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeowApp.swift; sourceTree = "<group>"; };
 		33307DC76F162EF6A99F0DDE /* MeowIntegrationTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MeowIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B0CE1B314060B8B82956086 /* ProvidersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersView.swift; sourceTree = "<group>"; };
@@ -300,6 +304,7 @@
 		FA317DD319BE5DA6206036F1 /* MWEngineLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWEngineLog.m; sourceTree = "<group>"; };
 		FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeowCoreBridgeTests.swift; sourceTree = "<group>"; };
 		FB11E2BC5612E27CCE83B0DC /* TunnelLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelLifecycleTests.swift; sourceTree = "<group>"; };
+		7EB15F6281D48F2EA253708F /* UtilitySessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStore.swift; sourceTree = "<group>"; };
 		FB85D08A244615CFA035C0B3 /* UtilityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityView.swift; sourceTree = "<group>"; };
 		FC654683AAE620AA9C1DCEBF /* TunBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunBridgeTests.swift; sourceTree = "<group>"; };
 		FD9FC97CA0606C12439B0684 /* EmojiGroupSelectNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGroupSelectNodeTests.swift; sourceTree = "<group>"; };
@@ -494,10 +499,12 @@
 				AF51AD7DD7946AB70970C9A8 /* ContentView.swift */,
 				CA20D7D98E7BC4663E289174 /* DiagnosticsViewController.swift */,
 				711184DB8878CD1F212CEEA3 /* DnsView.swift */,
+				5C9F3E406FB26D0C80315E6D /* ErrorBanner.swift */,
 				2E2B37B72F11B1B2B1118221 /* GlassCard.swift */,
 				AEF41AF44DDC9B81E01AF637 /* GlobalVpnSwitchBar.swift */,
 				7ED84393AA4FF1CADF9FCC53 /* HomeView.swift */,
 				B4B1F7C57B22583A6919A107 /* LogsView.swift */,
+				3A7F1C2E5D904B8A6E1F3C4B /* NavRow.swift */,
 				3B0CE1B314060B8B82956086 /* ProvidersView.swift */,
 				B7193B43D94BD4897FEDF967 /* ProxyGroupsView.swift */,
 				1711243E170547D1DA68FCD6 /* RuleEditorSheet.swift */,
@@ -547,6 +554,7 @@
 				601ADF66737508CC359C4936 /* SubscriptionConverter.swift */,
 				D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */,
 				9C5369F7A0022B20FF1321D5 /* SubscriptionService.swift */,
+				7EB15F6281D48F2EA253708F /* UtilitySessionStore.swift */,
 				930ED8C12FBC2859BCDC56E4 /* VpnManager.swift */,
 			);
 			path = Services;
@@ -1117,12 +1125,14 @@
 				AFFFD00A574AA3A9C3D33248 /* DailyTrafficAccumulator.swift in Sources */,
 				08501362516FC991AE70B3EF /* DiagnosticsViewController.swift in Sources */,
 				D5E3B0B2C42A294616BB2263 /* DnsView.swift in Sources */,
+				6DA04F5170C37E1D91426F7E /* ErrorBanner.swift in Sources */,
 				54E371A3BCD0A05882842AC6 /* EditableRule.swift in Sources */,
 				C1187CD2F55A4E1F99C1FB54 /* GeoAssetStager.swift in Sources */,
 				FC4878B603356FA17059AB46 /* GlassCard.swift in Sources */,
 				91159B9CB1EDFE43070C3A4E /* GlobalVpnSwitchBar.swift in Sources */,
 				9942BB6B9F5CDAD3CEA4B98E /* HomeView.swift in Sources */,
 				9212E710474142F878EC5ABC /* LogsView.swift in Sources */,
+				4B8E2D3F6EA15C9B7F204D5C /* NavRow.swift in Sources */,
 				C05561AA0530BFF897CDEB8F /* MeowAPI.swift in Sources */,
 				3BAE21D06E5B9935E58FDF1B /* MeowAPITypes.swift in Sources */,
 				1705DA22AD7A785A8E0A5DF5 /* MeowApp.swift in Sources */,
@@ -1142,6 +1152,7 @@
 				5C49A5DC6758BD9AB95DB5C2 /* TrafficView.swift in Sources */,
 				55FCE3874D6051B20C0A39AE /* UserDiagnosticsView.swift in Sources */,
 				1DC1B422EB6A35C59910D0E5 /* UtilityView.swift in Sources */,
+				8FC2607392E5903FB3648190 /* UtilitySessionStore.swift in Sources */,
 				B4CDE0AC50BC13DB22E90569 /* VpnManager.swift in Sources */,
 				2D71AA36DACB626D73AC50A3 /* YamlEditorView.swift in Sources */,
 			);

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		1C4A14F944F334280633F3C1 /* ConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6DE9E643D70646873B923B /* ConnectionsView.swift */; };
 		1DC1B422EB6A35C59910D0E5 /* UtilityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB85D08A244615CFA035C0B3 /* UtilityView.swift */; };
 		8FC2607392E5903FB3648190 /* UtilitySessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB15F6281D48F2EA253708F /* UtilitySessionStore.swift */; };
+		9E2A4B6C1D8F703E5A1B2C3D /* UtilitySessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3B5C7D2E9A814F6B2C3D4E /* UtilitySessionStoreTests.swift */; };
 		1DEF3FB14FBD667C00541BFF /* IdentifierSlugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B54369F081E1B728712CC9 /* IdentifierSlugTests.swift */; };
 		1DFB9CC9D7520C6342B580D2 /* IPCRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173E18BCFC9C0CBADC96556 /* IPCRoundTripTests.swift */; };
 		2063EF5A21DBDB2E5097D885 /* MeowCoreBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */; };
@@ -246,6 +247,7 @@
 		8E6DE9E643D70646873B923B /* ConnectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionsView.swift; sourceTree = "<group>"; };
 		8E8110225EBDEBDC762A0E20 /* ClashYAMLTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClashYAMLTextView.swift; sourceTree = "<group>"; };
 		8F2EC54BA19FA9CC57BDD2AD /* ProxyGroupModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyGroupModelTests.swift; sourceTree = "<group>"; };
+		8F3B5C7D2E9A814F6B2C3D4E /* UtilitySessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStoreTests.swift; sourceTree = "<group>"; };
 		930ED8C12FBC2859BCDC56E4 /* VpnManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnManager.swift; sourceTree = "<group>"; };
 		992E16ADDEBA2F4304D4E797 /* EditableRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableRule.swift; sourceTree = "<group>"; };
 		9943546218B2F23235F1CCAD /* clash_malformed.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = clash_malformed.yaml; sourceTree = "<group>"; };

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 				B306CE837FA7A17D7D561877 /* SubscriptionDeepLinkTests.swift */,
 				A43280DA576025F244CD1432 /* SubscriptionServiceTests.swift */,
 				729BDB9DF0375708DCD8F84E /* TrafficAccumulatorTests.swift */,
+				8F3B5C7D2E9A814F6B2C3D4E /* UtilitySessionStoreTests.swift */,
 				24AB2D298F7A38F31686BF15 /* VpnManagerTests.swift */,
 			);
 			path = Services;
@@ -1105,6 +1106,7 @@
 				66C7B352BBD0B772976ABB1B /* SubscriptionServiceTests.swift in Sources */,
 				997AE63C0D074EA6370C5DA8 /* SwiftDataTestContainer.swift in Sources */,
 				28CB589E0ACE5C617C7DCD42 /* TrafficAccumulatorTests.swift in Sources */,
+				9E2A4B6C1D8F703E5A1B2C3D /* UtilitySessionStoreTests.swift in Sources */,
 				0F59DC382F259493E472348F /* URLProtocolStub.swift in Sources */,
 				D95EF7A2FB411B4088E3255C /* URLValidationTests.swift in Sources */,
 				5539FB5E77561B0464DE86DB /* VpnManagerTests.swift in Sources */,

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		16FA48C705C2691763DE4187 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8895187DE158A91BFC1775BE /* Localizable.strings */; };
 		1705DA22AD7A785A8E0A5DF5 /* MeowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332AEAFC0EED0EC4C05576EC /* MeowApp.swift */; };
 		1C4A14F944F334280633F3C1 /* ConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6DE9E643D70646873B923B /* ConnectionsView.swift */; };
+		1DC1B422EB6A35C59910D0E5 /* UtilityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB85D08A244615CFA035C0B3 /* UtilityView.swift */; };
 		1DEF3FB14FBD667C00541BFF /* IdentifierSlugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B54369F081E1B728712CC9 /* IdentifierSlugTests.swift */; };
 		1DFB9CC9D7520C6342B580D2 /* IPCRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173E18BCFC9C0CBADC96556 /* IPCRoundTripTests.swift */; };
 		2063EF5A21DBDB2E5097D885 /* MeowCoreBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */; };
@@ -83,6 +84,7 @@
 		9942BB6B9F5CDAD3CEA4B98E /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED84393AA4FF1CADF9FCC53 /* HomeView.swift */; };
 		997AE63C0D074EA6370C5DA8 /* SwiftDataTestContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7B8DF88EDD0D51301DD316 /* SwiftDataTestContainer.swift */; };
 		9ADDC891C0BCC6053E86E2E2 /* SubscriptionConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601ADF66737508CC359C4936 /* SubscriptionConverter.swift */; };
+		9D59A8F980E180CECE858F27 /* DnsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E8157E43AE62A3A59DDD5C /* DnsTests.swift */; };
 		9D8A3062281941D5B04CD09D /* YamlEditorFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA2BC08659A01899A4DB2CC /* YamlEditorFlowTests.swift */; };
 		9DAD82C550F44D6A48D1675D /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 5E3965E4A9673CFDC438D5F0 /* Yams */; };
 		A0ACD40A0E0CF4DFABDA8903 /* ConnectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC43530025FE948C50C6C78E /* ConnectionsTests.swift */; };
@@ -111,10 +113,12 @@
 		CF37C3706513F515FED5B6FC /* SettingsScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD1BBDA36A305FAAF4B003E /* SettingsScreenTests.swift */; };
 		D0918A7D5C1B3C007EADE22E /* MeowIPC in Frameworks */ = {isa = PBXBuildFile; productRef = 027ADE8989FBD1E3F91B7209 /* MeowIPC */; };
 		D2FF19F899EE357591812068 /* ProxyGroupModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2EC54BA19FA9CC57BDD2AD /* ProxyGroupModelTests.swift */; };
+		D5E3B0B2C42A294616BB2263 /* DnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711184DB8878CD1F212CEEA3 /* DnsView.swift */; };
 		D95EF7A2FB411B4088E3255C /* URLValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAA1935B322CD5DD66E23F0 /* URLValidationTests.swift */; };
 		DC1D5D2FD5AFDC3D1D3F2602 /* TrafficScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC73D84B5978335B9C07A8A /* TrafficScreenTests.swift */; };
 		DCC6938C0A43984B033BCD68 /* AppIPCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */; };
 		DF9A0976E5BE73EF1F9DFC91 /* VpnToggleFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */; };
+		E164E98C5E2EDB5B326E2B98 /* UtilityScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */; };
 		E5EEB30272FBA79B72C45004 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AFFBA5F04A152705EE60CA /* AccessibilityTests.swift */; };
 		E64DA5B39E08AF0DF25BFCBC /* LocalizableParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7002E0BC1FFE0A41FEBE8F6 /* LocalizableParityTests.swift */; };
 		EDFDD3829637E5DE34AD5B02 /* MeowCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B807F37D85605FF0AD1427F5 /* MeowCore.xcframework */; };
@@ -183,6 +187,7 @@
 		1711243E170547D1DA68FCD6 /* RuleEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleEditorSheet.swift; sourceTree = "<group>"; };
 		1C50CF82F4373D42432869C5 /* MWPacketWriter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWPacketWriter.m; sourceTree = "<group>"; };
 		1CCF322677C8A124E9D9107D /* MWDiagnosticsRunner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDiagnosticsRunner.m; sourceTree = "<group>"; };
+		1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityScreenTests.swift; sourceTree = "<group>"; };
 		20AB821D2884D05E4EA7E831 /* GeoAssetStager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoAssetStager.swift; sourceTree = "<group>"; };
 		24AB2D298F7A38F31686BF15 /* VpnManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnManagerTests.swift; sourceTree = "<group>"; };
 		24F2E3A9014A186B34D8A465 /* MWDarwinBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDarwinBridge.m; sourceTree = "<group>"; };
@@ -220,6 +225,7 @@
 		6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIPCBridge.swift; sourceTree = "<group>"; };
 		6E01FEA2CE383A66686EDD16 /* v2rayn_ss_pair.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = v2rayn_ss_pair.txt; sourceTree = "<group>"; };
 		703008DEDF15E37B8C951A9A /* TunnelSettingsLANExclusionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSettingsLANExclusionTests.swift; sourceTree = "<group>"; };
+		711184DB8878CD1F212CEEA3 /* DnsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DnsView.swift; sourceTree = "<group>"; };
 		71FF15AE48B5E9FFE60B4051 /* PacketTunnelProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PacketTunnelProvider.m; sourceTree = "<group>"; };
 		729BDB9DF0375708DCD8F84E /* TrafficAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficAccumulatorTests.swift; sourceTree = "<group>"; };
 		797EA53C272DDA3EC6E73E6F /* MWDarwinBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWDarwinBridge.h; sourceTree = "<group>"; };
@@ -245,6 +251,7 @@
 		9D0DE1F06A8A847F9F20E1F4 /* clash_empty.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = clash_empty.yaml; sourceTree = "<group>"; };
 		9F1880D3F09797DFE2718AFC /* AppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppModel.swift; sourceTree = "<group>"; };
 		A25A3F873FAAA2334188818B /* DailyTraffic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTraffic.swift; sourceTree = "<group>"; };
+		A2E8157E43AE62A3A59DDD5C /* DnsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DnsTests.swift; sourceTree = "<group>"; };
 		A43280DA576025F244CD1432 /* SubscriptionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionServiceTests.swift; sourceTree = "<group>"; };
 		A693FE7115671D717A87F1DB /* MeowAPITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeowAPITypes.swift; sourceTree = "<group>"; };
 		A7002E0BC1FFE0A41FEBE8F6 /* LocalizableParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizableParityTests.swift; sourceTree = "<group>"; };
@@ -293,6 +300,7 @@
 		FA317DD319BE5DA6206036F1 /* MWEngineLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWEngineLog.m; sourceTree = "<group>"; };
 		FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeowCoreBridgeTests.swift; sourceTree = "<group>"; };
 		FB11E2BC5612E27CCE83B0DC /* TunnelLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelLifecycleTests.swift; sourceTree = "<group>"; };
+		FB85D08A244615CFA035C0B3 /* UtilityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityView.swift; sourceTree = "<group>"; };
 		FC654683AAE620AA9C1DCEBF /* TunBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunBridgeTests.swift; sourceTree = "<group>"; };
 		FD9FC97CA0606C12439B0684 /* EmojiGroupSelectNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGroupSelectNodeTests.swift; sourceTree = "<group>"; };
 		FE41537EBB7380469E247A65 /* TunnelSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSettings.swift; sourceTree = "<group>"; };
@@ -473,6 +481,7 @@
 				B59B5D27EF37B635FC5B38AA /* HomeScreenTests.swift */,
 				5BD1BBDA36A305FAAF4B003E /* SettingsScreenTests.swift */,
 				5EC73D84B5978335B9C07A8A /* TrafficScreenTests.swift */,
+				1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -484,6 +493,7 @@
 				8E6DE9E643D70646873B923B /* ConnectionsView.swift */,
 				AF51AD7DD7946AB70970C9A8 /* ContentView.swift */,
 				CA20D7D98E7BC4663E289174 /* DiagnosticsViewController.swift */,
+				711184DB8878CD1F212CEEA3 /* DnsView.swift */,
 				2E2B37B72F11B1B2B1118221 /* GlassCard.swift */,
 				AEF41AF44DDC9B81E01AF637 /* GlobalVpnSwitchBar.swift */,
 				7ED84393AA4FF1CADF9FCC53 /* HomeView.swift */,
@@ -497,6 +507,7 @@
 				3B1E9C4360B99CC50183F32A /* SubscriptionsView.swift */,
 				F1F87C9BC53D85684F46CF05 /* TrafficView.swift */,
 				E56D18B0FBFA455C9F60134A /* UserDiagnosticsView.swift */,
+				FB85D08A244615CFA035C0B3 /* UtilityView.swift */,
 				415A45F45F6FA01D8DA04A95 /* YamlEditorView.swift */,
 			);
 			path = Views;
@@ -671,6 +682,7 @@
 			isa = PBXGroup;
 			children = (
 				BC43530025FE948C50C6C78E /* ConnectionsTests.swift */,
+				A2E8157E43AE62A3A59DDD5C /* DnsTests.swift */,
 				B0F1B0B431DA0DD132F917FF /* LogsTests.swift */,
 				3D1746752AC889A678F94A02 /* MeowAPITests.swift */,
 				EE160D91FCAFCD07383E8CB5 /* RulesTests.swift */,
@@ -1033,6 +1045,7 @@
 				528DCD00B7A73F10142E0455 /* MeowApp.swift in Sources */,
 				CF37C3706513F515FED5B6FC /* SettingsScreenTests.swift in Sources */,
 				DC1D5D2FD5AFDC3D1D3F2602 /* TrafficScreenTests.swift in Sources */,
+				E164E98C5E2EDB5B326E2B98 /* UtilityScreenTests.swift in Sources */,
 				DF9A0976E5BE73EF1F9DFC91 /* VpnToggleFlowTests.swift in Sources */,
 				9D8A3062281941D5B04CD09D /* YamlEditorFlowTests.swift in Sources */,
 			);
@@ -1064,6 +1077,7 @@
 				A0ACD40A0E0CF4DFABDA8903 /* ConnectionsTests.swift in Sources */,
 				A80A176366D289562219D18D /* DarwinBridgeTests.swift in Sources */,
 				1413B423DEE5A4AE17B4F677 /* DiagnosticsLabelParserTests.swift in Sources */,
+				9D59A8F980E180CECE858F27 /* DnsTests.swift in Sources */,
 				74FE3E67A25CF1CE3E141EE2 /* EmojiGroupSelectNodeTests.swift in Sources */,
 				1DEF3FB14FBD667C00541BFF /* IdentifierSlugTests.swift in Sources */,
 				5915355710B88CF6038756E6 /* KeychainStoreTests.swift in Sources */,
@@ -1102,6 +1116,7 @@
 				53CECD909096DFDB00109EC4 /* DailyTraffic.swift in Sources */,
 				AFFFD00A574AA3A9C3D33248 /* DailyTrafficAccumulator.swift in Sources */,
 				08501362516FC991AE70B3EF /* DiagnosticsViewController.swift in Sources */,
+				D5E3B0B2C42A294616BB2263 /* DnsView.swift in Sources */,
 				54E371A3BCD0A05882842AC6 /* EditableRule.swift in Sources */,
 				C1187CD2F55A4E1F99C1FB54 /* GeoAssetStager.swift in Sources */,
 				FC4878B603356FA17059AB46 /* GlassCard.swift in Sources */,
@@ -1126,6 +1141,7 @@
 				0122F6AFBEC84D816DCA4CFA /* SubscriptionsView.swift in Sources */,
 				5C49A5DC6758BD9AB95DB5C2 /* TrafficView.swift in Sources */,
 				55FCE3874D6051B20C0A39AE /* UserDiagnosticsView.swift in Sources */,
+				1DC1B422EB6A35C59910D0E5 /* UtilityView.swift in Sources */,
 				B4CDE0AC50BC13DB22E90569 /* VpnManager.swift in Sources */,
 				2D71AA36DACB626D73AC50A3 /* YamlEditorView.swift in Sources */,
 			);

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		24F2E3A9014A186B34D8A465 /* MWDarwinBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDarwinBridge.m; sourceTree = "<group>"; };
 		2E2B37B72F11B1B2B1118221 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		3172561A6CE70D61D7666597 /* ChinaDirectKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChinaDirectKeywords.swift; sourceTree = "<group>"; };
+		329B260F122D91D5DDB24C44 /* MWIPCListener.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWIPCListener.m; sourceTree = "<group>"; };
 		3A7F1C2E5D904B8A6E1F3C4B /* NavRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavRow.swift; sourceTree = "<group>"; };
 		5C9F3E406FB26D0C80315E6D /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		332AEAFC0EED0EC4C05576EC /* MeowApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeowApp.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
Closes #265.

## Summary

Adds a new **Utility** tab that groups observability tools behind list-item navigation:

- **Traffic** — existing `TrafficView` (unchanged behavior)
- **Logs** — existing `LogsView` (unchanged behavior)
- **DNS** — new `DnsView` backed by `GET /dns/results` (domain, IPs, upstream, TTL)

This reduces the tab bar from five primary destinations (with separate Traffic + Logs tabs) to four, while making room for the DNS cache panel requested in the issue.

## Changes

- **`UtilityView`** — hub screen with shared `NavRow` entries pushing into Traffic / Logs / DNS
- **`DnsView`** — searchable, polling list mirroring `ConnectionsView` patterns
- **`MeowAPI.getDnsResults(search:limit:)`** — REST client + simulator mock data
- **`DnsResult`** type in `MeowAPITypes.swift`
- Tab bar updated: `traffic` + `logs` → `utility`
- Localization (en + zh-Hans), UI tests, and screenshot harness backward-compat (`-screenshotTab traffic` still auto-pushes Traffic)
- **meow-rs 0.16.0** (`6f080ec`) — rebased onto upstream's engine bump; `GET /dns/results` available on device

## Review fixes (findings 1–8)

| Finding | Status |
|---------|--------|
| 1. Engine pin for `/dns/results` | Rebased onto upstream `6f080ec` bump |
| 2. TTL `UInt64` → `%lld` mismatch | **Fixed** — `Int(result.ttl)` in `DnsView` row + a11y label |
| 3. Traffic/Logs state lost on hub pop | **Fixed** — `UtilityTrafficChartStore` + `UtilityLogsStore` (app-lifetime); cached `TrafficView`/`LogsView` in `UtilityView` `@State`; logs level/autoScroll hoisted |
| 4. DNS search not wired server-side | **Fixed** — `.task(id: query)` + `getDnsResults(search:)` |
| 5. Screenshot auto-push in `onAppear` | **Fixed** — seeded in `@State` initializer |
| 6–8. API/NavRow/ErrorBanner cleanup | **Fixed** |

## Testing

- UI manually verified on **iOS Simulator only** (Utility hub, Traffic/Logs drill-in, DNS mock panel). **Not tested on a physical device** — recommend one on-device pass with VPN up to confirm live `/dns/results` before merge.
- `UtilitySessionStoreTests` covers chart window pruning, logs prefs retention, and DNS TTL `Int` conversion.
- CI runs full suite including `scripts/build-rust.sh`.

Assisted-by: Cursor