### PR TITLE
feat(ui): add Shadowsocks servers via manual entry or QR scan

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -40,6 +40,8 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>meow uses the camera to scan Shadowsocks server QR codes.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -86,6 +86,39 @@
 "subscriptions.empty.title" = "No subscriptions yet";
 "subscriptions.empty.description" = "Tap + to add a Mihomo or Clash subscription URL.";
 "subscriptions.empty.importFile" = "Import File";
+"subscriptions.toolbar.addShadowsocks" = "Add Shadowsocks Server";
+
+
+/* Add Shadowsocks server sheet */
+"ssAdd.nav.title" = "Add Shadowsocks";
+"ssAdd.section.link" = "Link";
+"ssAdd.button.scan" = "Scan QR Code";
+"ssAdd.button.applyLink" = "Fill from Link";
+"ssAdd.error.invalidLink" = "Not a valid ss:// link.";
+"ssAdd.section.server" = "Server";
+"ssAdd.field.name" = "Name";
+"ssAdd.field.server" = "Server";
+"ssAdd.field.port" = "Port";
+"ssAdd.field.cipher" = "Cipher";
+"ssAdd.field.password" = "Password";
+"ssAdd.toggle.udp" = "UDP";
+"ssAdd.section.ech" = "ECH-TLS Tunnel";
+"ssAdd.toggle.ech" = "ECH-TLS Tunnel Plugin";
+"ssAdd.ech.footer" = "SIP003 ech-tls-tunnel transport built into the engine. Leave off for plain Shadowsocks.";
+"ssAdd.field.sni" = "SNI";
+"ssAdd.field.path" = "Path";
+"ssAdd.field.echConfig" = "ECH Config";
+"ssAdd.field.fingerprint" = "Fingerprint";
+"ssAdd.toggle.fastOpen" = "Fast Open";
+"ssAdd.plugin.passthrough %@" = "Plugin from link: %@";
+"ssAdd.footer.profile" = "Saved into a local profile generated from the built-in template. Adding more servers updates the same profile.";
+"ssAdd.button.add" = "Add";
+"ssAdd.button.adding" = "Adding…";
+"ssAdd.scanner.nav.title" = "Scan QR Code";
+"ssAdd.scanner.unavailable.title" = "Camera Unavailable";
+"ssAdd.scanner.unavailable.description" = "Scanning isn't available on this device. Paste the ss:// link instead.";
+"ssAdd.scanner.denied.description" = "Camera access is denied. Enable it in Settings, or paste the ss:// link instead.";
+"ssAdd.profile.defaultName" = "My Servers";
 
 
 /* Connections */

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -92,6 +92,39 @@
 "subscriptions.empty.title" = "暂无订阅";
 "subscriptions.empty.description" = "点击右上角的 + 添加 Mihomo 或 Clash 订阅链接。";
 "subscriptions.empty.importFile" = "导入文件";
+"subscriptions.toolbar.addShadowsocks" = "添加 Shadowsocks 服务器";
+
+
+/* Add Shadowsocks server sheet */
+"ssAdd.nav.title" = "添加 Shadowsocks";
+"ssAdd.section.link" = "链接";
+"ssAdd.button.scan" = "扫描二维码";
+"ssAdd.button.applyLink" = "从链接填充";
+"ssAdd.error.invalidLink" = "不是有效的 ss:// 链接。";
+"ssAdd.section.server" = "服务器";
+"ssAdd.field.name" = "名称";
+"ssAdd.field.server" = "服务器";
+"ssAdd.field.port" = "端口";
+"ssAdd.field.cipher" = "加密方式";
+"ssAdd.field.password" = "密码";
+"ssAdd.toggle.udp" = "UDP";
+"ssAdd.section.ech" = "ECH-TLS 隧道";
+"ssAdd.toggle.ech" = "ECH-TLS 隧道插件";
+"ssAdd.ech.footer" = "引擎内置的 SIP003 ech-tls-tunnel 传输。普通 Shadowsocks 请保持关闭。";
+"ssAdd.field.sni" = "SNI";
+"ssAdd.field.path" = "路径";
+"ssAdd.field.echConfig" = "ECH 配置";
+"ssAdd.field.fingerprint" = "指纹";
+"ssAdd.toggle.fastOpen" = "Fast Open";
+"ssAdd.plugin.passthrough %@" = "来自链接的插件：%@";
+"ssAdd.footer.profile" = "保存到由内置模板生成的本地配置，继续添加服务器会更新同一配置。";
+"ssAdd.button.add" = "添加";
+"ssAdd.button.adding" = "正在添加…";
+"ssAdd.scanner.nav.title" = "扫描二维码";
+"ssAdd.scanner.unavailable.title" = "相机不可用";
+"ssAdd.scanner.unavailable.description" = "此设备无法扫描，请改为粘贴 ss:// 链接。";
+"ssAdd.scanner.denied.description" = "相机权限已被拒绝。请在系统设置中开启，或改为粘贴 ss:// 链接。";
+"ssAdd.profile.defaultName" = "我的服务器";
 
 
 /* Connections */

--- a/App/Sources/Models/ShadowsocksServer.swift
+++ b/App/Sources/Models/ShadowsocksServer.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// A single Shadowsocks server, mirroring the field set of a Clash `type: ss`
+/// proxy entry plus the optional SIP003 plugin block (e.g. the engine's
+/// built-in `ech-tls-tunnel` client transport).
+struct ShadowsocksServer: Equatable {
+    /// One SIP003 plugin option. Kept as an ordered list (not a dictionary)
+    /// so `plugin-opts` round-trips in a stable order.
+    struct PluginOption: Equatable {
+        var key: String
+        var value: String
+
+        init(_ key: String, _ value: String) {
+            self.key = key
+            self.value = value
+        }
+    }
+
+    var name: String
+    var server: String
+    var port: Int
+    var cipher: String
+    var password: String
+    var udp: Bool
+    var plugin: String?
+    var pluginOpts: [PluginOption]
+
+    init(
+        name: String,
+        server: String,
+        port: Int,
+        cipher: String,
+        password: String,
+        udp: Bool = false,
+        plugin: String? = nil,
+        pluginOpts: [PluginOption] = [],
+    ) {
+        self.name = name
+        self.server = server
+        self.port = port
+        self.cipher = cipher
+        self.password = password
+        self.udp = udp
+        self.plugin = plugin
+        self.pluginOpts = pluginOpts
+    }
+
+    /// Fallback display name, matching the engine-side subscription
+    /// converter's convention (`ss-<host>-<port>`).
+    static func defaultName(server: String, port: Int) -> String {
+        "ss-\(server)-\(port)"
+    }
+
+    func pluginOption(_ key: String) -> String? {
+        pluginOpts.first { $0.key == key }?.value
+    }
+}
+
+extension ShadowsocksServer {
+    /// AEAD ciphers offered by the manual-entry picker. Link/QR imports pass
+    /// through whatever cipher the URI names, even if it isn't listed here.
+    static let commonCiphers = [
+        "aes-128-gcm",
+        "aes-192-gcm",
+        "aes-256-gcm",
+        "chacha20-ietf-poly1305",
+        "xchacha20-ietf-poly1305",
+        "2022-blake3-aes-128-gcm",
+        "2022-blake3-aes-256-gcm",
+        "2022-blake3-chacha20-poly1305",
+    ]
+
+    static let defaultCipher = "aes-128-gcm"
+
+    /// SIP003 plugin name of the engine's built-in ECH-TLS client transport.
+    static let echTLSPlugin = "ech-tls-tunnel"
+}

--- a/App/Sources/Services/ShadowsocksConfigBuilder.swift
+++ b/App/Sources/Services/ShadowsocksConfigBuilder.swift
@@ -1,0 +1,348 @@
+import Foundation
+import Yams
+
+/// Config skeleton for locally-added Shadowsocks servers, derived from the
+/// reference `ech-tls-mihomo.yaml` desktop config (credentials, providers,
+/// and the reference deployment's own domains stripped). User servers are
+/// injected into `proxies`, the 默认 group, and — for domain hosts — into
+/// `fake-ip-filter` / sniffer `skip-domain` / a DIRECT rule, mirroring how
+/// the reference config treats its own server domains.
+private let shadowsocksTemplateYAML = """
+mixed-port: 7890
+ipv6: true
+allow-lan: true
+unified-delay: false
+tcp-concurrent: true
+external-controller: 127.0.0.1:9090
+
+geodata-mode: true
+geox-url:
+  geoip: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip-lite.dat"
+  geosite: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
+  mmdb: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country-lite.mmdb"
+  asn: "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb"
+
+find-process-mode: strict
+global-client-fingerprint: chrome
+
+profile:
+  store-selected: true
+  store-fake-ip: true
+
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80, 8080]
+      override-destination: true
+    TLS:
+      ports: [443, 8443]
+  skip-domain:
+    - "Mijia Cloud"
+    - "+.push.apple.com"
+
+tun:
+  enable: false
+  stack: mixed
+  dns-hijack:
+    - "any:53"
+    - "tcp://any:53"
+  auto-route: true
+  auto-redirect: true
+  auto-detect-interface: true
+
+dns:
+  enable: true
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-filter:
+    - "*"
+    - "+.lan"
+    - "+.local"
+    - "+.market.xiaomi.com"
+  default-nameserver:
+    - tls://223.5.5.5
+    - tls://223.6.6.6
+  nameserver:
+    - https://doh.pub/dns-query
+    - https://dns.alidns.com/dns-query
+
+proxies:
+  - name: "直连"
+    type: direct
+    udp: true
+
+proxy-groups:
+  - name: 默认
+    type: select
+    proxies: [自动选择, 直连, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点]
+
+  - name: Google
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: Telegram
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: Twitter
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: 哔哩哔哩
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: 巴哈姆特
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: YouTube
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: NETFLIX
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: Spotify
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: Github
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: 国内
+    type: select
+    proxies: [直连, 默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择]
+
+  - name: 其他
+    type: select
+    proxies: [默认, 香港, 台湾, 日本, 新加坡, 美国, 其它地区, 全部节点, 自动选择, 直连]
+
+  - name: 香港
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)港|hk|hongkong|hong kong"
+
+  - name: 台湾
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)台|tw|taiwan"
+
+  - name: 日本
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)日|jp|japan|tyo"
+
+  - name: 美国
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)美|us|unitedstates|united states"
+
+  - name: 新加坡
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)(新|sg|singapore|sgp)"
+
+  - name: 其它地区
+    type: select
+    include-all: true
+    exclude-type: [direct]
+    filter: "(?i)^(?!.*(?:🇭🇰|🇯🇵|🇺🇸|🇸🇬|🇨🇳|港|hk|hongkong|台|tw|taiwan|日|jp|japan|tyo|新|sg|singapore|sgp|美|us|unitedstates)).*"
+
+  - name: 全部节点
+    type: select
+    include-all: true
+    exclude-type: [direct]
+
+  - name: 自动选择
+    type: url-test
+    include-all: true
+    exclude-type: [direct]
+    tolerance: 10
+
+rules:
+  - GEOIP,lan,直连,no-resolve
+  - GEOSITE,github,Github
+  - GEOSITE,twitter,Twitter
+  - GEOSITE,youtube,YouTube
+  - GEOSITE,google,Google
+  - GEOSITE,telegram,Telegram
+  - GEOSITE,netflix,NETFLIX
+  - GEOSITE,bilibili,哔哩哔哩
+  - GEOSITE,bahamut,巴哈姆特
+  - GEOSITE,spotify,Spotify
+  - GEOSITE,CN,国内
+  - GEOSITE,geolocation-!cn,其他
+  - GEOIP,google,Google
+  - GEOIP,netflix,NETFLIX
+  - GEOIP,telegram,Telegram
+  - GEOIP,twitter,Twitter
+  - GEOIP,CN,国内
+  - MATCH,其他
+"""
+
+/// Renders local Shadowsocks-server profiles from the built-in template and
+/// reads the servers back out of a previously rendered profile so repeated
+/// adds accumulate into one profile.
+enum ShadowsocksConfigBuilder {
+    /// First line of every rendered profile. Lets the subscription service
+    /// find the locally generated profile among imported ones.
+    static let marker = "# meow:ss-local-profile"
+
+    static let directProxyName = "直连"
+    static let defaultGroupName = "默认"
+
+    enum BuildError: Error {
+        case templateBroken
+    }
+
+    static func isGenerated(_ yaml: String) -> Bool {
+        yaml.hasPrefix(marker)
+    }
+
+    static func render(servers: [ShadowsocksServer]) throws -> String {
+        guard var root = try Yams.compose(yaml: shadowsocksTemplateYAML) else {
+            throw BuildError.templateBroken
+        }
+
+        guard let existing = root["proxies"]?.sequence.map({ Array($0) }) else {
+            throw BuildError.templateBroken
+        }
+        root["proxies"] = Node(existing + servers.map(proxyNode))
+
+        guard var groups = root["proxy-groups"]?.sequence.map({ Array($0) }) else {
+            throw BuildError.templateBroken
+        }
+        for index in groups.indices where groups[index]["name"]?.string == defaultGroupName {
+            guard var members = groups[index]["proxies"]?.sequence.map({ Array($0) }) else { continue }
+            // After 自动选择 + 直连, before the region groups — matching where
+            // the reference config lists its own servers.
+            let insertAt = min(2, members.count)
+            members.insert(contentsOf: servers.map { quoted($0.name) }, at: insertAt)
+            groups[index]["proxies"] = Node(members)
+        }
+        root["proxy-groups"] = Node(groups)
+
+        insertDomainEntries(into: &root, servers: servers)
+
+        let yaml = try Yams.serialize(node: root, width: -1, allowUnicode: true)
+        return marker + "\n" + yaml
+    }
+
+    static func extractServers(from yaml: String) -> [ShadowsocksServer] {
+        guard let root = try? Yams.compose(yaml: yaml),
+              let proxies = root["proxies"]?.sequence
+        else { return [] }
+        var servers: [ShadowsocksServer] = []
+        for node in proxies where node["type"]?.string == "ss" {
+            guard let name = node["name"]?.string,
+                  let server = node["server"]?.string,
+                  let port = node["port"]?.int,
+                  let cipher = node["cipher"]?.string,
+                  let password = node["password"]?.string
+            else { continue }
+            var opts: [ShadowsocksServer.PluginOption] = []
+            if let mapping = node["plugin-opts"]?.mapping {
+                for (key, value) in mapping {
+                    guard let keyText = key.string else { continue }
+                    if let flag = value.bool {
+                        opts.append(.init(keyText, flag ? "true" : "false"))
+                    } else {
+                        opts.append(.init(keyText, value.string ?? ""))
+                    }
+                }
+            }
+            servers.append(ShadowsocksServer(
+                name: name,
+                server: server,
+                port: port,
+                cipher: cipher,
+                password: password,
+                udp: node["udp"]?.bool ?? false,
+                plugin: node["plugin"]?.string,
+                pluginOpts: opts,
+            ))
+        }
+        return servers
+    }
+
+    // MARK: - Node assembly
+
+    private static func proxyNode(_ server: ShadowsocksServer) -> Node {
+        var pairs: [(Node, Node)] = [
+            ("name", quoted(server.name)),
+            ("type", Node("ss")),
+            ("server", quoted(server.server)),
+            ("port", Node(String(server.port), Tag(.int))),
+            ("cipher", Node(server.cipher)),
+            ("password", quoted(server.password)),
+            ("udp", boolNode(server.udp)),
+        ]
+        if let plugin = server.plugin, !plugin.isEmpty {
+            pairs.append(("plugin", Node(plugin)))
+            if !server.pluginOpts.isEmpty {
+                let optPairs: [(Node, Node)] = server.pluginOpts.map { opt in
+                    let value: Node = (opt.value == "true" || opt.value == "false")
+                        ? boolNode(opt.value == "true")
+                        : quoted(opt.value)
+                    return (Node(opt.key), value)
+                }
+                pairs.append(("plugin-opts", Node(optPairs)))
+            }
+        }
+        return Node(pairs)
+    }
+
+    /// Per-server treatment of domain hosts (IP-literal servers need none):
+    /// keep the server's own name out of fake-IP and route direct hits to it
+    /// outside the tunnel, exactly as the reference config does for its
+    /// deployment domain.
+    private static func insertDomainEntries(into root: inout Node, servers: [ShadowsocksServer]) {
+        var domains: [String] = []
+        for server in servers where !isIPAddress(server.server) && !domains.contains(server.server) {
+            domains.append(server.server)
+        }
+        guard !domains.isEmpty else { return }
+
+        let wildcarded = domains.map { quoted("+.\($0)") }
+        if var filter = root["dns"]?["fake-ip-filter"]?.sequence.map({ Array($0) }) {
+            filter.append(contentsOf: wildcarded)
+            root["dns"]?["fake-ip-filter"] = Node(filter)
+        }
+        if var skip = root["sniffer"]?["skip-domain"]?.sequence.map({ Array($0) }) {
+            skip.append(contentsOf: wildcarded)
+            root["sniffer"]?["skip-domain"] = Node(skip)
+        }
+        if var rules = root["rules"]?.sequence.map({ Array($0) }) {
+            let directRules = domains.map { Node("DOMAIN-SUFFIX,\($0),\(directProxyName)") }
+            rules.insert(contentsOf: directRules, at: rules.isEmpty ? 0 : 1)
+            root["rules"] = Node(rules)
+        }
+    }
+
+    /// Force-quoted string scalar so values that look like other YAML types
+    /// (numeric passwords, `true`, emoji-prefixed names) stay strings.
+    private static func quoted(_ value: String) -> Node {
+        Node(value, Tag(.str), .doubleQuoted)
+    }
+
+    private static func boolNode(_ value: Bool) -> Node {
+        Node(value ? "true" : "false", Tag(.bool))
+    }
+
+    private static func isIPAddress(_ host: String) -> Bool {
+        var v4 = in_addr()
+        var v6 = in6_addr()
+        return host.withCString { cstr in
+            inet_pton(AF_INET, cstr, &v4) == 1 || inet_pton(AF_INET6, cstr, &v6) == 1
+        }
+    }
+}

--- a/App/Sources/Services/ShadowsocksURIParser.swift
+++ b/App/Sources/Services/ShadowsocksURIParser.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// Parses `ss://` share links (manual paste or QR scan) into
+/// ``ShadowsocksServer`` values.
+///
+/// Supported shapes:
+/// - SIP002: `ss://BASE64URL(method:password)@host:port/?plugin=…#name`
+/// - SIP002 plain userinfo (SS-2022): `ss://method:password@host:port#name`
+/// - Legacy: `ss://BASE64(method:password@host:port)#name`
+///
+/// The `plugin` query parameter is decoded as a SIP003 option string
+/// (`name;key=value;flag`) so ECH-TLS tunnel QR codes round-trip.
+enum ShadowsocksURIParser {
+    enum ParseError: Error, Equatable {
+        case notShadowsocks
+        case malformed(String)
+    }
+
+    static func parse(_ raw: String) throws -> ShadowsocksServer {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.lowercased().hasPrefix("ss://") else {
+            throw ParseError.notShadowsocks
+        }
+        let body = String(trimmed.dropFirst("ss://".count))
+        let beforeFragment = body.prefix { $0 != "#" }
+        if beforeFragment.contains("@") {
+            return try parseSIP002(trimmed)
+        }
+        return try parseLegacy(body)
+    }
+
+    // MARK: - SIP002
+
+    private static func parseSIP002(_ uri: String) throws -> ShadowsocksServer {
+        guard let comps = URLComponents(string: uri), var host = comps.host, !host.isEmpty else {
+            throw ParseError.malformed("unparseable SIP002 URI")
+        }
+        // Foundation keeps the brackets of an IPv6 literal in `host`; Clash
+        // YAML wants the bare address.
+        if host.hasPrefix("["), host.hasSuffix("]") {
+            host = String(host.dropFirst().dropLast())
+        }
+        guard let port = comps.port, (1 ... 65535).contains(port) else {
+            throw ParseError.malformed("missing or invalid port")
+        }
+
+        let method: String
+        let password: String
+        if let plainPassword = comps.password, let user = comps.user {
+            // Plain `method:password` userinfo (percent-encoded) — used by
+            // SS-2022 ciphers. URLComponents already split at the first ':'.
+            method = user
+            password = plainPassword
+        } else if let user = comps.user,
+                  let decoded = decodeBase64(String(user)),
+                  let colon = decoded.firstIndex(of: ":")
+        {
+            method = String(decoded[..<colon])
+            password = String(decoded[decoded.index(after: colon)...])
+        } else {
+            throw ParseError.malformed("userinfo is neither base64 nor method:password")
+        }
+        guard !method.isEmpty else { throw ParseError.malformed("empty cipher") }
+
+        var plugin: String?
+        var opts: [ShadowsocksServer.PluginOption] = []
+        if let pluginValue = comps.queryItems?.first(where: { $0.name == "plugin" })?.value,
+           !pluginValue.isEmpty
+        {
+            (plugin, opts) = parseSIP003(pluginValue)
+        }
+
+        let name = comps.fragment?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return ShadowsocksServer(
+            name: name.isEmpty ? ShadowsocksServer.defaultName(server: host, port: port) : name,
+            server: host,
+            port: port,
+            cipher: method,
+            password: password,
+            plugin: plugin,
+            pluginOpts: opts,
+        )
+    }
+
+    /// Splits a SIP003 plugin string (`name;key=value;flag`) into the plugin
+    /// name and its options. Bare flags decode as `true`.
+    private static func parseSIP003(_ value: String) -> (String, [ShadowsocksServer.PluginOption]) {
+        var parts = value.components(separatedBy: ";")
+        let name = parts.removeFirst()
+        var opts: [ShadowsocksServer.PluginOption] = []
+        for part in parts where !part.isEmpty {
+            if let eq = part.firstIndex(of: "=") {
+                opts.append(.init(String(part[..<eq]), String(part[part.index(after: eq)...])))
+            } else {
+                opts.append(.init(part, "true"))
+            }
+        }
+        return (name, opts)
+    }
+
+    // MARK: - Legacy (whole-body base64)
+
+    private static func parseLegacy(_ body: String) throws -> ShadowsocksServer {
+        var rest = body
+        var name = ""
+        if let hash = rest.firstIndex(of: "#") {
+            name = String(rest[rest.index(after: hash)...]).removingPercentEncoding ?? ""
+            rest = String(rest[..<hash])
+        }
+        if let query = rest.firstIndex(of: "?") {
+            rest = String(rest[..<query])
+        }
+        while rest.hasSuffix("/") {
+            rest.removeLast()
+        }
+        guard let decoded = decodeBase64(rest) else {
+            throw ParseError.malformed("invalid base64 payload")
+        }
+        // method:password@host:port — password may itself contain '@' or ':',
+        // so split at the LAST '@' and the FIRST ':' of the userinfo.
+        guard let at = decoded.range(of: "@", options: .backwards) else {
+            throw ParseError.malformed("missing @ separator")
+        }
+        let userinfo = String(decoded[..<at.lowerBound])
+        let hostPort = String(decoded[at.upperBound...])
+        guard let colon = userinfo.firstIndex(of: ":") else {
+            throw ParseError.malformed("missing method:password separator")
+        }
+        let method = String(userinfo[..<colon])
+        let password = String(userinfo[userinfo.index(after: colon)...])
+        guard !method.isEmpty else { throw ParseError.malformed("empty cipher") }
+        let (host, port) = try parseHostPort(hostPort)
+        return ShadowsocksServer(
+            name: name.isEmpty ? ShadowsocksServer.defaultName(server: host, port: port) : name,
+            server: host,
+            port: port,
+            cipher: method,
+            password: password,
+        )
+    }
+
+    private static func parseHostPort(_ hostPort: String) throws -> (String, Int) {
+        let host: String
+        let portText: String
+        if hostPort.hasPrefix("[") {
+            guard let close = hostPort.firstIndex(of: "]") else {
+                throw ParseError.malformed("unterminated IPv6 literal")
+            }
+            host = String(hostPort[hostPort.index(after: hostPort.startIndex) ..< close])
+            let after = hostPort[hostPort.index(after: close)...]
+            guard after.hasPrefix(":") else {
+                throw ParseError.malformed("missing port")
+            }
+            portText = String(after.dropFirst())
+        } else {
+            guard let colon = hostPort.range(of: ":", options: .backwards) else {
+                throw ParseError.malformed("missing port")
+            }
+            host = String(hostPort[..<colon.lowerBound])
+            portText = String(hostPort[colon.upperBound...])
+        }
+        guard !host.isEmpty else { throw ParseError.malformed("empty host") }
+        guard let port = Int(portText), (1 ... 65535).contains(port) else {
+            throw ParseError.malformed("invalid port")
+        }
+        return (host, port)
+    }
+
+    /// Decodes standard or URL-safe base64, tolerating missing padding.
+    private static func decodeBase64(_ text: String) -> String? {
+        var b64 = text
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        b64.removeAll(where: \.isWhitespace)
+        while b64.count % 4 != 0 {
+            b64.append("=")
+        }
+        guard let data = Data(base64Encoded: b64) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/App/Sources/Services/SubscriptionService.swift
+++ b/App/Sources/Services/SubscriptionService.swift
@@ -46,6 +46,44 @@ final class SubscriptionService {
         return profile
     }
 
+    /// Add a manually-entered / QR-scanned Shadowsocks server. Servers live
+    /// in a single locally generated profile (rendered from the built-in
+    /// template): the first add creates it, later adds re-render it with the
+    /// accumulated server list. A server whose name matches an existing one
+    /// replaces it. The rendered YAML is engine-validated before anything is
+    /// persisted.
+    @discardableResult
+    func addShadowsocks(_ server: ShadowsocksServer) throws -> Profile {
+        let all = try modelContext.fetch(FetchDescriptor<Profile>())
+        let generated = all.first { ShadowsocksConfigBuilder.isGenerated($0.yamlContent) }
+
+        var servers = generated.map { ShadowsocksConfigBuilder.extractServers(from: $0.yamlContent) } ?? []
+        servers.removeAll { $0.name == server.name }
+        servers.append(server)
+
+        let yaml = try ShadowsocksConfigBuilder.render(servers: servers)
+        try MeowConfigValidator.validate(yaml)
+
+        if let generated {
+            generated.yamlBackup = generated.yamlContent
+            generated.yamlContent = yaml
+            generated.lastUpdated = .now
+            try modelContext.save()
+            if generated.isSelected {
+                try writeActiveConfig(generated)
+            }
+            return generated
+        }
+        let name = String(
+            localized: "ssAdd.profile.defaultName",
+            comment: "Name of the auto-created profile holding manually added Shadowsocks servers",
+        )
+        let profile = Profile(name: name, url: "", yamlContent: yaml, yamlBackup: yaml)
+        modelContext.insert(profile)
+        try modelContext.save()
+        return profile
+    }
+
     func refresh(_ profile: Profile) async throws {
         guard !profile.url.isEmpty else { throw SubscriptionError.invalidURL }
         let yaml = try await fetchAndNormalize(url: profile.url)

--- a/App/Sources/Views/AddShadowsocksSheet.swift
+++ b/App/Sources/Views/AddShadowsocksSheet.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+
+/// Form for adding a Shadowsocks server, either typed by hand or filled from
+/// a scanned / pasted `ss://` link. Saving hands the server to
+/// `SubscriptionService.addShadowsocks`, which renders it into the locally
+/// generated template profile.
+struct AddShadowsocksSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(SubscriptionService.self) private var service
+    @Binding var error: String?
+
+    @State private var link = ""
+    @State private var linkInvalid = false
+    @State private var showingScanner = false
+
+    @State private var name = ""
+    @State private var server = ""
+    @State private var port = ""
+    @State private var cipher = ShadowsocksServer.defaultCipher
+    @State private var password = ""
+    @State private var udp = false
+
+    @State private var echEnabled = false
+    @State private var sni = ""
+    @State private var path = ""
+    @State private var echConfig = ""
+    @State private var fingerprint = "chrome"
+    @State private var fastOpen = false
+
+    /// Plugin parsed from a link that isn't ech-tls-tunnel. Preserved
+    /// verbatim so scanning an arbitrary SIP002 QR code doesn't silently
+    /// drop its plugin options; toggling the ECH section replaces it.
+    @State private var passthroughPlugin: PassthroughPlugin?
+
+    @State private var submitting = false
+
+    private struct PassthroughPlugin: Equatable {
+        var name: String
+        var opts: [ShadowsocksServer.PluginOption]
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                linkSection
+                serverSection
+                echSection
+            }
+            .navigationTitle("ssAdd.nav.title")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("common.cancel") { dismiss() }
+                        .accessibilityIdentifier("ssAdd.cancelButton")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(LocalizedStringKey(
+                        submitting ? "ssAdd.button.adding" : "ssAdd.button.add",
+                    )) {
+                        save()
+                    }
+                    .disabled(builtServer == nil || submitting)
+                    .accessibilityIdentifier("ssAdd.addButton")
+                }
+            }
+            .sheet(isPresented: $showingScanner) {
+                ShadowsocksQRScannerSheet { payload in
+                    link = payload
+                    applyLink()
+                }
+            }
+        }
+    }
+
+    private var linkSection: some View {
+        Section {
+            Button {
+                showingScanner = true
+            } label: {
+                Label("ssAdd.button.scan", systemImage: "qrcode.viewfinder")
+            }
+            .accessibilityIdentifier("ssAdd.scanButton")
+
+            // Placeholder is an example value, deliberately unlocalized.
+            TextField("ss://…", text: $link)
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .onSubmit { applyLink() }
+                .accessibilityIdentifier("ssAdd.linkField")
+            if !link.isEmpty {
+                Button("ssAdd.button.applyLink") { applyLink() }
+                    .accessibilityIdentifier("ssAdd.applyLinkButton")
+            }
+        } header: {
+            Text("ssAdd.section.link")
+        } footer: {
+            if linkInvalid {
+                Text("ssAdd.error.invalidLink")
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var serverSection: some View {
+        Section {
+            TextField("ssAdd.field.name", text: $name)
+                .accessibilityIdentifier("ssAdd.nameField")
+            TextField("ssAdd.field.server", text: $server)
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .accessibilityIdentifier("ssAdd.serverField")
+            TextField("ssAdd.field.port", text: $port)
+                .keyboardType(.numberPad)
+                .accessibilityIdentifier("ssAdd.portField")
+            Picker("ssAdd.field.cipher", selection: $cipher) {
+                ForEach(ShadowsocksServer.commonCiphers, id: \.self) { c in
+                    Text(c).tag(c)
+                }
+                // A link can name a cipher outside the common list — keep it
+                // selectable instead of snapping to a different one.
+                if !ShadowsocksServer.commonCiphers.contains(cipher) {
+                    Text(cipher).tag(cipher)
+                }
+            }
+            .accessibilityIdentifier("ssAdd.cipherPicker")
+            SecureField("ssAdd.field.password", text: $password)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .accessibilityIdentifier("ssAdd.passwordField")
+            Toggle("ssAdd.toggle.udp", isOn: $udp)
+                .accessibilityIdentifier("ssAdd.udpToggle")
+        } header: {
+            Text("ssAdd.section.server")
+        } footer: {
+            if let passthroughPlugin {
+                Text("ssAdd.plugin.passthrough \(passthroughPlugin.name)")
+            } else {
+                Text("ssAdd.footer.profile")
+            }
+        }
+    }
+
+    private var echSection: some View {
+        Section {
+            Toggle("ssAdd.toggle.ech", isOn: $echEnabled)
+                .accessibilityIdentifier("ssAdd.echToggle")
+                .onChange(of: echEnabled) { _, enabled in
+                    if enabled { passthroughPlugin = nil }
+                }
+            if echEnabled {
+                TextField("ssAdd.field.sni", text: $sni)
+                    .keyboardType(.URL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .accessibilityIdentifier("ssAdd.sniField")
+                TextField("ssAdd.field.path", text: $path)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .accessibilityIdentifier("ssAdd.pathField")
+                TextField("ssAdd.field.echConfig", text: $echConfig)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .accessibilityIdentifier("ssAdd.echConfigField")
+                TextField("ssAdd.field.fingerprint", text: $fingerprint)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .accessibilityIdentifier("ssAdd.fingerprintField")
+                Toggle("ssAdd.toggle.fastOpen", isOn: $fastOpen)
+                    .accessibilityIdentifier("ssAdd.fastOpenToggle")
+            }
+        } header: {
+            Text("ssAdd.section.ech")
+        } footer: {
+            Text("ssAdd.ech.footer")
+        }
+    }
+
+    // MARK: - Link import
+
+    private func applyLink() {
+        do {
+            let parsed = try ShadowsocksURIParser.parse(link)
+            apply(parsed)
+            linkInvalid = false
+        } catch {
+            linkInvalid = true
+        }
+    }
+
+    private func apply(_ parsed: ShadowsocksServer) {
+        name = parsed.name
+        server = parsed.server
+        port = String(parsed.port)
+        cipher = parsed.cipher
+        password = parsed.password
+        udp = parsed.udp
+        if parsed.plugin == ShadowsocksServer.echTLSPlugin {
+            echEnabled = true
+            passthroughPlugin = nil
+            sni = parsed.pluginOption("sni") ?? ""
+            path = parsed.pluginOption("path") ?? ""
+            echConfig = parsed.pluginOption("ech_config") ?? ""
+            fingerprint = parsed.pluginOption("fingerprint") ?? "chrome"
+            fastOpen = parsed.pluginOption("fast_open") == "true"
+        } else if let plugin = parsed.plugin {
+            echEnabled = false
+            passthroughPlugin = PassthroughPlugin(name: plugin, opts: parsed.pluginOpts)
+        } else {
+            echEnabled = false
+            passthroughPlugin = nil
+        }
+    }
+
+    // MARK: - Save
+
+    private var builtServer: ShadowsocksServer? {
+        let host = server.trimmingCharacters(in: .whitespaces)
+        guard !host.isEmpty, !password.isEmpty, !cipher.isEmpty,
+              let portValue = Int(port), (1 ... 65535).contains(portValue)
+        else { return nil }
+
+        var plugin: String?
+        var opts: [ShadowsocksServer.PluginOption] = []
+        if echEnabled {
+            plugin = ShadowsocksServer.echTLSPlugin
+            opts.append(.init("mode", "client"))
+            let sniValue = sni.trimmingCharacters(in: .whitespaces)
+            opts.append(.init("sni", sniValue.isEmpty ? host : sniValue))
+            let pathValue = path.trimmingCharacters(in: .whitespaces)
+            if !pathValue.isEmpty { opts.append(.init("path", pathValue)) }
+            let echValue = echConfig.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !echValue.isEmpty { opts.append(.init("ech_config", echValue)) }
+            let fingerprintValue = fingerprint.trimmingCharacters(in: .whitespaces)
+            if !fingerprintValue.isEmpty { opts.append(.init("fingerprint", fingerprintValue)) }
+            if fastOpen { opts.append(.init("fast_open", "true")) }
+        } else if let passthroughPlugin {
+            plugin = passthroughPlugin.name
+            opts = passthroughPlugin.opts
+        }
+
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        return ShadowsocksServer(
+            name: trimmedName.isEmpty
+                ? ShadowsocksServer.defaultName(server: host, port: portValue)
+                : trimmedName,
+            server: host,
+            port: portValue,
+            cipher: cipher,
+            password: password,
+            udp: udp,
+            plugin: plugin,
+            pluginOpts: opts,
+        )
+    }
+
+    private func save() {
+        guard let built = builtServer else { return }
+        submitting = true
+        defer { submitting = false }
+        do {
+            _ = try service.addShadowsocks(built)
+            dismiss()
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/App/Sources/Views/ShadowsocksQRScannerSheet.swift
+++ b/App/Sources/Views/ShadowsocksQRScannerSheet.swift
@@ -1,0 +1,129 @@
+import AVFoundation
+import SwiftUI
+import VisionKit
+
+/// Camera sheet that scans a QR code and hands the payload string back.
+/// VisionKit's `DataScannerViewController` needs a physical camera — on
+/// Simulator / Mac the sheet degrades to a hint to paste the link instead
+/// (every iOS 17 device has the required A12+ hardware, so on-device
+/// availability is gated only by camera permission).
+struct ShadowsocksQRScannerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let onScan: (String) -> Void
+
+    private enum CameraState {
+        case checking
+        case ready
+        case denied
+        case unsupported
+    }
+
+    @State private var cameraState: CameraState = .checking
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch cameraState {
+                case .checking:
+                    ProgressView()
+                case .ready:
+                    QRCodeDataScanner { payload in
+                        onScan(payload)
+                        dismiss()
+                    }
+                    .ignoresSafeArea(edges: .bottom)
+                case .denied:
+                    ContentUnavailableView(
+                        "ssAdd.scanner.unavailable.title",
+                        systemImage: "camera",
+                        description: Text("ssAdd.scanner.denied.description"),
+                    )
+                case .unsupported:
+                    ContentUnavailableView(
+                        "ssAdd.scanner.unavailable.title",
+                        systemImage: "camera",
+                        description: Text("ssAdd.scanner.unavailable.description"),
+                    )
+                }
+            }
+            .navigationTitle("ssAdd.scanner.nav.title")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("common.cancel") { dismiss() }
+                        .accessibilityIdentifier("ssAdd.scanner.cancelButton")
+                }
+            }
+            .task { await resolveCameraState() }
+        }
+    }
+
+    private func resolveCameraState() async {
+        guard DataScannerViewController.isSupported else {
+            cameraState = .unsupported
+            return
+        }
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            cameraState = .ready
+        case .notDetermined:
+            let granted = await AVCaptureDevice.requestAccess(for: .video)
+            cameraState = granted ? .ready : .denied
+        default:
+            cameraState = .denied
+        }
+    }
+}
+
+private struct QRCodeDataScanner: UIViewControllerRepresentable {
+    let onScan: (String) -> Void
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let controller = DataScannerViewController(
+            recognizedDataTypes: [.barcode(symbologies: [.qr])],
+            qualityLevel: .fast,
+            isHighlightingEnabled: true,
+        )
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: DataScannerViewController, context _: Context) {
+        if !controller.isScanning {
+            try? controller.startScanning()
+        }
+    }
+
+    static func dismantleUIViewController(_ controller: DataScannerViewController, coordinator _: Coordinator) {
+        controller.stopScanning()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScan: onScan)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        private let onScan: (String) -> Void
+        private var delivered = false
+
+        init(onScan: @escaping (String) -> Void) {
+            self.onScan = onScan
+        }
+
+        func dataScanner(
+            _: DataScannerViewController,
+            didAdd added: [RecognizedItem],
+            allItems _: [RecognizedItem],
+        ) {
+            guard !delivered else { return }
+            for item in added {
+                if case let .barcode(barcode) = item, let payload = barcode.payloadStringValue {
+                    delivered = true
+                    onScan(payload)
+                    return
+                }
+            }
+        }
+    }
+}

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -6,6 +6,7 @@ struct SubscriptionsView: View {
     @Environment(SubscriptionService.self) private var service
     @Query(sort: \Profile.lastUpdated, order: .reverse) private var profiles: [Profile]
     @State private var showingAdd = false
+    @State private var showingAddShadowsocks = false
     @State private var showingImporter = false
     @State private var editing: Profile?
     @State private var editingInfo: Profile?
@@ -126,6 +127,9 @@ struct SubscriptionsView: View {
         .sheet(isPresented: $showingAdd) {
             AddSubscriptionSheet(error: $error)
         }
+        .sheet(isPresented: $showingAddShadowsocks) {
+            AddShadowsocksSheet(error: $error)
+        }
         .fileImporter(
             isPresented: $showingImporter,
             allowedContentTypes: yamlContentTypes(),
@@ -209,6 +213,13 @@ struct SubscriptionsView: View {
                 Label("subscriptions.toolbar.addFromURL", systemImage: "link")
             }
             .accessibilityIdentifier("subscriptions.toolbar.addFromURL")
+
+            Button {
+                showingAddShadowsocks = true
+            } label: {
+                Label("subscriptions.toolbar.addShadowsocks", systemImage: "qrcode.viewfinder")
+            }
+            .accessibilityIdentifier("subscriptions.toolbar.addShadowsocks")
 
             Button {
                 showingImporter = true

--- a/MeowTests/Parsing/ShadowsocksConfigBuilderTests.swift
+++ b/MeowTests/Parsing/ShadowsocksConfigBuilderTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+@testable import meow_ios
+import Testing
+import Yams
+
+/// Template rendering for locally added Shadowsocks servers: injection into
+/// `proxies` and the 默认 group, per-domain fake-IP / sniffer / DIRECT-rule
+/// entries, type-safe scalar quoting, and the extract → render round-trip
+/// that lets repeated adds accumulate into one profile.
+@Suite("Shadowsocks config builder", .tags(.parsing))
+struct ShadowsocksConfigBuilderTests {
+    private let echServer = ShadowsocksServer(
+        name: "🇸🇬 ech-sgp",
+        server: "sgp.example.com",
+        port: 443,
+        cipher: "aes-128-gcm",
+        password: "secret-password",
+        udp: false,
+        plugin: "ech-tls-tunnel",
+        pluginOpts: [
+            .init("mode", "client"),
+            .init("sni", "sgp.example.com"),
+            .init("path", "/ws-abc"),
+            .init("ech_config", "QUJDRA=="),
+            .init("fingerprint", "chrome"),
+            .init("fast_open", "true"),
+        ],
+    )
+
+    private let plainServer = ShadowsocksServer(
+        name: "plain",
+        server: "192.0.2.10",
+        port: 8388,
+        cipher: "aes-256-gcm",
+        password: "12345",
+        udp: true,
+    )
+
+    @Test
+    func `rendered config carries marker and injects server into proxies and default group`() throws {
+        let yaml = try ShadowsocksConfigBuilder.render(servers: [echServer])
+        #expect(ShadowsocksConfigBuilder.isGenerated(yaml))
+
+        let root = try #require(try Yams.load(yaml: yaml) as? [String: Any])
+        let proxies = try #require(root["proxies"] as? [[String: Any]])
+        #expect(proxies.count == 2)
+        #expect(proxies[0]["type"] as? String == "direct")
+        let ss = try #require(proxies.last)
+        #expect(ss["name"] as? String == "🇸🇬 ech-sgp")
+        #expect(ss["type"] as? String == "ss")
+        #expect(ss["server"] as? String == "sgp.example.com")
+        #expect(ss["port"] as? Int == 443)
+        #expect(ss["plugin"] as? String == "ech-tls-tunnel")
+        let opts = try #require(ss["plugin-opts"] as? [String: Any])
+        #expect(opts["mode"] as? String == "client")
+        #expect(opts["ech_config"] as? String == "QUJDRA==")
+        #expect(opts["fast_open"] as? Bool == true)
+
+        let groups = try #require(root["proxy-groups"] as? [[String: Any]])
+        let defaultGroup = try #require(groups.first { $0["name"] as? String == "默认" })
+        let members = try #require(defaultGroup["proxies"] as? [String])
+        // After 自动选择 + 直连, before the region groups.
+        #expect(members[2] == "🇸🇬 ech-sgp")
+
+        // Providers from the desktop reference config must not leak through.
+        #expect(root["proxy-providers"] == nil)
+    }
+
+    @Test
+    func `domain hosts get fake-ip-filter, sniffer skip, and DIRECT rule; IP hosts do not`() throws {
+        let yaml = try ShadowsocksConfigBuilder.render(servers: [echServer, plainServer])
+        let root = try #require(try Yams.load(yaml: yaml) as? [String: Any])
+
+        let dns = try #require(root["dns"] as? [String: Any])
+        let fakeIPFilter = try #require(dns["fake-ip-filter"] as? [String])
+        #expect(fakeIPFilter.contains("+.sgp.example.com"))
+        #expect(!fakeIPFilter.contains("+.192.0.2.10"))
+
+        let sniffer = try #require(root["sniffer"] as? [String: Any])
+        let skip = try #require(sniffer["skip-domain"] as? [String])
+        #expect(skip.contains("+.sgp.example.com"))
+
+        let rules = try #require(root["rules"] as? [String])
+        #expect(rules.first == "GEOIP,lan,直连,no-resolve")
+        #expect(rules[1] == "DOMAIN-SUFFIX,sgp.example.com,直连")
+        #expect(!rules.contains { $0.contains("192.0.2.10") })
+        #expect(rules.last == "MATCH,其他")
+    }
+
+    @Test
+    func `numeric-looking passwords stay strings`() throws {
+        let yaml = try ShadowsocksConfigBuilder.render(servers: [plainServer])
+        let root = try #require(try Yams.load(yaml: yaml) as? [String: Any])
+        let proxies = try #require(root["proxies"] as? [[String: Any]])
+        let ss = try #require(proxies.last)
+        #expect(ss["password"] as? String == "12345")
+        #expect(ss["udp"] as? Bool == true)
+    }
+
+    @Test
+    func `extractServers round-trips a rendered config`() throws {
+        let servers = [echServer, plainServer]
+        let yaml = try ShadowsocksConfigBuilder.render(servers: servers)
+        let extracted = ShadowsocksConfigBuilder.extractServers(from: yaml)
+        #expect(extracted == servers)
+    }
+
+    @Test
+    func `rendered config passes the structural linter`() throws {
+        let yaml = try ShadowsocksConfigBuilder.render(servers: [echServer, plainServer])
+        let diagnostics = ClashConfigLinter.lint(yaml)
+        #expect(diagnostics.isEmpty, "unexpected lint issues: \(diagnostics)")
+    }
+
+    @Test(.tags(.ffi))
+    func `rendered config passes engine validation`() throws {
+        let yaml = try ShadowsocksConfigBuilder.render(servers: [echServer, plainServer])
+        try MeowConfigValidator.validate(yaml)
+    }
+}

--- a/MeowTests/Parsing/ShadowsocksURIParserTests.swift
+++ b/MeowTests/Parsing/ShadowsocksURIParserTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import meow_ios
+import Testing
+
+/// `ss://` share-link parsing (manual paste + QR scan payloads): SIP002 with
+/// base64url or plain userinfo, the legacy whole-body-base64 form, and the
+/// SIP003 `plugin` query parameter used by ech-tls-tunnel QR codes.
+@Suite("Shadowsocks URI parser", .tags(.parsing))
+struct ShadowsocksURIParserTests {
+    private func base64(_ text: String) -> String {
+        Data(text.utf8).base64EncodedString()
+    }
+
+    private func base64URLNoPad(_ text: String) -> String {
+        Data(text.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    @Test
+    func `parses SIP002 with padded base64 userinfo and fragment name`() throws {
+        let uri = "ss://\(base64("aes-128-gcm:secret!pw"))@example.com:8443#My%20Node"
+        let server = try ShadowsocksURIParser.parse(uri)
+        #expect(server.name == "My Node")
+        #expect(server.server == "example.com")
+        #expect(server.port == 8443)
+        #expect(server.cipher == "aes-128-gcm")
+        #expect(server.password == "secret!pw")
+        #expect(server.plugin == nil)
+        #expect(server.udp == false)
+    }
+
+    @Test
+    func `parses SIP002 with unpadded base64url userinfo`() throws {
+        // "chacha20-ietf-poly1305:pa>ss" encodes to base64 needing both
+        // URL-safe substitution and re-padding.
+        let uri = "ss://\(base64URLNoPad("chacha20-ietf-poly1305:pa>ss"))@10.0.0.2:443"
+        let server = try ShadowsocksURIParser.parse(uri)
+        #expect(server.cipher == "chacha20-ietf-poly1305")
+        #expect(server.password == "pa>ss")
+        #expect(server.server == "10.0.0.2")
+        #expect(server.port == 443)
+        // No fragment → engine-style default name.
+        #expect(server.name == "ss-10.0.0.2-443")
+    }
+
+    @Test
+    func `parses SIP002 plain userinfo used by SS-2022 ciphers`() throws {
+        let uri = "ss://2022-blake3-aes-256-gcm:MTIzNDU2Nzg5MDEyMzQ1Ng%3D%3D@host.example.net:443#n1"
+        let server = try ShadowsocksURIParser.parse(uri)
+        #expect(server.cipher == "2022-blake3-aes-256-gcm")
+        #expect(server.password == "MTIzNDU2Nzg5MDEyMzQ1Ng==")
+        #expect(server.server == "host.example.net")
+    }
+
+    @Test
+    func `parses SIP003 plugin query into plugin and ordered options`() throws {
+        let plugin = "ech-tls-tunnel;mode=client;sni=sgp.example.com;path=/ws-abc"
+            + ";ech_config=QUJDRA==;fingerprint=chrome;fast_open"
+        var comps = URLComponents(string: "ss://\(base64("aes-128-gcm:pw"))@sgp.example.com:443")!
+        comps.queryItems = [URLQueryItem(name: "plugin", value: plugin)]
+        comps.fragment = "ech-sgp"
+        let server = try ShadowsocksURIParser.parse(comps.string!)
+        #expect(server.name == "ech-sgp")
+        #expect(server.plugin == "ech-tls-tunnel")
+        #expect(server.pluginOption("mode") == "client")
+        #expect(server.pluginOption("sni") == "sgp.example.com")
+        #expect(server.pluginOption("path") == "/ws-abc")
+        #expect(server.pluginOption("ech_config") == "QUJDRA==")
+        #expect(server.pluginOption("fingerprint") == "chrome")
+        // Bare SIP003 flag decodes as boolean true.
+        #expect(server.pluginOption("fast_open") == "true")
+    }
+
+    @Test
+    func `parses legacy whole-body base64 form`() throws {
+        let uri = "ss://\(base64("aes-256-gcm:p@ss:word@1.2.3.4:8388"))#Legacy%20Node"
+        let server = try ShadowsocksURIParser.parse(uri)
+        #expect(server.name == "Legacy Node")
+        #expect(server.cipher == "aes-256-gcm")
+        // Password containing '@' and ':' survives the last-@/first-: split.
+        #expect(server.password == "p@ss:word")
+        #expect(server.server == "1.2.3.4")
+        #expect(server.port == 8388)
+    }
+
+    @Test
+    func `parses IPv6 host in brackets`() throws {
+        let uri = "ss://\(base64("aes-128-gcm:pw"))@[2001:db8::1]:443#v6"
+        let server = try ShadowsocksURIParser.parse(uri)
+        #expect(server.server == "2001:db8::1")
+        #expect(server.port == 443)
+    }
+
+    @Test
+    func `rejects non-ss schemes and garbage payloads`() {
+        #expect(throws: ShadowsocksURIParser.ParseError.notShadowsocks) {
+            try ShadowsocksURIParser.parse("trojan://x@example.com:443")
+        }
+        #expect(throws: ShadowsocksURIParser.ParseError.self) {
+            try ShadowsocksURIParser.parse("ss://%%%not-base64%%%")
+        }
+        #expect(throws: ShadowsocksURIParser.ParseError.self) {
+            // SIP002 shape but no port.
+            try ShadowsocksURIParser.parse("ss://\(base64("aes-128-gcm:pw"))@example.com")
+        }
+    }
+}

--- a/MeowTests/Services/ShadowsocksAddServiceTests.swift
+++ b/MeowTests/Services/ShadowsocksAddServiceTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+@testable import meow_ios
+import SwiftData
+import Testing
+
+/// `SubscriptionService.addShadowsocks`: first add creates the generated
+/// local profile, later adds re-render it in place, and a same-name add
+/// replaces the earlier server. Uses the real template renderer + engine
+/// validation end to end.
+@Suite("Shadowsocks add service", .tags(.service))
+struct ShadowsocksAddServiceTests {
+    @MainActor
+    private func makeService() throws -> (SubscriptionService, ModelContext) {
+        let container = try ModelContainer(
+            for: Profile.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true),
+        )
+        let context = ModelContext(container)
+        return (SubscriptionService(modelContext: context), context)
+    }
+
+    private func server(name: String, host: String = "node.example.com", port: Int = 443) -> ShadowsocksServer {
+        ShadowsocksServer(
+            name: name,
+            server: host,
+            port: port,
+            cipher: "aes-128-gcm",
+            password: "pw-\(name)",
+        )
+    }
+
+    @Test
+    @MainActor
+    func `first add creates a marked local profile`() throws {
+        let (service, context) = try makeService()
+        let profile = try service.addShadowsocks(server(name: "n1"))
+
+        #expect(profile.url.isEmpty)
+        #expect(ShadowsocksConfigBuilder.isGenerated(profile.yamlContent))
+        #expect(ShadowsocksConfigBuilder.extractServers(from: profile.yamlContent).map(\.name) == ["n1"])
+        #expect(try context.fetch(FetchDescriptor<Profile>()).count == 1)
+    }
+
+    @Test
+    @MainActor
+    func `second add accumulates into the same profile`() throws {
+        let (service, context) = try makeService()
+        let first = try service.addShadowsocks(server(name: "n1"))
+        let second = try service.addShadowsocks(server(name: "n2", host: "10.1.2.3", port: 8388))
+
+        #expect(first.id == second.id)
+        #expect(try context.fetch(FetchDescriptor<Profile>()).count == 1)
+        let names = ShadowsocksConfigBuilder.extractServers(from: second.yamlContent).map(\.name)
+        #expect(names == ["n1", "n2"])
+        // Previous rendering is preserved as the editor-revert backup.
+        #expect(ShadowsocksConfigBuilder.extractServers(from: second.yamlBackup).map(\.name) == ["n1"])
+    }
+
+    @Test
+    @MainActor
+    func `same-name add replaces the earlier server`() throws {
+        let (service, _) = try makeService()
+        _ = try service.addShadowsocks(server(name: "n1", port: 443))
+        let profile = try service.addShadowsocks(server(name: "n1", port: 8443))
+
+        let servers = ShadowsocksConfigBuilder.extractServers(from: profile.yamlContent)
+        #expect(servers.count == 1)
+        #expect(servers.first?.port == 8443)
+    }
+
+    @Test
+    @MainActor
+    func `imported subscriptions are not mistaken for the generated profile`() throws {
+        let (service, context) = try makeService()
+        let imported = Profile(
+            name: "Imported",
+            url: "",
+            yamlContent: "proxies:\n  - name: x\n    type: ss\n    server: a.example.com\n"
+                + "    port: 443\n    cipher: aes-128-gcm\n    password: p\n",
+        )
+        context.insert(imported)
+        try context.save()
+
+        _ = try service.addShadowsocks(server(name: "n1"))
+        let profiles = try context.fetch(FetchDescriptor<Profile>())
+        #expect(profiles.count == 2)
+        // The imported profile's YAML is untouched.
+        #expect(ShadowsocksConfigBuilder.extractServers(from: imported.yamlContent).map(\.name) == ["x"])
+    }
+}

--- a/MeowUITests/Flows/AddShadowsocksFlowTests.swift
+++ b/MeowUITests/Flows/AddShadowsocksFlowTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+/// Flow: add a Shadowsocks server manually and via a pasted `ss://` link.
+/// The QR-scan path feeds the scanned payload through the same parse+apply
+/// code the link field uses — the camera itself can't run on Simulator.
+final class AddShadowsocksFlowTests: XCTestCase {
+    override func setUp() {
+        continueAfterFailure = false
+    }
+
+    private func openSheet(_ meow: MeowApp) {
+        meow.subscriptionsTab.tap()
+        let addMenu = meow.app.buttons["subscriptions.toolbar.add"]
+        XCTAssertTrue(addMenu.waitForExistence(timeout: 5))
+        addMenu.tap()
+        let item = meow.app.buttons["subscriptions.toolbar.addShadowsocks"]
+        XCTAssertTrue(item.waitForExistence(timeout: 5))
+        item.tap()
+        XCTAssertTrue(meow.app.navigationBars["Add Shadowsocks"].waitForExistence(timeout: 5))
+    }
+
+    func testManualEntryCreatesLocalProfile() {
+        let meow = MeowApp()
+        meow.launch()
+        openSheet(meow)
+
+        let app = meow.app
+        let server = app.textFields["ssAdd.serverField"]
+        XCTAssertTrue(server.waitForExistence(timeout: 5))
+        server.tap()
+        server.typeText("node.example.com")
+        let port = app.textFields["ssAdd.portField"]
+        port.tap()
+        port.typeText("8388")
+        let password = app.secureTextFields["ssAdd.passwordField"]
+        password.tap()
+        password.typeText("hunter22")
+
+        let add = app.buttons["ssAdd.addButton"]
+        XCTAssertTrue(add.isEnabled)
+        add.tap()
+
+        // Saving renders the template profile and engine-validates it before
+        // the sheet dismisses; the generated profile then shows in the list.
+        XCTAssertTrue(app.staticTexts["My Servers"].waitForExistence(timeout: 10))
+    }
+
+    func testLinkFillPopulatesForm() {
+        let meow = MeowApp()
+        meow.launch()
+        openSheet(meow)
+
+        let app = meow.app
+        let link = app.textFields["ssAdd.linkField"]
+        XCTAssertTrue(link.waitForExistence(timeout: 5))
+        link.tap()
+        let userinfo = Data("aes-128-gcm:pw".utf8).base64EncodedString()
+        link.typeText("ss://\(userinfo)@qr.example.com:443#Scanned")
+
+        let apply = app.buttons["ssAdd.applyLinkButton"]
+        XCTAssertTrue(apply.waitForExistence(timeout: 5))
+        apply.tap()
+
+        let server = app.textFields["ssAdd.serverField"]
+        XCTAssertEqual(server.value as? String, "qr.example.com")
+        XCTAssertEqual(app.textFields["ssAdd.portField"].value as? String, "443")
+        XCTAssertEqual(app.textFields["ssAdd.nameField"].value as? String, "Scanned")
+    }
+}

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -24,9 +24,11 @@
 		1DEF3FB14FBD667C00541BFF /* IdentifierSlugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B54369F081E1B728712CC9 /* IdentifierSlugTests.swift */; };
 		1DFB9CC9D7520C6342B580D2 /* IPCRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173E18BCFC9C0CBADC96556 /* IPCRoundTripTests.swift */; };
 		2063EF5A21DBDB2E5097D885 /* MeowCoreBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */; };
+		2534B8CDD2E40D5F2105C9EF /* ShadowsocksServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F650A5FA59D90978E2D8BC6 /* ShadowsocksServer.swift */; };
 		25931B4F38353E7DF1CD7F5E /* ProxiesDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A0587577F4B11031F0816D /* ProxiesDecodingTests.swift */; };
 		25E66559A88A13B0FEE0233B /* SubscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5369F7A0022B20FF1321D5 /* SubscriptionService.swift */; };
 		2687DFC8A2EC27D66312C06F /* UtilitySessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B3F7EB51045141F84569793 /* UtilitySessionStore.swift */; };
+		27E34E45FFE9A9D2242373E2 /* ShadowsocksURIParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48800BB67F7CB5E42F942A83 /* ShadowsocksURIParser.swift */; };
 		28CB589E0ACE5C617C7DCD42 /* TrafficAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729BDB9DF0375708DCD8F84E /* TrafficAccumulatorTests.swift */; };
 		2A21E16ED84D0DF4A7C140A4 /* clash_emoji_groups_realworld.yaml in Resources */ = {isa = PBXBuildFile; fileRef = F73DB7377F110302EA3E8B4B /* clash_emoji_groups_realworld.yaml */; };
 		2D71AA36DACB626D73AC50A3 /* YamlEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415A45F45F6FA01D8DA04A95 /* YamlEditorView.swift */; };
@@ -37,6 +39,7 @@
 		34358821D3A262F7D08C62D9 /* MeowIPC in Frameworks */ = {isa = PBXBuildFile; productRef = 0CA41BA11AE3954D104A7AB8 /* MeowIPC */; };
 		34B4F8F808C424CBAF8E7EA9 /* MWSharedStore.m in Sources */ = {isa = PBXBuildFile; fileRef = AB83B7A37D165EF0E16A47BA /* MWSharedStore.m */; };
 		3BAE21D06E5B9935E58FDF1B /* MeowAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A693FE7115671D717A87F1DB /* MeowAPITypes.swift */; };
+		43CC40E5E8E7DEEB9E61CEB8 /* ShadowsocksConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2646E6E7241DEDBA8C6127C6 /* ShadowsocksConfigBuilder.swift */; };
 		45310440BCC0654BDE996BA2 /* SubscriptionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0AD4D11A4D395987DD843B /* SubscriptionParserTests.swift */; };
 		458E58A53D18E7E14542FAB8 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC4AC97B3877B1A566FBFF6 /* Profile.swift */; };
 		4660565BBEE9CDFD88BD62AF /* SharedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08020B398C102C110F6A8567 /* SharedStoreTests.swift */; };
@@ -48,6 +51,7 @@
 		4C1FB9714B9308B7577B9622 /* MeowModels in Frameworks */ = {isa = PBXBuildFile; productRef = 564BE37A8BC742522CCABC5E /* MeowModels */; };
 		4E366621A02CAF97E4AA2EF2 /* RulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE160D91FCAFCD07383E8CB5 /* RulesTests.swift */; };
 		4F29B935B393F48182AC7CE4 /* MWIPCListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 329B260F122D91D5DDB24C44 /* MWIPCListener.m */; };
+		4F396A44EF40DD59F1A79D3B /* ShadowsocksConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2286E52FC6D973728DE5D1A8 /* ShadowsocksConfigBuilderTests.swift */; };
 		51B3C9F10FE6A03AFD50A5E6 /* NavRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8D0D6120471BD1DBC4ACFB /* NavRow.swift */; };
 		5247368E57963DA43B22D272 /* UDPProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF0A80A8CEB2105E171334C /* UDPProtocolTests.swift */; };
 		528DCD00B7A73F10142E0455 /* MeowApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF3488443D31DA0A523BC30 /* MeowApp.swift */; };
@@ -64,6 +68,7 @@
 		6092CAC783B65174F68E0606 /* MWTunnelEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 620106BFB5E8593748590EBA /* MWTunnelEngine.m */; };
 		63B152B9AED7714B67D9FA21 /* Country.mmdb in Resources */ = {isa = PBXBuildFile; fileRef = F2B40C39BB5FC5957F42AC74 /* Country.mmdb */; };
 		646AA7E070AB3AB4CD605644 /* RulesYAMLEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D2AA0F7CC09650CF8263EF /* RulesYAMLEditor.swift */; };
+		648D6C8316865A3DFBD6766D /* ShadowsocksURIParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6052B63FD334E86DC81BAE1E /* ShadowsocksURIParserTests.swift */; };
 		66C7B352BBD0B772976ABB1B /* SubscriptionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43280DA576025F244CD1432 /* SubscriptionServiceTests.swift */; };
 		684752187B329EEE17E6EA1C /* MWAppGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = E605B002F990CE95032AA3A8 /* MWAppGroup.m */; };
 		6A844E6BF259DEC60C66D7D9 /* clash_minimal.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 47CD1F1E7DD00599AF2A5238 /* clash_minimal.yaml */; };
@@ -84,6 +89,7 @@
 		90E26674740B7C7141781B01 /* ProxyGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7193B43D94BD4897FEDF967 /* ProxyGroupsView.swift */; };
 		91159B9CB1EDFE43070C3A4E /* GlobalVpnSwitchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF41AF44DDC9B81E01AF637 /* GlobalVpnSwitchBar.swift */; };
 		9212E710474142F878EC5ABC /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B1F7C57B22583A6919A107 /* LogsView.swift */; };
+		938E95C0263F042450113B67 /* ShadowsocksAddServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B378E3EF2591C9CD059E98 /* ShadowsocksAddServiceTests.swift */; };
 		94FA8AB54FFDDD7D188A8C2A /* PacketTunnel.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 459136B958385ACB511D5D14 /* PacketTunnel.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9609134F0D274943E5E18297 /* LogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F1B0B431DA0DD132F917FF /* LogsTests.swift */; };
 		9942BB6B9F5CDAD3CEA4B98E /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED84393AA4FF1CADF9FCC53 /* HomeView.swift */; };
@@ -117,7 +123,9 @@
 		CADE5E260230B0FEB1F6786C /* MWTunnelSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = E8B56935362D1576450CB4A3 /* MWTunnelSettings.m */; };
 		CF37C3706513F515FED5B6FC /* SettingsScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD1BBDA36A305FAAF4B003E /* SettingsScreenTests.swift */; };
 		D0918A7D5C1B3C007EADE22E /* MeowIPC in Frameworks */ = {isa = PBXBuildFile; productRef = 027ADE8989FBD1E3F91B7209 /* MeowIPC */; };
+		D09A565179DB1D6C03527E69 /* AddShadowsocksSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B827CA25C7C1502C8AB3535 /* AddShadowsocksSheet.swift */; };
 		D2FF19F899EE357591812068 /* ProxyGroupModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2EC54BA19FA9CC57BDD2AD /* ProxyGroupModelTests.swift */; };
+		D49CAAAAB4878A24C8A7D52B /* ShadowsocksQRScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1871555B4BB947666ABD54B /* ShadowsocksQRScannerSheet.swift */; };
 		D5E3B0B2C42A294616BB2263 /* DnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711184DB8878CD1F212CEEA3 /* DnsView.swift */; };
 		D95EF7A2FB411B4088E3255C /* URLValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAA1935B322CD5DD66E23F0 /* URLValidationTests.swift */; };
 		DC1D5D2FD5AFDC3D1D3F2602 /* TrafficScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC73D84B5978335B9C07A8A /* TrafficScreenTests.swift */; };
@@ -127,6 +135,7 @@
 		E5EEB30272FBA79B72C45004 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AFFBA5F04A152705EE60CA /* AccessibilityTests.swift */; };
 		E64DA5B39E08AF0DF25BFCBC /* LocalizableParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7002E0BC1FFE0A41FEBE8F6 /* LocalizableParityTests.swift */; };
 		EDFDD3829637E5DE34AD5B02 /* MeowCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B807F37D85605FF0AD1427F5 /* MeowCore.xcframework */; };
+		F29284A5EE821CC192BE2993 /* AddShadowsocksFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A3FCA37BA819ACC0A9D0EB /* AddShadowsocksFlowTests.swift */; };
 		F3F6C8C58BB119BAA42C632B /* ChinaDirectKeywordsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C840E453765151986763DE2B /* ChinaDirectKeywordsTests.swift */; };
 		F453433A7CD958D28F7693DA /* ConnectionsScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E90E01A4CE68C4F872A40B /* ConnectionsScreenTests.swift */; };
 		F789FAB627C81F4087EEE0AF /* PacketTunnelProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 71FF15AE48B5E9FFE60B4051 /* PacketTunnelProvider.m */; };
@@ -185,6 +194,7 @@
 		0539F84A7F111BFF4BDD1840 /* MWSharedStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWSharedStore.h; sourceTree = "<group>"; };
 		06D2AA0F7CC09650CF8263EF /* RulesYAMLEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesYAMLEditor.swift; sourceTree = "<group>"; };
 		08020B398C102C110F6A8567 /* SharedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStoreTests.swift; sourceTree = "<group>"; };
+		0F650A5FA59D90978E2D8BC6 /* ShadowsocksServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksServer.swift; sourceTree = "<group>"; };
 		0F8A47B96274873533987FFA /* MeowTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MeowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1046B4656B3C3717791D82D4 /* EngineBootTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineBootTests.swift; sourceTree = "<group>"; };
 		134693AAF1481D4CF2945CAD /* MeowUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MeowUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -195,8 +205,10 @@
 		1CCF322677C8A124E9D9107D /* MWDiagnosticsRunner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDiagnosticsRunner.m; sourceTree = "<group>"; };
 		1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityScreenTests.swift; sourceTree = "<group>"; };
 		20AB821D2884D05E4EA7E831 /* GeoAssetStager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoAssetStager.swift; sourceTree = "<group>"; };
+		2286E52FC6D973728DE5D1A8 /* ShadowsocksConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksConfigBuilderTests.swift; sourceTree = "<group>"; };
 		24AB2D298F7A38F31686BF15 /* VpnManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnManagerTests.swift; sourceTree = "<group>"; };
 		24F2E3A9014A186B34D8A465 /* MWDarwinBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDarwinBridge.m; sourceTree = "<group>"; };
+		2646E6E7241DEDBA8C6127C6 /* ShadowsocksConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksConfigBuilder.swift; sourceTree = "<group>"; };
 		2D7D7768D31382CD90DFEBA6 /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		2E2B37B72F11B1B2B1118221 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		3172561A6CE70D61D7666597 /* ChinaDirectKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChinaDirectKeywords.swift; sourceTree = "<group>"; };
@@ -213,7 +225,9 @@
 		468AB5369E33BCD92920CF52 /* MWPreferences.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWPreferences.m; sourceTree = "<group>"; };
 		47CD1F1E7DD00599AF2A5238 /* clash_minimal.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = clash_minimal.yaml; sourceTree = "<group>"; };
 		48057A73B8C1C158EB155986 /* MWIPCListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWIPCListener.h; sourceTree = "<group>"; };
+		48800BB67F7CB5E42F942A83 /* ShadowsocksURIParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksURIParser.swift; sourceTree = "<group>"; };
 		4B0AD4D11A4D395987DD843B /* SubscriptionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionParserTests.swift; sourceTree = "<group>"; };
+		4B827CA25C7C1502C8AB3535 /* AddShadowsocksSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddShadowsocksSheet.swift; sourceTree = "<group>"; };
 		5173E18BCFC9C0CBADC96556 /* IPCRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPCRoundTripTests.swift; sourceTree = "<group>"; };
 		5736CEC2431764A6D333891B /* KeychainStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStoreTests.swift; sourceTree = "<group>"; };
 		5BD1BBDA36A305FAAF4B003E /* SettingsScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenTests.swift; sourceTree = "<group>"; };
@@ -221,6 +235,7 @@
 		5EC73D84B5978335B9C07A8A /* TrafficScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficScreenTests.swift; sourceTree = "<group>"; };
 		5EEF0D1CF99CA135B39D3676 /* MWPreferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWPreferences.h; sourceTree = "<group>"; };
 		601ADF66737508CC359C4936 /* SubscriptionConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionConverter.swift; sourceTree = "<group>"; };
+		6052B63FD334E86DC81BAE1E /* ShadowsocksURIParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksURIParserTests.swift; sourceTree = "<group>"; };
 		620106BFB5E8593748590EBA /* MWTunnelEngine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWTunnelEngine.m; sourceTree = "<group>"; };
 		664BEEB7B966973C3D0A5074 /* DailyTrafficAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTrafficAccumulator.swift; sourceTree = "<group>"; };
 		66EEA26ED8A4895932CE53E3 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -289,6 +304,7 @@
 		D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionDeepLink.swift; sourceTree = "<group>"; };
 		D1A7AFDD113E049439EEE4A9 /* MeowShared */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MeowShared; path = MeowShared; sourceTree = SOURCE_ROOT; };
 		D51C2BC68B7800884B68643F /* DiagnosticsLabelParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLabelParserTests.swift; sourceTree = "<group>"; };
+		D5A3FCA37BA819ACC0A9D0EB /* AddShadowsocksFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddShadowsocksFlowTests.swift; sourceTree = "<group>"; };
 		D7A0587577F4B11031F0816D /* ProxiesDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxiesDecodingTests.swift; sourceTree = "<group>"; };
 		DAEF8BEDC4B0E7EF70E37EE1 /* UtilitySessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStoreTests.swift; sourceTree = "<group>"; };
 		DFC4AC97B3877B1A566FBFF6 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
@@ -301,11 +317,13 @@
 		EE160D91FCAFCD07383E8CB5 /* RulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesTests.swift; sourceTree = "<group>"; };
 		EE63F2C20D91AB9B68EB33C8 /* MWAppGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWAppGroup.h; sourceTree = "<group>"; };
 		F0A2F021F1A3C84F902320EB /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		F1871555B4BB947666ABD54B /* ShadowsocksQRScannerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksQRScannerSheet.swift; sourceTree = "<group>"; };
 		F1F87C9BC53D85684F46CF05 /* TrafficView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficView.swift; sourceTree = "<group>"; };
 		F2B40C39BB5FC5957F42AC74 /* Country.mmdb */ = {isa = PBXFileReference; path = Country.mmdb; sourceTree = "<group>"; };
 		F4B2AEF174C775BBB240908B /* meow-ios.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "meow-ios.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F582EC213C10F2BB97940B21 /* ClashConfigLinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClashConfigLinter.swift; sourceTree = "<group>"; };
 		F58373225092C298E65BB090 /* geosite.mrs */ = {isa = PBXFileReference; path = geosite.mrs; sourceTree = "<group>"; };
+		F5B378E3EF2591C9CD059E98 /* ShadowsocksAddServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksAddServiceTests.swift; sourceTree = "<group>"; };
 		F73DB7377F110302EA3E8B4B /* clash_emoji_groups_realworld.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = clash_emoji_groups_realworld.yaml; sourceTree = "<group>"; };
 		FA317DD319BE5DA6206036F1 /* MWEngineLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWEngineLog.m; sourceTree = "<group>"; };
 		FA64C2503B8306CC64B9D23D /* MeowCoreBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeowCoreBridgeTests.swift; sourceTree = "<group>"; };
@@ -435,6 +453,7 @@
 		3E8C8F01F85BB79409FEB60B /* Flows */ = {
 			isa = PBXGroup;
 			children = (
+				D5A3FCA37BA819ACC0A9D0EB /* AddShadowsocksFlowTests.swift */,
 				9CA7DC0A8AEAA9185A7B40F0 /* AddSubscriptionFlowTests.swift */,
 				8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */,
 				3BA2BC08659A01899A4DB2CC /* YamlEditorFlowTests.swift */,
@@ -455,6 +474,7 @@
 		546289FB1F7F3C7197D240BC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				F5B378E3EF2591C9CD059E98 /* ShadowsocksAddServiceTests.swift */,
 				B306CE837FA7A17D7D561877 /* SubscriptionDeepLinkTests.swift */,
 				A43280DA576025F244CD1432 /* SubscriptionServiceTests.swift */,
 				729BDB9DF0375708DCD8F84E /* TrafficAccumulatorTests.swift */,
@@ -500,6 +520,7 @@
 		82D5A212559F590D21A902F8 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				4B827CA25C7C1502C8AB3535 /* AddShadowsocksSheet.swift */,
 				8E8110225EBDEBDC762A0E20 /* ClashYAMLTextView.swift */,
 				8E6DE9E643D70646873B923B /* ConnectionsView.swift */,
 				AF51AD7DD7946AB70970C9A8 /* ContentView.swift */,
@@ -517,6 +538,7 @@
 				BC8D42838BD27620D7F278DE /* RulesEditorView.swift */,
 				8A1CBAFD55A777C3B13296E2 /* RulesView.swift */,
 				F0A2F021F1A3C84F902320EB /* SettingsView.swift */,
+				F1871555B4BB947666ABD54B /* ShadowsocksQRScannerSheet.swift */,
 				3B1E9C4360B99CC50183F32A /* SubscriptionsView.swift */,
 				F1F87C9BC53D85684F46CF05 /* TrafficView.swift */,
 				E56D18B0FBFA455C9F60134A /* UserDiagnosticsView.swift */,
@@ -557,6 +579,8 @@
 				5E114A82C37433E90AFEAD0E /* MeowAPI.swift */,
 				A693FE7115671D717A87F1DB /* MeowAPITypes.swift */,
 				06D2AA0F7CC09650CF8263EF /* RulesYAMLEditor.swift */,
+				2646E6E7241DEDBA8C6127C6 /* ShadowsocksConfigBuilder.swift */,
+				48800BB67F7CB5E42F942A83 /* ShadowsocksURIParser.swift */,
 				601ADF66737508CC359C4936 /* SubscriptionConverter.swift */,
 				D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */,
 				9C5369F7A0022B20FF1321D5 /* SubscriptionService.swift */,
@@ -666,6 +690,7 @@
 				992E16ADDEBA2F4304D4E797 /* EditableRule.swift */,
 				DFC4AC97B3877B1A566FBFF6 /* Profile.swift */,
 				6A820C8680856C83B4C8EF7F /* ProxyGroupModel.swift */,
+				0F650A5FA59D90978E2D8BC6 /* ShadowsocksServer.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -709,6 +734,8 @@
 			isa = PBXGroup;
 			children = (
 				FD9FC97CA0606C12439B0684 /* EmojiGroupSelectNodeTests.swift */,
+				2286E52FC6D973728DE5D1A8 /* ShadowsocksConfigBuilderTests.swift */,
+				6052B63FD334E86DC81BAE1E /* ShadowsocksURIParserTests.swift */,
 				4B0AD4D11A4D395987DD843B /* SubscriptionParserTests.swift */,
 			);
 			path = Parsing;
@@ -1054,6 +1081,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E5EEB30272FBA79B72C45004 /* AccessibilityTests.swift in Sources */,
+				F29284A5EE821CC192BE2993 /* AddShadowsocksFlowTests.swift in Sources */,
 				FA6DFC3CA7B13A278CB1D630 /* AddSubscriptionFlowTests.swift in Sources */,
 				7770F0EA76C4181C58C020EC /* AppShellTests.swift in Sources */,
 				0AAE287B7127912BEE7EFC15 /* HomeScreenTests.swift in Sources */,
@@ -1105,6 +1133,9 @@
 				D2FF19F899EE357591812068 /* ProxyGroupModelTests.swift in Sources */,
 				4E366621A02CAF97E4AA2EF2 /* RulesTests.swift in Sources */,
 				C7B7EACD6297D7AA66065602 /* RulesYAMLEditorTests.swift in Sources */,
+				938E95C0263F042450113B67 /* ShadowsocksAddServiceTests.swift in Sources */,
+				4F396A44EF40DD59F1A79D3B /* ShadowsocksConfigBuilderTests.swift in Sources */,
+				648D6C8316865A3DFBD6766D /* ShadowsocksURIParserTests.swift in Sources */,
 				4660565BBEE9CDFD88BD62AF /* SharedStoreTests.swift in Sources */,
 				AB4AFCDA6C326D173F7C6D01 /* SubscriptionDeepLinkTests.swift in Sources */,
 				45310440BCC0654BDE996BA2 /* SubscriptionParserTests.swift in Sources */,
@@ -1122,6 +1153,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D09A565179DB1D6C03527E69 /* AddShadowsocksSheet.swift in Sources */,
 				DCC6938C0A43984B033BCD68 /* AppIPCBridge.swift in Sources */,
 				ADBD29F9A34A3AF34057D104 /* AppModel.swift in Sources */,
 				B2761759D155051F32B46F2D /* AppModelContainer.swift in Sources */,
@@ -1154,6 +1186,10 @@
 				8E43F6904E5AAD529AACBA1C /* RulesView.swift in Sources */,
 				646AA7E070AB3AB4CD605644 /* RulesYAMLEditor.swift in Sources */,
 				A247AFB42C2CB73BACCD3CB0 /* SettingsView.swift in Sources */,
+				43CC40E5E8E7DEEB9E61CEB8 /* ShadowsocksConfigBuilder.swift in Sources */,
+				D49CAAAAB4878A24C8A7D52B /* ShadowsocksQRScannerSheet.swift in Sources */,
+				2534B8CDD2E40D5F2105C9EF /* ShadowsocksServer.swift in Sources */,
+				27E34E45FFE9A9D2242373E2 /* ShadowsocksURIParser.swift in Sources */,
 				9ADDC891C0BCC6053E86E2E2 /* SubscriptionConverter.swift in Sources */,
 				07BE855FF6DC83A07129C654 /* SubscriptionDeepLink.swift in Sources */,
 				25E66559A88A13B0FEE0233B /* SubscriptionService.swift in Sources */,

--- a/project.yml
+++ b/project.yml
@@ -43,7 +43,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.2"
-        CFBundleVersion: "2026062802"
+        CFBundleVersion: "2026070401"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -58,6 +58,7 @@ targets:
         NSAppTransportSecurity:
           NSAllowsArbitraryLoads: false
           NSAllowsLocalNetworking: true
+        NSCameraUsageDescription: "meow uses the camera to scan Shadowsocks server QR codes."
         ITSAppUsesNonExemptEncryption: false
         CFBundleURLTypes:
           - CFBundleURLName: com.tangzixiang.meow.deeplink
@@ -188,7 +189,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.2"
-        CFBundleVersion: "2026062802"
+        CFBundleVersion: "2026070401"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

- New **Add Shadowsocks Server** entry in the Subscriptions "+" menu.
- **Manual entry**: server / port / cipher picker / password / UDP toggle, plus an optional **ECH-TLS Tunnel** section (SIP003 `ech-tls-tunnel`: `sni`, `path`, `ech_config`, `fingerprint`, `fast_open`).
- **QR scan** via VisionKit `DataScannerViewController` (new `NSCameraUsageDescription`; graceful fallback on Simulator/Mac or denied camera), plus a paste field. Both feed `ShadowsocksURIParser`: SIP002 (base64url or plain userinfo), legacy whole-body base64, IPv6 literals, SIP003 `plugin` query param. Non-ECH plugins pass through verbatim.
- **Template-generated local config**: saving renders a profile from a built-in template derived from the desktop `ech-tls-mihomo.yaml` reference config (proxy-providers, credentials, and deployment-specific domains stripped). Servers are injected into `proxies` and the 默认 group; domain hosts additionally get `fake-ip-filter`, sniffer `skip-domain`, and `DOMAIN-SUFFIX,…,直连` rule entries — mirroring how the reference config treats its own server domains. The rendered YAML is validated by `meow_engine_validate_config` before anything is persisted.
- Repeated adds re-render the **same** generated profile (identified by a line-1 marker comment); same-name adds replace that server; previous rendering is kept as `yamlBackup`; the active config is re-written if the generated profile is selected.
- `project.yml` `CFBundleVersion` synced to `2026070401` so `xcodegen generate` is idempotent again.

## Path B local-CI attestation

1. ✅ `swiftformat --lint .` — 0 violations (`0/111 files require formatting`).
2. ✅ `swiftlint --strict` — 0 violations (exit 0).
3. ✅ `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -testLanguage en` — full scheme run (MeowTests + MeowUITests + MeowIntegrationTests) **TEST SUCCEEDED**, including 17 new unit tests (URI parser, config builder incl. FFI engine validation of rendered YAML, add-service accumulation/replacement) — 158 MeowTests total. New `MeowUITests/AddShadowsocksFlowTests` (manual-entry end-to-end incl. in-app engine validation, and link-fill) run separately after joining the project: `xcodebuild test … -only-testing:MeowUITests/AddShadowsocksFlowTests -testLanguage en` — **TEST SUCCEEDED** (2/2).
4. ✅ `git diff origin/main...HEAD --stat` verified — 16 files, all intended (5 new App sources, 4 new test files, SubscriptionsView/SubscriptionService edits, en+zh-Hans strings, project.yml + regenerated pbxproj/Info.plist).

No `.github/workflows` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)