### PR TITLE
fix(ui): shorter import label on empty-state card

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -85,6 +85,7 @@
 "subscriptions.import.invalidEncoding" = "The selected file isn't valid UTF-8 text.";
 "subscriptions.empty.title" = "No subscriptions yet";
 "subscriptions.empty.description" = "Tap + to add a Mihomo or Clash subscription URL.";
+"subscriptions.empty.importFile" = "Import File";
 
 
 /* Connections */

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "subscriptions.import.invalidEncoding" = "所选文件不是有效的 UTF-8 文本。";
 "subscriptions.empty.title" = "暂无订阅";
 "subscriptions.empty.description" = "点击右上角的 + 添加 Mihomo 或 Clash 订阅链接。";
+"subscriptions.empty.importFile" = "导入文件";
 
 
 /* Connections */

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -176,7 +176,10 @@ struct SubscriptionsView: View {
                     Button {
                         showingImporter = true
                     } label: {
-                        Label("subscriptions.toolbar.importFromFile", systemImage: "icloud.and.arrow.down")
+                        // Shorter than the toolbar-menu label — the full
+                        // "Import from iCloud Drive…" truncates at this
+                        // half-card width.
+                        Label("subscriptions.empty.importFile", systemImage: "icloud.and.arrow.down")
                             .font(.subheadline.weight(.semibold))
                             .lineLimit(1)
                             .minimumScaleFactor(0.82)


### PR DESCRIPTION
## Summary
"Import from iCloud Drive…" truncates at the empty-state card's half-width button (caught while recapturing App Store screenshots). The button now uses a dedicated shorter string `subscriptions.empty.importFile` ("Import File" / "导入文件"); the toolbar menu keeps the long label.

## Path B local-CI attestation
1. `swiftformat --lint .` at repo root → 0 violations (0/101 files require formatting).
2. `swiftlint --strict` at repo root → 0 violations in 90 files.
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -testLanguage en` → TEST SUCCEEDED.
4. `git diff origin/main...HEAD --stat` verified → exactly `App/Sources/Views/SubscriptionsView.swift` + the two `Localizable.strings` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)