### PR TITLE
fix(ui): tint VPN switch by connection status

### DIFF
--- a/App/Sources/Views/GlobalVpnSwitchBar.swift
+++ b/App/Sources/Views/GlobalVpnSwitchBar.swift
@@ -143,9 +143,12 @@ struct GlobalVpnSwitchBar: View {
         }
     }
 
+    /// Mirrors `StageDot`'s status palette so the switch reads as connection
+    /// state: green while connected, amber in flight, red for error / the
+    /// connect call-to-action.
     private var toggleTint: Color {
         switch vpnManager.stage {
-        case .connected: AppTheme.danger
+        case .connected: AppTheme.connected
         case .preparing, .connecting, .stopping: AppTheme.warning
         case .error: AppTheme.danger
         default: AppTheme.accent


### PR DESCRIPTION
## Summary
- The connect/disconnect button in `GlobalVpnSwitchBar` was `AppTheme.danger` red while connected and `accent` red while idle — the two constants are the same `0xE23E2C`, so the switch never signalled connection state.
- It now uses `StageDot`'s status palette: green (`AppTheme.connected`) while connected, amber (`warning`) while preparing/connecting/stopping, red for error and for the idle connect call-to-action.

## Path B local-CI attestation
1. `swiftformat --lint .` at repo root → 0 violations (0/101 files require formatting).
2. `swiftlint --strict` at repo root → 0 violations in 90 files.
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -testLanguage en` → TEST SUCCEEDED (All tests passed).
4. `git diff origin/main...HEAD --stat` verified → exactly `App/Sources/Views/GlobalVpnSwitchBar.swift`, no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)