### PR TITLE
fix(tunnel): absorb address-family flips within 30s of an engine start

### DIFF
--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -47,6 +47,12 @@ static os_log_t gLog;
     // so a canceled monitor cannot schedule a delayed restart for a later
     // tunnel generation.
     _Atomic uint64_t    _pathGeneration;
+    // CLOCK_MONOTONIC nanoseconds of the last successful engine start or
+    // restart (0 = never). Written on _engineControlQueue, read on _pathQueue,
+    // hence atomic. CLOCK_MONOTONIC keeps counting across sleep, so a grace
+    // window that straddles a sleep/wake cycle expires rather than suppressing
+    // a restart the post-wake network state genuinely needs.
+    _Atomic uint64_t    _lastEngineStartNs;
 }
 
 // Quiet window after the last path event before a triggered engine restart
@@ -54,6 +60,15 @@ static os_log_t gLog;
 // restarts, short enough that a genuine path change recovers connectivity
 // quickly.
 static const NSTimeInterval kEngineRestartDebounceS = 3.0;
+
+// Grace window after a successful engine (re)start during which an
+// address-family-only path change does NOT trigger another restart. Routers
+// commonly deliver the IPv6 RA / DHCPv6 prefix 5-30s after DHCPv4 completes,
+// so one physical reconnect would otherwise restart the engine twice —
+// dropping every connection again and re-resolving proxy hostnames from a
+// fresh (empty) DNS cache. A family change outside the window still restarts:
+// the network genuinely changed shape mid-session.
+static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
 
 + (void)initialize {
     if (self == [PacketTunnelProvider class]) {
@@ -72,6 +87,7 @@ static const NSTimeInterval kEngineRestartDebounceS = 3.0;
             "com.tangzixiang.meow.PacketTunnel.engine-control", attr);
         atomic_init(&_restartGeneration, 0);
         atomic_init(&_pathGeneration, 0);
+        atomic_init(&_lastEngineStartNs, 0);
     }
     return self;
 }
@@ -115,6 +131,9 @@ static const NSTimeInterval kEngineRestartDebounceS = 3.0;
                 return;
             }
             self->_engine = engine;
+            atomic_store_explicit(&self->_lastEngineStartNs,
+                                  clock_gettime_nsec_np(CLOCK_MONOTONIC),
+                                  memory_order_relaxed);
 
             MWIPCListener *listener = [[MWIPCListener alloc]
                 initWithHandler:^(NSDictionary *intent) {
@@ -217,6 +236,9 @@ static const NSTimeInterval kEngineRestartDebounceS = 3.0;
             return;
         }
 
+        atomic_store_explicit(&self->_lastEngineStartNs,
+                              clock_gettime_nsec_np(CLOCK_MONOTONIC),
+                              memory_order_relaxed);
         os_log_info(gLog, "%{public}@ restart: engine restarted", reason);
         MWEngineLogf(MWLogInfo, @"NE: %@ restart — engine restarted", reason);
     });
@@ -476,12 +498,31 @@ static const NSTimeInterval kEngineRestartDebounceS = 3.0;
         // Same interface, same satisfied state, but the address-family set
         // changed — e.g. the Wi-Fi network silently lost (or gained) IPv6
         // via expired RAs or an upstream change. Restart the engine + tun2socks
-        // after a debounce so the fresh stack tracks the new network shape.
-        os_log_info(gLog, "path: address family changed v4 %d -> %d, v6 %d -> %d",
-                    _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6);
-        MWEngineLogf(MWLogInfo, @"NE: path — address family changed v4 %d -> %d, v6 %d -> %d",
-                     _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6);
-        shouldRestart = YES;
+        // after a debounce so the fresh stack tracks the new network shape —
+        // unless an engine (re)start just happened, in which case this is
+        // almost certainly the late-v6 tail of the same physical reconnect
+        // and the fresh engine will pick the family up lazily on next dial.
+        uint64_t lastStartNs = atomic_load_explicit(&_lastEngineStartNs,
+                                                    memory_order_relaxed);
+        uint64_t nowNs = clock_gettime_nsec_np(CLOCK_MONOTONIC);
+        NSTimeInterval sinceStart = (NSTimeInterval)(nowNs - lastStartNs) / NSEC_PER_SEC;
+        if (lastStartNs != 0 && sinceStart < kAddressFamilyRestartGraceS) {
+            os_log_info(gLog,
+                        "path: address family changed v4 %d -> %d, v6 %d -> %d "
+                        "within %.0fs of engine start, absorbing (no restart)",
+                        _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6, sinceStart);
+            MWEngineLogf(MWLogInfo,
+                         @"NE: path — address family changed v4 %d -> %d, v6 %d -> %d "
+                         @"within %.0fs of engine start, absorbing (no restart)",
+                         _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6, sinceStart);
+        } else {
+            os_log_info(gLog, "path: address family changed v4 %d -> %d, v6 %d -> %d",
+                        _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6);
+            MWEngineLogf(MWLogInfo,
+                         @"NE: path — address family changed v4 %d -> %d, v6 %d -> %d",
+                         _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6);
+            shouldRestart = YES;
+        }
     }
 
     _lastSatisfied = satisfied;


### PR DESCRIPTION
## Summary

One physical reconnect often produces **two full engine restarts**: link-up trips the connectivity-regained restart immediately, then the router delivers the IPv6 RA / DHCPv6 prefix 5–30 s later, flipping `hasIPv6` and tripping the separate address-family-changed branch in `handlePathUpdate:`. The 3 s debounce only coalesces events inside its own window, so the late-v6 tail tears down tun2socks a second time — dropping every active connection again right after the user regained connectivity, and re-resolving proxy hostnames from a fresh (empty) DNS cache.

The fix records `CLOCK_MONOTONIC` on every successful engine (re)start (`_Atomic uint64_t`, written on `_engineControlQueue`, read on `_pathQueue`) and **absorbs address-family-only changes that land within a 30 s grace window** of it — the fresh engine resolves lazily at dial time and picks the family change up on its own. Deliberately preserved semantics:

- Family changes **outside** the window (Wi-Fi silently losing/gaining v6 mid-session — the case the branch was added for) still restart.
- The connectivity-regained and interface-changed triggers stay **ungated**.
- `CLOCK_MONOTONIC` counts across sleep, so a window straddling sleep/wake expires instead of suppressing a restart the post-wake network genuinely needs.
- A failed restart does not refresh the timestamp.
- As a side effect, flappy-IPv6 networks get damped: each absorbed flip updates `_lastHasIPv4/6` without a restart.

Found via a find→adversarial-verify workflow sweep for redundant DNS lookups; follow-up to #272.

## Path B local-CI attestation

- [x] `swiftformat --lint .` at repo root → 0 files require formatting (101 checked)
- [x] `swiftlint --strict --quiet` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests -testLanguage en` → **TEST SUCCEEDED**; xcresult confirms both bundles Passed (MeowTests + MeowIntegrationTests, incl. `meow-rs engine lifecycle`, `tun2socks bridge`, `TunnelSettingsLANExclusionTests`), PacketTunnel target compiled clean
- [x] `git diff origin/main --stat` verified → only `PacketTunnel/Sources/PacketTunnelProvider.m` (+47/−6), no accidental additions

## On-device note

The absorbed path only fires on a real network transition (late RA on physical hardware), which simulator tests can't exercise. The `absorbing (no restart)` os_log/MWEngineLog line is greppable in the Utility→Logs panel or USB syslog for on-device confirmation on the next Wi-Fi handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)