### PR TITLE
feat(dns): revert to fake-IP mode for meow-dns

### DIFF
--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -2,11 +2,10 @@
 //! DNS listeners that `tun2socks` dials through loopback.
 //!
 //! DNS is delegated end-to-end to meow's resolver. The pinned `dns:` block from
-//! `meow_patch_config` puts the resolver in `redir-host` (normal) mode with a
-//! local DNS listen socket — no fake-ip pool is installed. The tun2socks
-//! UDP/53 path sends non-blocked DNS queries to that listener, which returns
-//! real upstream IPs and self-populates its IP->host reverse cache so meow's
-//! inbound path can recover the hostname for domain-rule matching.
+//! `meow_patch_config` puts the resolver in fake-IP mode with the FFI's chosen
+//! CIDR (`28.0.0.0/8`) and a local DNS listen socket. The tun2socks UDP/53
+//! path sends non-blocked DNS queries to that listener, so synthesis and
+//! fake-IP reverse mapping stay owned by meow-dns.
 //!
 //! Lifecycle: `start(config_path)` spawns the REST API on the meow-engine
 //! tokio runtime and keeps its `JoinHandle` in `EngineState`. `stop()` aborts
@@ -84,8 +83,8 @@ fn prepare_ios_config(yaml: &str) -> Result<String> {
             "tproxy-port",
             "listeners",
             // Drop the entire `sniffer:` block. meow's
-            // `pre_handle_metadata` reverse-looks-up each real destination IP
-            // back to the qname recorded by the resolver before rule matching,
+            // `pre_handle_metadata` reverses each fake-IP destination back
+            // to the qname recorded by the resolver before rule matching,
             // so SNI/ALPN sniffing is redundant — and when enabled it would
             // overwrite the resolver-derived hostname based on whatever the
             // sniffer parses out of the first TLS / HTTP record, which is a
@@ -249,8 +248,8 @@ pub fn start(config_path: &str) -> Result<()> {
     // 2-worker engine runtime (data path + REST API both freeze). The meow-dns
     // resolver resolves async, coalesces concurrent lookups, and caches —
     // collapsing the burst to one lookup. `resolve_ip` returns real addresses
-    // (in redir-host / normal mode the resolver never synthesizes; A queries
-    // resolve to the real upstream IP). Android installs the same
+    // (fake-IP synthesis lives only in the DNS-server `lookup_ipv4/6` path), so
+    // the upstream never resolves to a 28.x fake IP. Android installs the same
     // hook plus a `SocketProtector` via its JNI bridge; iOS needs only the hook
     // (the NE process's own sockets already bypass its tunnel).
     meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(resolver.clone())));
@@ -353,8 +352,8 @@ pub fn start(config_path: &str) -> Result<()> {
     let log_tx = log_broadcast_tx().clone();
 
     // No FFI-side fake-IP pool, no FFI-side CN-IP table, no resolver hand-off:
-    // meow's own resolver (redir-host / normal mode) owns resolution +
-    // IP->host reverse mapping behind the DNS listener that tun2socks dials.
+    // meow's own fake-IP pool owns synthesis + reverse mapping behind the DNS
+    // listener that tun2socks dials.
 
     let api_task = cfg.api.external_controller.map(|addr| {
         let api_server = ApiServer::new(
@@ -535,7 +534,8 @@ bind-address: 0.0.0.0
 dns:
   enable: true
   listen: 0.0.0.0:1053
-  enhanced-mode: redir-host
+  enhanced-mode: fake-ip
+  fake-ip-range: 28.0.0.0/8
   nameserver:
     - 119.29.29.29
 rules:

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -13,10 +13,9 @@
 //! The staticlib owns separate tokio runtimes for the packet/netstack driver
 //! and for meow engine work so lwIP backpressure cannot starve the
 //! REST/API/proxy workers. DNS is delegated to a local meow-dns UDP listener
-//! running in `redir-host` (normal) mode: the tun2socks UDP/53 path still
-//! answers AAAA and HTTP/3-blocked HTTPS/SVCB queries NOERROR-empty itself,
-//! then sends other DNS queries to the listener, which returns real upstream
-//! IPs and self-populates its IP->host reverse cache. The FFI no longer
+//! running in fake-IP mode: the tun2socks UDP/53 path still answers
+//! IPv6-disabled AAAA and HTTP/3-blocked HTTPS/SVCB queries NOERROR-empty
+//! itself, then sends other DNS queries to the listener. The FFI no longer
 //! carries its own fake-IP pool, china-DNS split-horizon, CN-IP table, DoH
 //! cache, or in-FFI TCP-DNS client.
 
@@ -693,12 +692,10 @@ pub unsafe extern "C" fn meow_patch_config(
         return -1;
     };
 
-    // Strip `dns` (iOS pins its own resolver block — see below: the resolver
-    // is pinned to `redir-host` (normal) mode, NOT fake-ip, so meow-dns
-    // returns real upstream IPs and self-populates its IP->host reverse cache
-    // for domain-rule matching; no fake-ip-range is installed) and
-    // `subscriptions` (handled app-side). `secret` is intentionally NOT
-    // stripped here — we
+    // Strip `dns` (iOS pins its own resolver block — see below: fake-IP mode
+    // with the FFI's chosen `28.0.0.0/8` range, so meow-dns owns synthesis and
+    // fake-IP reverse mapping for domain-rule matching) and `subscriptions`
+    // (handled app-side). `secret` is intentionally NOT stripped here — we
     // overwrite it below with a per-install random token so the REST API on
     // loopback is authenticated rather than open.
     for key in ["dns", "subscriptions"] {
@@ -736,9 +733,10 @@ pub unsafe extern "C" fn meow_patch_config(
             "listen",
             serde_yaml::Value::String(format!("{bind_addr}:{dns_port}")),
         ),
+        ("enhanced-mode", serde_yaml::Value::String("fake-ip".into())),
         (
-            "enhanced-mode",
-            serde_yaml::Value::String("redir-host".into()),
+            "fake-ip-range",
+            serde_yaml::Value::String("28.0.0.0/8".into()),
         ),
     ] {
         dns.insert(serde_yaml::Value::String(k.into()), v);
@@ -1127,6 +1125,8 @@ rules:
         assert!(patched.contains("allow-lan: true"));
         assert!(patched.contains("bind-address: 0.0.0.0"));
         assert!(patched.contains("listen: 0.0.0.0:1054"));
+        assert!(patched.contains("enhanced-mode: fake-ip"));
+        assert!(patched.contains("fake-ip-range: 28.0.0.0/8"));
         assert!(!patched.contains("subscriptions:"));
     }
 

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -7,36 +7,31 @@
 //! callback registered in [`start`]. No file descriptors cross the FFI.
 //!
 //! DNS: A (1), TXT (16), MX (15), PTR (12), and other non-blocked queries are
-//! sent as raw UDP packets to the local meow-dns listener. In `redir-host`
-//! (normal) mode the listener resolves A queries to the real upstream IP and
-//! records the IP->host mapping in its reverse cache; generic qtypes get
-//! meow-dns's upstream-forward behavior.
+//! sent as raw UDP packets to the local meow-dns listener. A gets fake-IP
+//! synthesis there; generic qtypes get meow-dns's upstream-forward behavior.
 //! AAAA (28) queries are answered NOERROR-empty by the FFI itself when IPv6 is
-//! disabled in app settings (the default) — the tunnel is then IPv4-only (the
-//! TUN advertises no v6 route), so stripping AAAA forces every client onto the
-//! v4 path instead of leaking (or black-holing) connections over v6. When IPv6
-//! is enabled, AAAA queries are forwarded to meow-dns like A queries (real v6
-//! addresses) and the Swift TUN advertises an IPv6 address + default route so
-//! those connections enter the netstack. When "block HTTP/3" is enabled,
-//! HTTPS/SVCB (65/64) queries also get NOERROR-empty so clients cannot
+//! disabled in app settings (the default) — the fake-IP pool is v4-only, so
+//! stripping AAAA forces every client onto it instead of leaking (or
+//! black-holing) connections over v6. When IPv6 is enabled, AAAA queries are
+//! forwarded to meow-dns like A queries — with a v4-only fake-IP pool the
+//! resolver itself suppresses AAAA for fake-IP'd domains, so clients still land
+//! on the v4 fake path; the Swift TUN advertises an IPv6 address + default
+//! route so v6-literal destinations enter the netstack. When "block HTTP/3" is
+//! enabled, HTTPS/SVCB (65/64) queries also get NOERROR-empty so clients cannot
 //! discover QUIC hints.
 //!
 //! NEDNSSettings advertises a TUN-subnet address as the system resolver, so
 //! every UDP DNS query arrives as an in-TUN IP packet. netstack turns that into
 //! a UDP payload, the FFI branches on qtype, and non-blocked queries go to the
 //! local DNS listener with the reply injected back through netstack. The
-//! resolver owns resolution, reverse (IP->host) mapping, hosts / NXDOMAIN
+//! resolver owns fake-IP synthesis, reverse mapping, hosts / NXDOMAIN
 //! semantics, and TTL handling; the FFI owns only the qtype peek plus the
 //! blocked-query short-circuit.
 //!
-//! TCP/UDP destination IPs are the real upstream IPs returned by meow's
-//! resolver. `dispatch_tcp` and `dispatch_udp` pass the literal destination to
-//! the mixed listener via SOCKS5; meow's normal inbound path reverse-looks-up
-//! the IP back to the original qname (from the resolver's reverse cache) before
-//! rule matching. (Real upstream IPs reach the TUN because the Swift
-//! NEPacketTunnelProvider already advertises the IPv4 default route — see
-//! `MWTunnelSettings.m`, `ipv4.includedRoutes = defaultRoute` with RFC1918
-//! LAN exclusions — so no routing change was needed for the fake-IP drop.)
+//! TCP/UDP destination IPs come back as fake-IPs from meow's resolver pool.
+//! `dispatch_tcp` and `dispatch_udp` pass the literal destination to the
+//! mixed listener via SOCKS5; meow's normal inbound path reverses fake-IPs back
+//! to the original qname before rule matching.
 
 use crate::logging;
 use futures::{SinkExt, StreamExt};


### PR DESCRIPTION
## Summary
- Reverts the redir-host switch from `a69fcc8`: `meow_patch_config` pins `enhanced-mode: fake-ip` + `fake-ip-range: 28.0.0.0/8` again, so meow-dns owns fake-IP synthesis + reverse mapping behind the local DNS listener.
- Not a git-revert: the meow-rs pin stays at 6f080ec (0.16.0) — `a69fcc8` also carried a pin bump that has since moved on.
- Composes with the IPv6 toggle (`99021ee`): with a v4-only fake-ip pool, meow-dns itself suppresses AAAA for fake-IP'd domains (`resolver.rs` `lookup_ipv6`), so IPv6-enabled clients still land on the v4 fake path; v6-literal destinations still route.
- `patch_config_pins_lan_mixed_and_dns_listener` now asserts the pinned mode + range so the DNS mode can't silently drift again.

## Path B local-CI attestation
1. `swiftformat --lint .` at repo root → 0 violations (0/101 files require formatting).
2. `swiftlint --strict` at repo root → 0 violations in 90 files.
3. Tests on iPhone 17 (iOS 26) simulator: `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowIntegrationTests -only-testing:MeowTests` → TEST SUCCEEDED (MeowIntegrationTests 26 tests / 4 suites). Rust/FFI: `scripts/build-rust.sh` (xcframework rebuilt), and in `core/rust/meow-ios-ffi/`: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` → 52 passed, 0 failed.
4. `git diff origin/main...HEAD --stat` verified → exactly `core/rust/meow-ios-ffi/src/{engine.rs,lib.rs,tun2socks.rs}`, no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)