### PR TITLE
feat(ui): discoverable rename for subscription profiles

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -79,6 +79,8 @@
 "subscriptions.row.updatedAgo %@" = "Updated %@ ago";
 "subscriptions.row.a11y.edit %@" = "Edit YAML for %@";
 "subscriptions.row.a11y.refresh %@" = "Refresh %@";
+"subscriptions.row.a11y.editInfo %@" = "Rename or edit info for %@";
+"subscriptions.row.a11y.editInfoHint" = "Opens the name and URL editor";
 "subscriptions.toolbar.a11y.add" = "Add subscription";
 "subscriptions.toolbar.addFromURL" = "Add from URL";
 "subscriptions.toolbar.importFromFile" = "Import from iCloud Drive…";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -85,6 +85,8 @@
 "subscriptions.row.updatedAgo %@" = "%@前更新";
 "subscriptions.row.a11y.edit %@" = "编辑 %@ 的 YAML";
 "subscriptions.row.a11y.refresh %@" = "刷新 %@";
+"subscriptions.row.a11y.editInfo %@" = "重命名或编辑 %@ 的信息";
+"subscriptions.row.a11y.editInfoHint" = "打开名称与 URL 编辑器";
 "subscriptions.toolbar.a11y.add" = "添加订阅";
 "subscriptions.toolbar.addFromURL" = "从 URL 添加";
 "subscriptions.toolbar.importFromFile" = "从 iCloud 云盘导入…";

--- a/App/Sources/AppModelContainer.swift
+++ b/App/Sources/AppModelContainer.swift
@@ -19,6 +19,7 @@ enum AppModelContainer {
                 cloudKitDatabase: .none,
             )
             let container = try ModelContainer(for: schema, configurations: config)
+            seedProfileForUITestsIfRequested(container)
             return Holder(container: container)
         } catch {
             fatalError("Unable to open SwiftData store: \(error)")
@@ -39,6 +40,27 @@ enum AppModelContainer {
         for suffix in ["", "-wal", "-shm"] {
             try? FileManager.default.removeItem(at: URL(fileURLWithPath: url.path + suffix))
         }
+    }
+
+    /// `-SeedProfile <name>` inserts a single local profile so UI tests that
+    /// act on an existing row (rename, delete, select) don't have to drive the
+    /// add flow — whose password SecureField triggers an iOS "Save Password?"
+    /// dialog that covers the list.
+    private static func seedProfileForUITestsIfRequested(_ container: ModelContainer) {
+        let args = ProcessInfo.processInfo.arguments
+        guard args.contains("-UITests"), let idx = args.firstIndex(of: "-SeedProfile"),
+              idx + 1 < args.count
+        else { return }
+        let name = args[idx + 1]
+        let context = ModelContext(container)
+        let profile = Profile(
+            name: name,
+            url: "",
+            yamlContent: "proxies:\n  - name: seed\n    type: direct\n",
+            yamlBackup: "proxies:\n  - name: seed\n    type: direct\n",
+        )
+        context.insert(profile)
+        try? context.save()
     }
 
     private static func storeURL() throws -> URL {

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -25,27 +25,38 @@ struct SubscriptionsView: View {
                 ForEach(profiles) { profile in
                     GlassCard {
                         HStack {
-                            Image(systemName: profile.isSelected ? "largecircle.fill.circle" : "circle")
-                                .foregroundStyle(profile.isSelected ? AppTheme.connected : .secondary)
-                                .accessibilityHidden(true)
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(profile.name).font(.headline)
-                                Text(
-                                    "subscriptions.row.updatedAgo \(profile.lastUpdated, style: .relative)",
-                                    comment: "Subscription row subtitle; %@ = relative time since last update",
-                                )
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            // Selection is scoped to the leading label so the
+                            // trailing action buttons stay independently
+                            // tappable (a whole-row onTapGesture otherwise
+                            // shadows them and steals taps in UI tests).
+                            Button {
+                                try? service.select(profile)
+                            } label: {
+                                HStack {
+                                    Image(systemName: profile.isSelected ? "largecircle.fill.circle" : "circle")
+                                        .foregroundStyle(profile.isSelected ? AppTheme.connected : .secondary)
+                                        .accessibilityHidden(true)
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(profile.name).font(.headline)
+                                        Text(
+                                            "subscriptions.row.updatedAgo \(profile.lastUpdated, style: .relative)",
+                                            comment: "Subscription row subtitle; %@ = relative time since last update",
+                                        )
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    }
+                                    Spacer(minLength: 0)
+                                }
+                                .contentShape(Rectangle())
                             }
-                            .accessibilityElement(children: .combine)
+                            .buttonStyle(.plain)
                             .accessibilityValue(Text(
                                 profile.isSelected
                                     ? "subscriptions.row.a11y.selected"
                                     : "subscriptions.row.a11y.notSelected",
                             ))
                             .accessibilityHint(Text("subscriptions.row.a11y.selectHint"))
-                            .accessibilityAddTraits(.isButton)
-                            Spacer()
+                            .accessibilityIdentifier("subscriptions.row.select")
                             Button {
                                 editing = profile
                             } label: {
@@ -69,14 +80,27 @@ struct SubscriptionsView: View {
                                 .accessibilityLabel(Text("subscriptions.row.a11y.refresh \(profile.name)"))
                                 .accessibilityHint(Text("subscriptions.row.a11y.refreshHint"))
                             }
+                            Button {
+                                editingInfo = profile
+                            } label: {
+                                Image(systemName: "square.and.pencil")
+                                    .frame(minWidth: 44, minHeight: 44)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityLabel(Text("subscriptions.row.a11y.editInfo \(profile.name)"))
+                            .accessibilityHint(Text("subscriptions.row.a11y.editInfoHint"))
+                            .accessibilityIdentifier("subscriptions.row.editInfoButton")
                         }
                     }
+                    // `.contain` keeps the row id on the group without
+                    // clobbering the child buttons' own identifiers (a bare
+                    // identifier on a container propagates to every child).
+                    .accessibilityElement(children: .contain)
                     .accessibilityIdentifier("subscription.row.\(profile.name)")
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
-                    .contentShape(Rectangle())
-                    .onTapGesture { try? service.select(profile) }
                     .swipeActions(edge: .leading) {
                         Button {
                             editingInfo = profile
@@ -358,10 +382,12 @@ private struct EditSubscriptionInfoSheet: View {
             Form {
                 Section {
                     TextField("subscriptions.add.field.name", text: $name)
+                        .accessibilityIdentifier("subscriptions.editInfo.nameField")
                     TextField("subscriptions.add.field.url", text: $url)
                         .keyboardType(.URL)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled(true)
+                        .accessibilityIdentifier("subscriptions.editInfo.urlField")
                 } footer: {
                     Text("subscriptions.editInfo.footer")
                 }
@@ -382,6 +408,7 @@ private struct EditSubscriptionInfoSheet: View {
                         }
                     }
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .accessibilityIdentifier("subscriptions.editInfo.saveButton")
                 }
             }
         }

--- a/MeowUITests/Flows/RenameSubscriptionFlowTests.swift
+++ b/MeowUITests/Flows/RenameSubscriptionFlowTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+/// Flow: rename a profile via the row's edit-info button → Edit Info sheet.
+/// The profile is seeded via `-SeedProfile` so the test doesn't drive the add
+/// flow (whose SecureField triggers an iOS "Save Password?" dialog).
+final class RenameSubscriptionFlowTests: XCTestCase {
+    override func setUp() {
+        continueAfterFailure = false
+    }
+
+    func testRenamePersists() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-UITests", "-ResetState", "-SeedProfile", "My Servers"]
+        app.launch()
+
+        app.tabBars.buttons["Subscriptions"].tap()
+        XCTAssertTrue(app.staticTexts["My Servers"].waitForExistence(timeout: 5))
+
+        // The always-visible edit-info button opens the rename sheet.
+        let editInfo = app.buttons["subscriptions.row.editInfoButton"]
+        XCTAssertTrue(editInfo.waitForExistence(timeout: 5))
+        editInfo.tap()
+
+        let nameField = app.textFields["subscriptions.editInfo.nameField"]
+        XCTAssertTrue(nameField.waitForExistence(timeout: 5))
+        // Cursor to the end of the text, clear it, type the new name.
+        nameField.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+        let existing = (nameField.value as? String) ?? ""
+        nameField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: existing.count + 2))
+        nameField.typeText("SG Servers")
+        app.buttons["subscriptions.editInfo.saveButton"].tap()
+
+        XCTAssertTrue(app.staticTexts["SG Servers"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["My Servers"].exists)
+    }
+}

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		D95EF7A2FB411B4088E3255C /* URLValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAA1935B322CD5DD66E23F0 /* URLValidationTests.swift */; };
 		DC1D5D2FD5AFDC3D1D3F2602 /* TrafficScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC73D84B5978335B9C07A8A /* TrafficScreenTests.swift */; };
 		DCC6938C0A43984B033BCD68 /* AppIPCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */; };
+		DE9A4BC5630A1A55FD1880C4 /* RenameSubscriptionFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25242F15DCC48F0C6C9BAD2C /* RenameSubscriptionFlowTests.swift */; };
 		DF9A0976E5BE73EF1F9DFC91 /* VpnToggleFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */; };
 		E164E98C5E2EDB5B326E2B98 /* UtilityScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */; };
 		E5EEB30272FBA79B72C45004 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AFFBA5F04A152705EE60CA /* AccessibilityTests.swift */; };
@@ -208,6 +209,7 @@
 		2286E52FC6D973728DE5D1A8 /* ShadowsocksConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksConfigBuilderTests.swift; sourceTree = "<group>"; };
 		24AB2D298F7A38F31686BF15 /* VpnManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnManagerTests.swift; sourceTree = "<group>"; };
 		24F2E3A9014A186B34D8A465 /* MWDarwinBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDarwinBridge.m; sourceTree = "<group>"; };
+		25242F15DCC48F0C6C9BAD2C /* RenameSubscriptionFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameSubscriptionFlowTests.swift; sourceTree = "<group>"; };
 		2646E6E7241DEDBA8C6127C6 /* ShadowsocksConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksConfigBuilder.swift; sourceTree = "<group>"; };
 		2D7D7768D31382CD90DFEBA6 /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		2E2B37B72F11B1B2B1118221 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
@@ -455,6 +457,7 @@
 			children = (
 				D5A3FCA37BA819ACC0A9D0EB /* AddShadowsocksFlowTests.swift */,
 				9CA7DC0A8AEAA9185A7B40F0 /* AddSubscriptionFlowTests.swift */,
+				25242F15DCC48F0C6C9BAD2C /* RenameSubscriptionFlowTests.swift */,
 				8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */,
 				3BA2BC08659A01899A4DB2CC /* YamlEditorFlowTests.swift */,
 			);
@@ -1086,6 +1089,7 @@
 				7770F0EA76C4181C58C020EC /* AppShellTests.swift in Sources */,
 				0AAE287B7127912BEE7EFC15 /* HomeScreenTests.swift in Sources */,
 				528DCD00B7A73F10142E0455 /* MeowApp.swift in Sources */,
+				DE9A4BC5630A1A55FD1880C4 /* RenameSubscriptionFlowTests.swift in Sources */,
 				CF37C3706513F515FED5B6FC /* SettingsScreenTests.swift in Sources */,
 				DC1D5D2FD5AFDC3D1D3F2602 /* TrafficScreenTests.swift in Sources */,
 				E164E98C5E2EDB5B326E2B98 /* UtilityScreenTests.swift in Sources */,


### PR DESCRIPTION
## Summary

- Adds an **always-visible edit-info button** (`square.and.pencil`) to each subscription row, opening the existing Edit Info sheet (name + URL). Rename was previously only reachable via an undiscoverable leading swipe.
- **Row restructure**: profile selection moves from a whole-row `onTapGesture` onto an explicit leading `Button`, so the trailing action buttons (edit YAML, refresh, edit info) are independently tappable rather than being shadowed by the row-wide tap target. Adds `.accessibilityElement(children: .contain)` so the row's identifier no longer propagates onto and clobbers the child buttons' own ids.
- The leading swipe → Edit Info action is retained.

## Testability

- New `-SeedProfile <name>` UI-test launch arg (`AppModelContainer`, gated on `-UITests`) inserts one local profile so row-level flows don't drive the add flow — whose password SecureField pops an iOS "Save Password?" springboard dialog that covers the list.
- New `RenameSubscriptionFlowTests` drives edit-info button → sheet → rename → save end to end.

## Path B local-CI attestation

1. ✅ `swiftformat --lint .` — 0 violations.
2. ✅ `swiftlint --strict` — 0 violations.
3. ✅ `xcodebuild test … -only-testing:MeowTests -only-testing:MeowUITests -testLanguage en` — MeowTests 161/31 passed; **full MeowUITests suite passed** (row restructure re-verified against AppShell + AddShadowsocks flows).
4. ✅ `git diff origin/main...HEAD --stat` — 6 files, all intended (SubscriptionsView, AppModelContainer, en+zh-Hans strings, new test, regenerated pbxproj).

No `.github/workflows` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)