### PR TITLE
chore(metadata): rename app to "Meow - Smart VPN"

### DIFF
--- a/fastlane/metadata/en-US/name.txt
+++ b/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-Meow (Clash)
+Meow - Smart VPN

--- a/fastlane/metadata/zh-Hans/name.txt
+++ b/fastlane/metadata/zh-Hans/name.txt
@@ -1,1 +1,1 @@
-Meow (Clash)
+Meow - Smart VPN

--- a/metadata/en-US/name.txt
+++ b/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-Meow (Clash)
+Meow - Smart VPN

--- a/metadata/zh-Hans/name.txt
+++ b/metadata/zh-Hans/name.txt
@@ -1,1 +1,1 @@
-Meow (Clash)
+Meow - Smart VPN


### PR DESCRIPTION
## Summary
- Update the App Store display name from "Meow (Clash)" to "Meow - Smart VPN" in both `fastlane/metadata` and `metadata` copies (en-US, zh-Hans).

## Merge path
Path A (non-code): diff touches only `fastlane/metadata/` and `metadata/` name.txt files — no Swift/Rust/YAML/project files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)