### PR TITLE
fix(dns): debounce search-driven polling in DNS panel

### DIFF
--- a/App/Sources/Views/DnsView.swift
+++ b/App/Sources/Views/DnsView.swift
@@ -44,7 +44,13 @@ struct DnsView: View {
             comment: "DNS screen navigation title; %lld = result count",
         ))
         .navigationBarTitleDisplayMode(.inline)
-        .task(id: query) { await poll() }
+        .task(id: query) {
+            // Debounce keystrokes so typing doesn't fire one request per character.
+            if !query.isEmpty {
+                try? await Task.sleep(for: .milliseconds(300))
+            }
+            await poll()
+        }
     }
 
     private var displayCount: Int {
@@ -96,6 +102,8 @@ struct DnsView: View {
                 results = fetched
                 errorMessage = nil
             } catch {
+                // A cancelled fetch means the task was superseded; don't flash its error.
+                if Task.isCancelled { break }
                 errorMessage = error.localizedDescription
             }
             try? await Task.sleep(for: .seconds(2))


### PR DESCRIPTION
## Summary

Typing in the Utility-tab DNS panel's search field restarted the poll loop on every keystroke (`.task(id: query)` in `DnsView.swift`), firing an immediate `GET /dns/results` per character with no debounce — typing "example" issued up to 7 back-to-back loopback requests to the NE's REST controller for soon-to-be-discarded prefixes. This adds a 300 ms debounce before polling when a search query is set, so a typing burst collapses to one request per pause. Initial load (empty query) still polls immediately.

Also fixes an adjacent race the same path made likely: a cancelled (superseded) poll iteration could flash a spurious "cancelled" error banner over the replacement task's results; the catch now breaks out silently when the task is cancelled.

Found via a find→adversarial-verify workflow sweep for redundant DNS lookups (per-keystroke burst confirmed on physical-device builds; simulator uses the mock transport).

## Path B local-CI attestation

- [x] `swiftformat --lint .` at repo root → 0 files require formatting (101 checked)
- [x] `swiftlint --strict --quiet` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -testLanguage en` → **TEST SUCCEEDED**, 88 passed / 0 failed / 79 skipped (known blocked-on-T5.9 + locale skips) on iPhone 17, iOS 26.4
- [x] `git diff origin/main...HEAD --stat` verified → only `App/Sources/Views/DnsView.swift` (+9/−1), no accidental additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)