### PR TITLE
fix(api): tolerate any history[].time wire shape; bump meow-rs for RFC 3339

### DIFF
--- a/App/Sources/Services/MeowAPI.swift
+++ b/App/Sources/Services/MeowAPI.swift
@@ -422,16 +422,16 @@ private extension MeowAPI {
 
     static func mockProxies() -> ProxiesResponse {
         let history: [Proxy.History] = [
-            .init(time: "2026-06-28T09:40:00Z", delay: 82),
-            .init(time: "2026-06-28T09:41:00Z", delay: 76),
+            .init(delay: 82),
+            .init(delay: 76),
         ]
         let singaporeHistory: [Proxy.History] = [
-            .init(time: "2026-06-28T09:40:00Z", delay: 138),
-            .init(time: "2026-06-28T09:41:00Z", delay: 121),
+            .init(delay: 138),
+            .init(delay: 121),
         ]
         let westHistory: [Proxy.History] = [
-            .init(time: "2026-06-28T09:40:00Z", delay: 192),
-            .init(time: "2026-06-28T09:41:00Z", delay: 168),
+            .init(delay: 192),
+            .init(delay: 168),
         ]
         let proxies: [String: Proxy] = [
             "GLOBAL": .init(

--- a/App/Sources/Services/MeowAPITypes.swift
+++ b/App/Sources/Services/MeowAPITypes.swift
@@ -11,8 +11,13 @@ struct Proxy: Decodable, Identifiable {
     let all: [String]?
     let history: [History]?
 
+    /// `history[].time` is deliberately not decoded: the UI only reads
+    /// `delay`, and the engine's `time` wire format changed once already
+    /// (serde's default `SystemTime` object → RFC 3339 string, meow-rs
+    /// #290). Decoding it made the WHOLE /proxies payload undecodable the
+    /// moment any probe recorded history — proxy groups froze with no
+    /// delays (issue #255 follow-up).
     struct History: Decodable {
-        let time: String
         let delay: Int
     }
 }

--- a/MeowTests/API/ProxiesDecodingTests.swift
+++ b/MeowTests/API/ProxiesDecodingTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import meow_ios
+import Testing
+
+/// Wire-format tolerance for `GET /proxies` (issue #255 follow-up).
+///
+/// The engine's `history[].time` representation changed once already —
+/// meow-rs serialized serde's default `SystemTime` object
+/// (`{"secs_since_epoch":…,"nanos_since_epoch":…}`) before moving to the
+/// upstream RFC 3339 string. When the Swift client decoded `time`, either
+/// shape mismatch made the WHOLE `ProxiesResponse` throw, so proxy groups
+/// silently froze with no delays after the first probe recorded history.
+/// The client now decodes only `delay` and must tolerate any `time` shape.
+@Suite("ProxiesResponse decoding", .tags(.api))
+struct ProxiesDecodingTests {
+    private func decode(historyJSON: String) throws -> ProxiesResponse {
+        let json = """
+        {"proxies": {"node-01": {
+            "name": "node-01", "type": "Shadowsocks", "alive": true,
+            "udp": true, "history": [\(historyJSON)]
+        }}}
+        """
+        return try JSONDecoder().decode(ProxiesResponse.self, from: Data(json.utf8))
+    }
+
+    @Test
+    func `history with RFC 3339 string time decodes`() throws {
+        let resp = try decode(historyJSON: #"{"time": "2026-07-03T07:16:40Z", "delay": 76}"#)
+        #expect(resp.proxies["node-01"]?.history?.last?.delay == 76)
+    }
+
+    @Test
+    func `history with legacy SystemTime object time decodes`() throws {
+        let resp = try decode(
+            historyJSON: #"{"time": {"secs_since_epoch": 1751527000, "nanos_since_epoch": 12}, "delay": 321}"#,
+        )
+        #expect(resp.proxies["node-01"]?.history?.last?.delay == 321)
+    }
+
+    @Test
+    func `history without a time field decodes`() throws {
+        let resp = try decode(historyJSON: #"{"delay": 42}"#)
+        #expect(resp.proxies["node-01"]?.history?.last?.delay == 42)
+    }
+}

--- a/MeowTests/Models/ProxyGroupModelTests.swift
+++ b/MeowTests/Models/ProxyGroupModelTests.swift
@@ -21,7 +21,7 @@ struct ProxyGroupModelTests {
             type: type,
             now: now,
             all: all,
-            history: delay.map { [Proxy.History(time: "", delay: $0)] },
+            history: delay.map { [Proxy.History(delay: $0)] },
         )
     }
 

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -793,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "axum",
  "base64",
@@ -1731,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1746,6 +1746,7 @@ dependencies = [
  "socket2 0.5.10",
  "subtle",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tracing",
 ]
@@ -1753,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1786,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1850,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "base64",
  "libc",
@@ -1865,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1907,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1924,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1953,12 +1954,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=6f080ecb3ed8af406661ad9faf073689eac7bf8c#6f080ecb3ed8af406661ad9faf073689eac7bf8c"
+source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2038,7 +2039,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2321,7 +2322,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2567,7 +2568,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3026,7 +3027,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3755,7 +3756,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,15 +68,20 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 6f080ec (meow-rs 0.16.0) — adds GET /dns/results (meow-rs#253),
-# consumed by the app's DNS panel; also picks up the vendored meow-anytls
-# fork (#265) and quinn-proto/memmap2 RUSTSEC bumps (#263). meow-dns still
+# HEAD: 498967e (meow-rs 0.16.0) — DelayHistory `time` now serializes as an
+# RFC 3339 string (meow-rs#290): the previous serde-default SystemTime object
+# made GET /proxies undecodable for the app once any probe recorded history
+# (issue #255, no latency shown in proxy groups). Also picks up tproxy fixes
+# meow-rs#267–#269 (Linux/macOS CLI only). Previous pin 6f080ec added
+# GET /dns/results (meow-rs#253), consumed by the app's DNS panel, the
+# vendored meow-anytls fork (#265) and quinn-proto/memmap2 RUSTSEC bumps
+# (#263). meow-dns still
 # runs in normal/Mapping (redir-host) mode: the resolver returns real
 # upstream IPs and keeps an IP → host reverse cache (decoupled from the DNS
 # TTL via REVERSE_TTL_FLOOR, meow-rs#240) so `pre_handle_metadata` recovers
 # the hostname for domain-rule matching. The FFI config parser pins
 # `enhanced-mode: redir-host` (no fake-ip-range); fake-IP is no longer used.
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -84,12 +89,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "6f080ecb3ed8af406661ad9faf073689eac7bf8c" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0122F6AFBEC84D816DCA4CFA /* SubscriptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1E9C4360B99CC50183F32A /* SubscriptionsView.swift */; };
 		015E7A4A8FB3A518506DDB2B /* clash_empty.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 9D0DE1F06A8A847F9F20E1F4 /* clash_empty.yaml */; };
+		045DFF9802FC965259E31D7C /* UtilitySessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEF8BEDC4B0E7EF70E37EE1 /* UtilitySessionStoreTests.swift */; };
 		07BE855FF6DC83A07129C654 /* SubscriptionDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */; };
 		08501362516FC991AE70B3EF /* DiagnosticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA20D7D98E7BC4663E289174 /* DiagnosticsViewController.swift */; };
 		0AAE287B7127912BEE7EFC15 /* HomeScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59B5D27EF37B635FC5B38AA /* HomeScreenTests.swift */; };
@@ -20,12 +21,12 @@
 		1705DA22AD7A785A8E0A5DF5 /* MeowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332AEAFC0EED0EC4C05576EC /* MeowApp.swift */; };
 		1C4A14F944F334280633F3C1 /* ConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6DE9E643D70646873B923B /* ConnectionsView.swift */; };
 		1DC1B422EB6A35C59910D0E5 /* UtilityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB85D08A244615CFA035C0B3 /* UtilityView.swift */; };
-		8FC2607392E5903FB3648190 /* UtilitySessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB15F6281D48F2EA253708F /* UtilitySessionStore.swift */; };
-		9E2A4B6C1D8F703E5A1B2C3D /* UtilitySessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3B5C7D2E9A814F6B2C3D4E /* UtilitySessionStoreTests.swift */; };
 		1DEF3FB14FBD667C00541BFF /* IdentifierSlugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B54369F081E1B728712CC9 /* IdentifierSlugTests.swift */; };
 		1DFB9CC9D7520C6342B580D2 /* IPCRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173E18BCFC9C0CBADC96556 /* IPCRoundTripTests.swift */; };
 		2063EF5A21DBDB2E5097D885 /* MeowCoreBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */; };
+		25931B4F38353E7DF1CD7F5E /* ProxiesDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A0587577F4B11031F0816D /* ProxiesDecodingTests.swift */; };
 		25E66559A88A13B0FEE0233B /* SubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5369F7A0022B20FF1321D5 /* SubscriptionService.swift */; };
+		2687DFC8A2EC27D66312C06F /* UtilitySessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B3F7EB51045141F84569793 /* UtilitySessionStore.swift */; };
 		28CB589E0ACE5C617C7DCD42 /* TrafficAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729BDB9DF0375708DCD8F84E /* TrafficAccumulatorTests.swift */; };
 		2A21E16ED84D0DF4A7C140A4 /* clash_emoji_groups_realworld.yaml in Resources */ = {isa = PBXBuildFile; fileRef = F73DB7377F110302EA3E8B4B /* clash_emoji_groups_realworld.yaml */; };
 		2D71AA36DACB626D73AC50A3 /* YamlEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415A45F45F6FA01D8DA04A95 /* YamlEditorView.swift */; };
@@ -41,11 +42,13 @@
 		4660565BBEE9CDFD88BD62AF /* SharedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08020B398C102C110F6A8567 /* SharedStoreTests.swift */; };
 		4702884A9BD243CD419172C4 /* ProvidersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0CE1B314060B8B82956086 /* ProvidersView.swift */; };
 		478984A879E2B44990BF3A87 /* MeowModels in Frameworks */ = {isa = PBXBuildFile; productRef = 08F8D6F37F44DDC126510FF4 /* MeowModels */; };
+		49DF75906671CC1725B8FBB2 /* ErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7D7768D31382CD90DFEBA6 /* ErrorBanner.swift */; };
 		4A6D4B20B4094E334F26892F /* TunBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC654683AAE620AA9C1DCEBF /* TunBridgeTests.swift */; };
 		4AFF0859870D8941AC3CE716 /* MeowIPC in Frameworks */ = {isa = PBXBuildFile; productRef = BE92B6925662A398B4A18E9C /* MeowIPC */; };
 		4C1FB9714B9308B7577B9622 /* MeowModels in Frameworks */ = {isa = PBXBuildFile; productRef = 564BE37A8BC742522CCABC5E /* MeowModels */; };
 		4E366621A02CAF97E4AA2EF2 /* RulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE160D91FCAFCD07383E8CB5 /* RulesTests.swift */; };
 		4F29B935B393F48182AC7CE4 /* MWIPCListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 329B260F122D91D5DDB24C44 /* MWIPCListener.m */; };
+		51B3C9F10FE6A03AFD50A5E6 /* NavRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8D0D6120471BD1DBC4ACFB /* NavRow.swift */; };
 		5247368E57963DA43B22D272 /* UDPProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF0A80A8CEB2105E171334C /* UDPProtocolTests.swift */; };
 		528DCD00B7A73F10142E0455 /* MeowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF3488443D31DA0A523BC30 /* MeowApp.swift */; };
 		53CECD909096DFDB00109EC4 /* DailyTraffic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25A3F873FAAA2334188818B /* DailyTraffic.swift */; };
@@ -81,7 +84,6 @@
 		90E26674740B7C7141781B01 /* ProxyGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7193B43D94BD4897FEDF967 /* ProxyGroupsView.swift */; };
 		91159B9CB1EDFE43070C3A4E /* GlobalVpnSwitchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF41AF44DDC9B81E01AF637 /* GlobalVpnSwitchBar.swift */; };
 		9212E710474142F878EC5ABC /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B1F7C57B22583A6919A107 /* LogsView.swift */; };
-		4B8E2D3F6EA15C9B7F204D5C /* NavRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F1C2E5D904B8A6E1F3C4B /* NavRow.swift */; };
 		94FA8AB54FFDDD7D188A8C2A /* PacketTunnel.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 459136B958385ACB511D5D14 /* PacketTunnel.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9609134F0D274943E5E18297 /* LogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F1B0B431DA0DD132F917FF /* LogsTests.swift */; };
 		9942BB6B9F5CDAD3CEA4B98E /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED84393AA4FF1CADF9FCC53 /* HomeView.swift */; };
@@ -120,7 +122,6 @@
 		D95EF7A2FB411B4088E3255C /* URLValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAA1935B322CD5DD66E23F0 /* URLValidationTests.swift */; };
 		DC1D5D2FD5AFDC3D1D3F2602 /* TrafficScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC73D84B5978335B9C07A8A /* TrafficScreenTests.swift */; };
 		DCC6938C0A43984B033BCD68 /* AppIPCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */; };
-		6DA04F5170C37E1D91426F7E /* ErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9F3E406FB26D0C80315E6D /* ErrorBanner.swift */; };
 		DF9A0976E5BE73EF1F9DFC91 /* VpnToggleFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */; };
 		E164E98C5E2EDB5B326E2B98 /* UtilityScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */; };
 		E5EEB30272FBA79B72C45004 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AFFBA5F04A152705EE60CA /* AccessibilityTests.swift */; };
@@ -189,17 +190,17 @@
 		134693AAF1481D4CF2945CAD /* MeowUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MeowUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1509E80EF5E3A28E045FE8C9 /* GeoLite2-ASN.mmdb */ = {isa = PBXFileReference; path = "GeoLite2-ASN.mmdb"; sourceTree = "<group>"; };
 		1711243E170547D1DA68FCD6 /* RuleEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleEditorSheet.swift; sourceTree = "<group>"; };
+		1B3F7EB51045141F84569793 /* UtilitySessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStore.swift; sourceTree = "<group>"; };
 		1C50CF82F4373D42432869C5 /* MWPacketWriter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWPacketWriter.m; sourceTree = "<group>"; };
 		1CCF322677C8A124E9D9107D /* MWDiagnosticsRunner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDiagnosticsRunner.m; sourceTree = "<group>"; };
 		1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityScreenTests.swift; sourceTree = "<group>"; };
 		20AB821D2884D05E4EA7E831 /* GeoAssetStager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoAssetStager.swift; sourceTree = "<group>"; };
 		24AB2D298F7A38F31686BF15 /* VpnManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnManagerTests.swift; sourceTree = "<group>"; };
 		24F2E3A9014A186B34D8A465 /* MWDarwinBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDarwinBridge.m; sourceTree = "<group>"; };
+		2D7D7768D31382CD90DFEBA6 /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		2E2B37B72F11B1B2B1118221 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		3172561A6CE70D61D7666597 /* ChinaDirectKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChinaDirectKeywords.swift; sourceTree = "<group>"; };
 		329B260F122D91D5DDB24C44 /* MWIPCListener.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWIPCListener.m; sourceTree = "<group>"; };
-		3A7F1C2E5D904B8A6E1F3C4B /* NavRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavRow.swift; sourceTree = "<group>"; };
-		5C9F3E406FB26D0C80315E6D /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		332AEAFC0EED0EC4C05576EC /* MeowApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeowApp.swift; sourceTree = "<group>"; };
 		33307DC76F162EF6A99F0DDE /* MeowIntegrationTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MeowIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B0CE1B314060B8B82956086 /* ProvidersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvidersView.swift; sourceTree = "<group>"; };
@@ -247,8 +248,8 @@
 		8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnToggleFlowTests.swift; sourceTree = "<group>"; };
 		8E6DE9E643D70646873B923B /* ConnectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionsView.swift; sourceTree = "<group>"; };
 		8E8110225EBDEBDC762A0E20 /* ClashYAMLTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClashYAMLTextView.swift; sourceTree = "<group>"; };
+		8E8D0D6120471BD1DBC4ACFB /* NavRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavRow.swift; sourceTree = "<group>"; };
 		8F2EC54BA19FA9CC57BDD2AD /* ProxyGroupModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyGroupModelTests.swift; sourceTree = "<group>"; };
-		8F3B5C7D2E9A814F6B2C3D4E /* UtilitySessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStoreTests.swift; sourceTree = "<group>"; };
 		930ED8C12FBC2859BCDC56E4 /* VpnManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnManager.swift; sourceTree = "<group>"; };
 		992E16ADDEBA2F4304D4E797 /* EditableRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableRule.swift; sourceTree = "<group>"; };
 		9943546218B2F23235F1CCAD /* clash_malformed.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = clash_malformed.yaml; sourceTree = "<group>"; };
@@ -288,6 +289,8 @@
 		D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionDeepLink.swift; sourceTree = "<group>"; };
 		D1A7AFDD113E049439EEE4A9 /* MeowShared */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MeowShared; path = MeowShared; sourceTree = SOURCE_ROOT; };
 		D51C2BC68B7800884B68643F /* DiagnosticsLabelParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLabelParserTests.swift; sourceTree = "<group>"; };
+		D7A0587577F4B11031F0816D /* ProxiesDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxiesDecodingTests.swift; sourceTree = "<group>"; };
+		DAEF8BEDC4B0E7EF70E37EE1 /* UtilitySessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStoreTests.swift; sourceTree = "<group>"; };
 		DFC4AC97B3877B1A566FBFF6 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		E327200BE05E4504B91CAACC /* .swiftformat */ = {isa = PBXFileReference; path = .swiftformat; sourceTree = "<group>"; };
 		E56D18B0FBFA455C9F60134A /* UserDiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDiagnosticsView.swift; sourceTree = "<group>"; };
@@ -307,7 +310,6 @@
 		FA317DD319BE5DA6206036F1 /* MWEngineLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWEngineLog.m; sourceTree = "<group>"; };
 		FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeowCoreBridgeTests.swift; sourceTree = "<group>"; };
 		FB11E2BC5612E27CCE83B0DC /* TunnelLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelLifecycleTests.swift; sourceTree = "<group>"; };
-		7EB15F6281D48F2EA253708F /* UtilitySessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStore.swift; sourceTree = "<group>"; };
 		FB85D08A244615CFA035C0B3 /* UtilityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityView.swift; sourceTree = "<group>"; };
 		FC654683AAE620AA9C1DCEBF /* TunBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunBridgeTests.swift; sourceTree = "<group>"; };
 		FD9FC97CA0606C12439B0684 /* EmojiGroupSelectNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiGroupSelectNodeTests.swift; sourceTree = "<group>"; };
@@ -456,7 +458,7 @@
 				B306CE837FA7A17D7D561877 /* SubscriptionDeepLinkTests.swift */,
 				A43280DA576025F244CD1432 /* SubscriptionServiceTests.swift */,
 				729BDB9DF0375708DCD8F84E /* TrafficAccumulatorTests.swift */,
-				8F3B5C7D2E9A814F6B2C3D4E /* UtilitySessionStoreTests.swift */,
+				DAEF8BEDC4B0E7EF70E37EE1 /* UtilitySessionStoreTests.swift */,
 				24AB2D298F7A38F31686BF15 /* VpnManagerTests.swift */,
 			);
 			path = Services;
@@ -503,12 +505,12 @@
 				AF51AD7DD7946AB70970C9A8 /* ContentView.swift */,
 				CA20D7D98E7BC4663E289174 /* DiagnosticsViewController.swift */,
 				711184DB8878CD1F212CEEA3 /* DnsView.swift */,
-				5C9F3E406FB26D0C80315E6D /* ErrorBanner.swift */,
+				2D7D7768D31382CD90DFEBA6 /* ErrorBanner.swift */,
 				2E2B37B72F11B1B2B1118221 /* GlassCard.swift */,
 				AEF41AF44DDC9B81E01AF637 /* GlobalVpnSwitchBar.swift */,
 				7ED84393AA4FF1CADF9FCC53 /* HomeView.swift */,
 				B4B1F7C57B22583A6919A107 /* LogsView.swift */,
-				3A7F1C2E5D904B8A6E1F3C4B /* NavRow.swift */,
+				8E8D0D6120471BD1DBC4ACFB /* NavRow.swift */,
 				3B0CE1B314060B8B82956086 /* ProvidersView.swift */,
 				B7193B43D94BD4897FEDF967 /* ProxyGroupsView.swift */,
 				1711243E170547D1DA68FCD6 /* RuleEditorSheet.swift */,
@@ -558,7 +560,7 @@
 				601ADF66737508CC359C4936 /* SubscriptionConverter.swift */,
 				D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */,
 				9C5369F7A0022B20FF1321D5 /* SubscriptionService.swift */,
-				7EB15F6281D48F2EA253708F /* UtilitySessionStore.swift */,
+				1B3F7EB51045141F84569793 /* UtilitySessionStore.swift */,
 				930ED8C12FBC2859BCDC56E4 /* VpnManager.swift */,
 			);
 			path = Services;
@@ -697,6 +699,7 @@
 				A2E8157E43AE62A3A59DDD5C /* DnsTests.swift */,
 				B0F1B0B431DA0DD132F917FF /* LogsTests.swift */,
 				3D1746752AC889A678F94A02 /* MeowAPITests.swift */,
+				D7A0587577F4B11031F0816D /* ProxiesDecodingTests.swift */,
 				EE160D91FCAFCD07383E8CB5 /* RulesTests.swift */,
 			);
 			path = API;
@@ -1098,6 +1101,7 @@
 				2E4C5E6BA16E22D2EAD4EB22 /* MeowAPITests.swift in Sources */,
 				2063EF5A21DBDB2E5097D885 /* MeowCoreBridgeTests.swift in Sources */,
 				8C45959FE9EE5CD0D3F06BB7 /* ProfileTests.swift in Sources */,
+				25931B4F38353E7DF1CD7F5E /* ProxiesDecodingTests.swift in Sources */,
 				D2FF19F899EE357591812068 /* ProxyGroupModelTests.swift in Sources */,
 				4E366621A02CAF97E4AA2EF2 /* RulesTests.swift in Sources */,
 				C7B7EACD6297D7AA66065602 /* RulesYAMLEditorTests.swift in Sources */,
@@ -1107,9 +1111,9 @@
 				66C7B352BBD0B772976ABB1B /* SubscriptionServiceTests.swift in Sources */,
 				997AE63C0D074EA6370C5DA8 /* SwiftDataTestContainer.swift in Sources */,
 				28CB589E0ACE5C617C7DCD42 /* TrafficAccumulatorTests.swift in Sources */,
-				9E2A4B6C1D8F703E5A1B2C3D /* UtilitySessionStoreTests.swift in Sources */,
 				0F59DC382F259493E472348F /* URLProtocolStub.swift in Sources */,
 				D95EF7A2FB411B4088E3255C /* URLValidationTests.swift in Sources */,
+				045DFF9802FC965259E31D7C /* UtilitySessionStoreTests.swift in Sources */,
 				5539FB5E77561B0464DE86DB /* VpnManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1130,17 +1134,17 @@
 				AFFFD00A574AA3A9C3D33248 /* DailyTrafficAccumulator.swift in Sources */,
 				08501362516FC991AE70B3EF /* DiagnosticsViewController.swift in Sources */,
 				D5E3B0B2C42A294616BB2263 /* DnsView.swift in Sources */,
-				6DA04F5170C37E1D91426F7E /* ErrorBanner.swift in Sources */,
 				54E371A3BCD0A05882842AC6 /* EditableRule.swift in Sources */,
+				49DF75906671CC1725B8FBB2 /* ErrorBanner.swift in Sources */,
 				C1187CD2F55A4E1F99C1FB54 /* GeoAssetStager.swift in Sources */,
 				FC4878B603356FA17059AB46 /* GlassCard.swift in Sources */,
 				91159B9CB1EDFE43070C3A4E /* GlobalVpnSwitchBar.swift in Sources */,
 				9942BB6B9F5CDAD3CEA4B98E /* HomeView.swift in Sources */,
 				9212E710474142F878EC5ABC /* LogsView.swift in Sources */,
-				4B8E2D3F6EA15C9B7F204D5C /* NavRow.swift in Sources */,
 				C05561AA0530BFF897CDEB8F /* MeowAPI.swift in Sources */,
 				3BAE21D06E5B9935E58FDF1B /* MeowAPITypes.swift in Sources */,
 				1705DA22AD7A785A8E0A5DF5 /* MeowApp.swift in Sources */,
+				51B3C9F10FE6A03AFD50A5E6 /* NavRow.swift in Sources */,
 				458E58A53D18E7E14542FAB8 /* Profile.swift in Sources */,
 				4702884A9BD243CD419172C4 /* ProvidersView.swift in Sources */,
 				784598C57754825780BD4F2C /* ProxyGroupModel.swift in Sources */,
@@ -1156,8 +1160,8 @@
 				0122F6AFBEC84D816DCA4CFA /* SubscriptionsView.swift in Sources */,
 				5C49A5DC6758BD9AB95DB5C2 /* TrafficView.swift in Sources */,
 				55FCE3874D6051B20C0A39AE /* UserDiagnosticsView.swift in Sources */,
+				2687DFC8A2EC27D66312C06F /* UtilitySessionStore.swift in Sources */,
 				1DC1B422EB6A35C59910D0E5 /* UtilityView.swift in Sources */,
-				8FC2607392E5903FB3648190 /* UtilitySessionStore.swift in Sources */,
 				B4CDE0AC50BC13DB22E90569 /* VpnManager.swift in Sources */,
 				2D71AA36DACB626D73AC50A3 /* YamlEditorView.swift in Sources */,
 			);


### PR DESCRIPTION
Follow-up to #283 / issue #255 — on-device, no latency ever appeared after a delay test.

**Root cause:** meow-rs serialized `DelayHistory.time` with serde's default `SystemTime` representation (a `{secs_since_epoch, nanos_since_epoch}` object) while the Swift client decoded `time: String`. The moment any probe recorded history, the whole `GET /proxies` payload became undecodable, `refresh()` failed quietly, and the proxy-groups screen kept rendering stale groups with no delay badges.

**Two-sided fix:**
1. Swift no longer decodes `time` at all — the UI only reads `delay` — so `/proxies` decoding survives any time format (old engines, new engines). New `ProxiesDecodingTests` covers the RFC 3339 string, the legacy SystemTime object, and a missing `time` field.
2. Pin meow-rs to `498967e`, which serializes `history[].time` as an RFC 3339 string (madeye/meow-rs#290, merged with full CI green), matching upstream Go mihomo's wire format so external clash dashboards decode it too. Pulls in only tproxy fixes #267–#269 beyond the old pin (Linux/macOS CLI paths, not used by iOS).

`project.pbxproj` churn is xcodegen regeneration to add the new test file (a few unrelated files got fresh UUIDs, same file set).

## Path B local-CI attestation

- [x] `swiftformat --lint .` at repo root → 0/102 files require formatting
- [x] `swiftlint --strict` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests -testLanguage en` → TEST SUCCEEDED (service-layer diff → integration bundle included)
- [x] `scripts/build-rust.sh` → xcframework written; `cargo test` in `core/rust/meow-ios-ffi` → 52 passed, 0 failed (against the new pin)
- [x] `git diff origin/main...HEAD --stat` verified — exactly the 7 intended files, no accidental additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)