### PR TITLE
feat(ui): actionable add-subscription empty state on home tab

### DIFF
--- a/App/Sources/AppModelContainer.swift
+++ b/App/Sources/AppModelContainer.swift
@@ -11,6 +11,7 @@ enum AppModelContainer {
         do {
             let schema = Schema([Profile.self, DailyTraffic.self])
             let url = try storeURL()
+            resetStoreForUITestsIfRequested(at: url)
             let config = ModelConfiguration(
                 "meow",
                 schema: schema,
@@ -26,6 +27,18 @@ enum AppModelContainer {
 
     struct Holder {
         let container: ModelContainer
+    }
+
+    /// `-ResetState` promises UI tests a known state, but it only reset the
+    /// mock IPC snapshot — SwiftData profiles persisted across launches, so
+    /// empty-state tests flaked on whatever earlier runs left behind. Wipe
+    /// the store (and its SQLite sidecars) before the container opens it.
+    private static func resetStoreForUITestsIfRequested(at url: URL) {
+        let args = ProcessInfo.processInfo.arguments
+        guard args.contains("-UITests"), args.contains("-ResetState") else { return }
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: url.path + suffix))
+        }
     }
 
     private static func storeURL() throws -> URL {

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -150,16 +150,51 @@ struct SubscriptionsView: View {
 
     private var emptySubscriptionCard: some View {
         GlassCard {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 12) {
                 Label("subscriptions.empty.title", systemImage: "tray")
                     .font(.headline)
                     .foregroundStyle(.primary)
                 Text("subscriptions.empty.description")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                HStack(spacing: 10) {
+                    Button {
+                        showingAdd = true
+                    } label: {
+                        Label("subscriptions.toolbar.addFromURL", systemImage: "link")
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .buttonBorderShape(.roundedRectangle(radius: 8))
+                    .tint(AppTheme.accent)
+                    .accessibilityIdentifier("subscriptions.empty.addFromURL")
+
+                    Button {
+                        showingImporter = true
+                    } label: {
+                        Label("subscriptions.toolbar.importFromFile", systemImage: "icloud.and.arrow.down")
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.bordered)
+                    .buttonBorderShape(.roundedRectangle(radius: 8))
+                    .tint(AppTheme.accent)
+                    .accessibilityIdentifier("subscriptions.empty.importFromFile")
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        // `.contain` keeps the card id on the group without clobbering the
+        // buttons' own identifiers (a bare identifier on a container view
+        // propagates to every child element).
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("subscriptions.emptyState")
     }
 

--- a/MeowUITests/Screens/AppShellTests.swift
+++ b/MeowUITests/Screens/AppShellTests.swift
@@ -29,6 +29,18 @@ final class AppShellTests: XCTestCase {
         XCTAssertFalse(meow.app.tabBars.buttons["Home"].exists)
     }
 
+    func testEmptySubscriptionsOffersAddActions() {
+        let meow = MeowApp()
+        meow.launch()
+
+        let addFromURL = meow.app.buttons["subscriptions.empty.addFromURL"]
+        XCTAssertTrue(addFromURL.waitForExistence(timeout: 5))
+        XCTAssertTrue(meow.app.buttons["subscriptions.empty.importFromFile"].exists)
+
+        addFromURL.tap()
+        XCTAssertTrue(meow.app.navigationBars["Add Subscription"].waitForExistence(timeout: 5))
+    }
+
     func testProxyGroupsIsTopLevelTab() {
         let meow = MeowApp()
         meow.launch()


### PR DESCRIPTION
## Summary
- The Subscriptions (home) tab's empty state was a passive card; first-time users had to find the small "+" toolbar menu. It now shows prominent **Add from URL** / **Import from file** buttons wired to the existing sheets, reusing the toolbar's localized strings.
- Fixed an accessibility-identifier trap: the container's bare `.accessibilityIdentifier` propagated to all children, so the new buttons were unfindable; `.accessibilityElement(children: .contain)` keeps the card id without clobbering child identifiers.
- `-ResetState` now wipes the SwiftData store under `-UITests` (it previously only reset mock IPC state, so profiles persisted across test launches and empty-state tests flaked).
- New UI test `testEmptySubscriptionsOffersAddActions` covers the buttons and the Add sheet.

## Path B local-CI attestation
1. `swiftformat --lint .` at repo root → 0 violations (0/101 files require formatting).
2. `swiftlint --strict` at repo root → 0 violations in 90 files.
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -testLanguage en` → TEST SUCCEEDED. (One intermediate run failed on simulator-infra flake — "SBMainWorkspace: Busy" launch denial; passed after `simctl shutdown all`.)
4. `git diff origin/main...HEAD --stat` verified → exactly `App/Sources/Views/SubscriptionsView.swift`, `App/Sources/AppModelContainer.swift`, `MeowUITests/Screens/AppShellTests.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)