### PR TITLE
feat(ui): group-level latency test button + proxy type captions

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -332,6 +332,7 @@
 "a11y.proxyGroups.group.expanded" = "Expanded";
 "a11y.proxyGroups.group.collapsed" = "Collapsed";
 "a11y.proxyGroups.group.hint" = "Shows or hides the proxies in this group.";
+"a11y.proxyGroups.group.action.testAll" = "Test latency of all proxies";
 "a11y.proxyGroups.proxy.hint" = "Selects this proxy for the group.";
 "a11y.proxyGroups.proxy.action.ping" = "Test latency";
 "a11y.proxyGroups.proxy.delay %@" = "%@ milliseconds";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -338,6 +338,7 @@
 "a11y.proxyGroups.group.expanded" = "已展开";
 "a11y.proxyGroups.group.collapsed" = "已折叠";
 "a11y.proxyGroups.group.hint" = "显示或隐藏该组中的代理。";
+"a11y.proxyGroups.group.action.testAll" = "测试组内所有代理延迟";
 "a11y.proxyGroups.proxy.hint" = "为该组选择此代理。";
 "a11y.proxyGroups.proxy.action.ping" = "测试延迟";
 "a11y.proxyGroups.proxy.delay %@" = "%@ 毫秒";

--- a/App/Sources/Services/MeowAPI.swift
+++ b/App/Sources/Services/MeowAPI.swift
@@ -20,8 +20,8 @@ final class MeowAPI: @unchecked Sendable {
         case invalidComponents(endpoint: URL)
     }
 
-    private static func buildTestDelayURL(base: URL, proxy: String, url: String, timeout: Int) throws -> URL {
-        let endpoint = base.appending(path: "/proxies/\(proxy.urlEscaped)/delay")
+    private static func buildTestDelayURL(base: URL, path: String, url: String, timeout: Int) throws -> URL {
+        let endpoint = base.appending(path: path)
         guard var comps = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
             throw URLBuildError.invalidComponents(endpoint: endpoint)
         }
@@ -164,7 +164,12 @@ final class MeowAPI: @unchecked Sendable {
         }
 
         struct Resp: Decodable { let delay: Int? }
-        let target = try Self.buildTestDelayURL(base: baseURL, proxy: proxy, url: url, timeout: timeout)
+        let target = try Self.buildTestDelayURL(
+            base: baseURL,
+            path: "/proxies/\(proxy.urlEscaped)/delay",
+            url: url,
+            timeout: timeout,
+        )
         #if DEBUG
             // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
             log.info("HTTP GET \(target.absoluteString, privacy: .public)")
@@ -172,6 +177,36 @@ final class MeowAPI: @unchecked Sendable {
         let (data, resp) = try await session.data(for: request(for: target))
         logResponse(resp, body: data, url: target)
         return try (JSONDecoder().decode(Resp.self, from: data).delay) ?? -1
+    }
+
+    /// Batch delay test for every member of a proxy group
+    /// (`GET /group/{name}/delay`). The engine probes members with bounded
+    /// concurrency (16) under a *single* `timeout` budget for the whole
+    /// batch — hence the larger default than the per-proxy test — and
+    /// records each outcome in the proxy's delay history, so callers
+    /// refresh `/proxies` afterwards to pick up the new badges. Returns
+    /// the name → delay map; a whole-batch overrun surfaces as
+    /// `MeowAPIError.http(status: 504)` even when some members completed.
+    @discardableResult
+    func testGroupDelay(group: String, url: String, timeout: Int = 10000) async throws -> [String: Int] {
+        if Self.usesMockTransport {
+            return Self.mockGroupDelay(for: group)
+        }
+
+        let target = try Self.buildTestDelayURL(
+            base: baseURL,
+            path: "/group/\(group.urlEscaped)/delay",
+            url: url,
+            timeout: timeout,
+        )
+        #if DEBUG
+            // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
+            log.info("HTTP GET \(target.absoluteString, privacy: .public)")
+        #endif
+        let (data, resp) = try await session.data(for: request(for: target))
+        logResponse(resp, body: data, url: target)
+        try throwIfHTTPError(resp)
+        return try JSONDecoder().decode([String: Int].self, from: data)
     }
 
     func getConnections() async throws -> ConnectionsResponse {
@@ -441,6 +476,11 @@ private extension MeowAPI {
         case "US West 03": 168
         default: 94
         }
+    }
+
+    static func mockGroupDelay(for group: String) -> [String: Int] {
+        let members = mockProxies().proxies[group]?.all ?? []
+        return Dictionary(uniqueKeysWithValues: members.map { ($0, mockDelay(for: $0)) })
     }
 
     static func mockConnections() -> ConnectionsResponse {

--- a/App/Sources/Views/ProxyGroupsView.swift
+++ b/App/Sources/Views/ProxyGroupsView.swift
@@ -12,6 +12,7 @@ struct ProxyGroupsView: View {
     @State private var groups: [ProxyGroupModel] = []
     @State private var expandedGroupID: String?
     @State private var inflightDelay: Set<String> = []
+    @State private var inflightGroupTest: Set<String> = []
     @State private var loadError: String?
 
     var body: some View {
@@ -43,6 +44,7 @@ struct ProxyGroupsView: View {
                             group: group,
                             isExpanded: expandedGroupID == group.id,
                             inflight: inflightDelay,
+                            isTestingGroup: inflightGroupTest.contains(group.name),
                             onToggleExpand: {
                                 withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.2)) {
                                     expandedGroupID = expandedGroupID == group.id ? nil : group.id
@@ -53,6 +55,9 @@ struct ProxyGroupsView: View {
                             },
                             onPing: { proxy in
                                 Task { await ping(proxy: proxy) }
+                            },
+                            onPingGroup: {
+                                Task { await pingGroup(group) }
                             },
                         )
                     }
@@ -134,14 +139,29 @@ private extension ProxyGroupsView {
         return error.localizedDescription
     }
 
+    static let delayTestURL = "http://www.gstatic.com/generate_204"
+
     func ping(proxy: String) async {
         inflightDelay.insert(proxy)
-        _ = try? await meowAPI.testDelay(
-            proxy: proxy,
-            url: "http://www.gstatic.com/generate_204",
-        )
+        _ = try? await meowAPI.testDelay(proxy: proxy, url: Self.delayTestURL)
         await refresh()
         inflightDelay.remove(proxy)
+    }
+
+    /// One-tap batch test for a whole group (issue #255). The engine
+    /// probes every member and records the outcomes in each proxy's
+    /// history, so a single `refresh()` afterwards repaints all badges.
+    /// Failures are silent, matching the per-proxy `ping` — a 504 batch
+    /// overrun still leaves partial results in the histories.
+    func pingGroup(_ group: ProxyGroupModel) async {
+        guard !inflightGroupTest.contains(group.name) else { return }
+        inflightGroupTest.insert(group.name)
+        let members = Set(group.children.map(\.name))
+        inflightDelay.formUnion(members)
+        _ = try? await meowAPI.testGroupDelay(group: group.name, url: Self.delayTestURL)
+        await refresh()
+        inflightGroupTest.remove(group.name)
+        inflightDelay.subtract(members)
     }
 }
 
@@ -149,46 +169,53 @@ private struct ProxyGroupCard: View {
     let group: ProxyGroupModel
     let isExpanded: Bool
     let inflight: Set<String>
+    let isTestingGroup: Bool
     var onToggleExpand: () -> Void
     var onSelect: (String) -> Void
     var onPing: (String) -> Void
+    var onPingGroup: () -> Void
 
     var body: some View {
         GlassCard {
             VStack(alignment: .leading, spacing: isExpanded ? 12 : 0) {
-                Button(action: onToggleExpand) {
-                    HStack(spacing: 10) {
-                        Image(systemName: groupSymbol)
+                // Tap-gesture row (not a Button) so the group-test control
+                // can live inside it with its own tap target — the same
+                // idiom `proxyRow` uses for the delay badge.
+                HStack(spacing: 10) {
+                    Image(systemName: groupSymbol)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(group.name)
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+                        Text(group.type)
+                            .font(.caption)
                             .foregroundStyle(.secondary)
-                            .frame(width: 24)
-                            .accessibilityHidden(true)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(group.name)
-                                .font(.headline)
-                                .foregroundStyle(.primary)
-                            Text(group.type)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer()
-                        if let now = group.now {
-                            Text(now)
-                                .font(.subheadline)
-                                .foregroundStyle(.tint)
-                                .lineLimit(1)
-                        }
-                        Image(systemName: "chevron.right")
-                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                            .foregroundStyle(.tertiary)
-                            .accessibilityHidden(true)
                     }
-                    .contentShape(Rectangle())
+                    Spacer()
+                    if let now = group.now {
+                        Text(now)
+                            .font(.subheadline)
+                            .foregroundStyle(.tint)
+                            .lineLimit(1)
+                    }
+                    groupTestControl
+                    Image(systemName: "chevron.right")
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .foregroundStyle(.tertiary)
                 }
-                .buttonStyle(.plain)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onToggleExpand)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(group.name)
                 .accessibilityValue(isExpanded
                     ? Text("a11y.proxyGroups.group.expanded")
                     : Text("a11y.proxyGroups.group.collapsed"))
+                .accessibilityAddTraits(.isButton)
                 .accessibilityHint(Text("a11y.proxyGroups.group.hint"))
+                .accessibilityAction(named: Text("a11y.proxyGroups.group.action.testAll")) { onPingGroup() }
 
                 if isExpanded {
                     Divider()
@@ -203,14 +230,41 @@ private struct ProxyGroupCard: View {
         .accessibilityIdentifier("home.group.\(group.id.identifierSlug)")
     }
 
+    /// Lightning-bolt tap target that fires the whole-group delay test;
+    /// swaps to a spinner while the batch is in flight.
+    private var groupTestControl: some View {
+        Group {
+            if isTestingGroup {
+                ProgressView()
+                    .controlSize(.mini)
+            } else {
+                Image(systemName: "bolt.fill")
+                    .imageScale(.small)
+                    .foregroundStyle(.tint)
+            }
+        }
+        .frame(minWidth: 32, minHeight: 44)
+        .contentShape(Rectangle())
+        .onTapGesture { onPingGroup() }
+    }
+
     private func proxyRow(_ child: ProxyGroupModel.Child) -> some View {
         HStack(spacing: 10) {
             Image(systemName: child.name == group.now ? "largecircle.fill.circle" : "circle")
                 .foregroundStyle(child.name == group.now ? AppTheme.accent : .secondary)
                 .frame(width: 20)
-            Text(child.name)
-                .font(.subheadline)
-                .lineLimit(1)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(child.name)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                // Provider-sourced stubs (issue #180) have an unknown
+                // type — omit the caption instead of showing an empty row.
+                if !child.type.isEmpty {
+                    Text(child.type)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
             Spacer()
             DelayBadge(delay: child.delay, isLoading: inflight.contains(child.name))
                 .frame(minHeight: 44)


### PR DESCRIPTION
Closes #255.

Two proxy-groups screen improvements requested in the issue:

1. **每个 ProxyGroup 显示测速按钮** — each group header now has a ⚡ button that fires the engine's batch delay test (`GET /group/{name}/delay`, new `MeowAPI.testGroupDelay`). All member badges show the testing spinner while the batch runs, then repaint from the refreshed `/proxies` histories. The engine probes with 16-way concurrency under a single timeout budget (default 10 s for the batch vs 5 s per-proxy); a 504 overrun still leaves partial results in the histories, matching the silent-failure behavior of the per-proxy ping. VoiceOver reaches the control via a named action (`a11y.proxyGroups.group.action.testAll`, en + zh-Hans).
2. **每个 Proxy 显示代理类型** — each proxy row shows its protocol type (Shadowsocks, Trojan, Vless, …) as a caption under the name. Provider-sourced stub rows (#180) have an unknown type and omit the caption.

The group header moves from `Button` to the tap-gesture idiom `proxyRow` already uses, so the test control gets its own tap target inside the row (verified in the simulator: tapping ⚡ does not toggle expansion).

## Path B local-CI attestation

- [x] `swiftformat --lint .` at repo root → 0/101 files require formatting
- [x] `swiftlint --strict` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -testLanguage en` → TEST SUCCEEDED
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowUITests -testLanguage en` → TEST SUCCEEDED (UI diff)
- [x] `git diff origin/main...HEAD --stat` verified — exactly the 4 intended files (2 Swift, 2 Localizable.strings), no accidental additions

Also visually verified on the iPhone 17 simulator (mock transport): bolt renders on collapsed and expanded headers, type captions render per row, group test leaves badges intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)