### PR TITLE
docs(asc): review notes, demo config, and subscription-term clarification

### DIFF
--- a/docs/review-demo-config.yaml
+++ b/docs/review-demo-config.yaml
@@ -1,0 +1,17 @@
+# Demo configuration subscription for App Store review.
+#
+# This is a minimal Clash-format configuration that routes all traffic
+# DIRECT (no proxy server), so reviewers can exercise the full
+# subscribe -> import -> connect flow without needing credentials to a
+# real proxy server. It is referenced from the App Review notes.
+mixed-port: 7890
+mode: rule
+log-level: info
+proxies: []
+proxy-groups:
+  - name: Demo
+    type: select
+    proxies:
+      - DIRECT
+rules:
+  - MATCH,Demo

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -21,6 +21,8 @@ REQUIREMENTS
 • iOS 26 or later (iPhone and iPad)
 • A proxy subscription you trust — meow does not provide any proxy servers
 
+meow is free, with no in-app purchases. "Subscription" here means a proxy configuration URL (a Clash-style config subscription) that you supply — not a paid subscription.
+
 PUBLIC BETA
 This release is a public beta. Some features are in active development. Please report issues on GitHub or via the in-app feedback link.
 

--- a/fastlane/metadata/review_information/notes.txt
+++ b/fastlane/metadata/review_information/notes.txt
@@ -1,1 +1,14 @@
+meow is a client-side proxy / VPN utility. It has NO account system, NO in-app purchases, and NO paid subscriptions, so no demo account is needed.
 
+TERMINOLOGY: "Subscription" in our description means a proxy CONFIGURATION subscription — a Clash-format YAML configuration fetched from a URL the user supplies (the standard term in this app category). It is not a paid or auto-renewing subscription.
+
+HOW TO TEST THE SUBSCRIPTION FEATURE
+1. Launch meow. The first tab is "Subscriptions".
+2. Tap the "+" button in the top-right toolbar and choose "Add from URL".
+3. Enter any name and this demo configuration URL:
+   https://raw.githubusercontent.com/madeye/meow-ios/main/docs/review-demo-config.yaml
+4. Tap Add. The YAML configuration is downloaded and listed. The pencil icon opens the built-in YAML editor; the refresh icon re-fetches the subscription.
+5. With the demo subscription selected, turn on the switch in the bar at the top of the screen and approve the iOS VPN permission prompt. The packet tunnel starts; the "Proxy Groups" tab shows the "Demo" group from the configuration.
+6. Browse in Safari — traffic flows through the on-device tunnel (the demo configuration routes it DIRECT, since meow does not operate any proxy servers).
+
+PRIVACY: the app collects no user data of any kind (no analytics/tracking SDKs, no developer servers). Traffic is processed entirely on-device by the Network Extension and forwarded only to servers from the user's own configuration. Privacy policy: https://github.com/madeye/meow-ios/blob/main/PRIVACY.md

--- a/fastlane/metadata/zh-Hans/description.txt
+++ b/fastlane/metadata/zh-Hans/description.txt
@@ -21,6 +21,8 @@ Shadowsocks、Trojan、VLESS 出站协议（支持 TLS、WebSocket、gRPC、H2 �
 • iOS 26 或更高版本（iPhone、iPad）
 • 一份你信任的代理订阅——meow 本身不提供任何代理服务器
 
+meow 完全免费，不含任何内购。本页所述"订阅"指你自行提供的代理配置链接（Clash 风格配置订阅），并非付费订阅。
+
 公开测试版
 本次为公开测试版本。部分功能仍在开发中。请通过 GitHub 或 App 内的反馈链接报告问题。
 


### PR DESCRIPTION
## Summary
Addresses the App Review feedback on 1.3.2 (Guideline 2.1 information request + Guideline 2.3 "unable to locate the subscription"):
- Fills the previously **empty** `fastlane/metadata/review_information/notes.txt` with reviewer instructions: no accounts/IAP, "subscription" = Clash-format configuration subscription, step-by-step test flow.
- Adds `docs/review-demo-config.yaml`, a minimal DIRECT-mode config served from this public repo, so reviewers can exercise subscribe → import → connect without real proxy credentials.
- Adds one clarifying line to the en-US and zh-Hans store descriptions: free app, no IAP, "subscription" is a configuration URL.

Path A admin-bypass: diff touches only `docs/` and `fastlane/metadata/` (non-code paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)