### PR TITLE
fix(metadata): remove Android references from App Store descriptions

### DIFF
--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -1,4 +1,4 @@
-meow is a native iOS port of the Android "meow" client — a full meow-rs proxy engine wrapped in a SwiftUI iOS 26 Liquid Glass UI, with traffic carried by a NetworkExtension packet tunnel provider.
+meow is a native iOS proxy client built on the meow-rs engine — wrapped in a SwiftUI iOS 26 Liquid Glass UI, with traffic carried by a NetworkExtension packet tunnel provider.
 
 If you have ever managed a Clash or meow-rs configuration, meow will feel familiar. Subscribe to a YAML config, choose a proxy group, flip the toggle, and your traffic flows through the proxy engine — all on-device, with no cloud component.
 

--- a/fastlane/metadata/zh-Hans/description.txt
+++ b/fastlane/metadata/zh-Hans/description.txt
@@ -1,4 +1,4 @@
-meow 是 Android 版 "meow" 客户端的原生 iOS 版本——将完整的 meow-rs 代理引擎包裹在 SwiftUI iOS 26 Liquid Glass 界面中，通过 NetworkExtension 数据包隧道承载流量。
+meow 是基于 meow-rs 引擎的原生 iOS 代理客户端——采用 SwiftUI iOS 26 Liquid Glass 界面，通过 NetworkExtension 数据包隧道承载流量。
 
 如果你管理过 Clash 或 meow-rs 配置，使用 meow 会非常顺手：订阅一份 YAML 配置、选择代理组、打开开关——你的流量便会通过代理引擎转发。整个过程完全在设备上完成，没有任何云端组件。
 

--- a/metadata/en-US/description.txt
+++ b/metadata/en-US/description.txt
@@ -1,4 +1,4 @@
-meow is a native iOS port of the Android "meow" client — a full meow-rs proxy engine wrapped in a SwiftUI iOS 26 Liquid Glass UI, with traffic carried by a NetworkExtension packet tunnel provider.
+meow is a native iOS proxy client built on the meow-rs engine — wrapped in a SwiftUI iOS 26 Liquid Glass UI, with traffic carried by a NetworkExtension packet tunnel provider.
 
 If you have ever managed a Clash or meow-rs configuration, meow will feel familiar. Subscribe to a YAML config, choose a proxy group, flip the toggle, and your traffic flows through the proxy engine — all on-device, with no cloud component.
 
@@ -20,6 +20,8 @@ The app does not collect analytics, subscription URLs, proxy credentials, config
 REQUIREMENTS
 • iOS 26 or later (iPhone and iPad)
 • A proxy subscription you trust — meow does not provide any proxy servers
+
+meow is a one-time purchase, with no in-app purchases and no subscription fees. "Subscription" here means a proxy configuration URL (a Clash-style config subscription) that you supply — not a paid subscription.
 
 PUBLIC BETA
 This release is a public beta. Some features are in active development. Please report issues on GitHub or via the in-app feedback link.

--- a/metadata/zh-Hans/description.txt
+++ b/metadata/zh-Hans/description.txt
@@ -1,4 +1,4 @@
-meow 是 Android 版 "meow" 客户端的原生 iOS 版本——将完整的 meow-rs 代理引擎包裹在 SwiftUI iOS 26 Liquid Glass 界面中，通过 NetworkExtension 数据包隧道承载流量。
+meow 是基于 meow-rs 引擎的原生 iOS 代理客户端——采用 SwiftUI iOS 26 Liquid Glass 界面，通过 NetworkExtension 数据包隧道承载流量。
 
 如果你管理过 Clash 或 meow-rs 配置，使用 meow 会非常顺手：订阅一份 YAML 配置、选择代理组、打开开关——你的流量便会通过代理引擎转发。整个过程完全在设备上完成，没有任何云端组件。
 
@@ -20,6 +20,8 @@ Shadowsocks、Trojan、VLESS 出站协议（支持 TLS、WebSocket、gRPC、H2 �
 系统要求
 • iOS 26 或更高版本（iPhone、iPad）
 • 一份你信任的代理订阅——meow 本身不提供任何代理服务器
+
+meow 为一次性买断的付费应用，不含任何内购或订阅收费。本页所述"订阅"指你自行提供的代理配置链接（Clash 风格配置订阅），并非付费订阅。
 
 公开测试版
 本次为公开测试版本。部分功能仍在开发中。请通过 GitHub 或 App 内的反馈链接报告问题。


### PR DESCRIPTION
## Summary
- Apple rejected v1.3.2 under **Guideline 2.3.10 — Accurate Metadata** for third-party platform (Android) references in the App Store description.
- The live en-US description had already been hand-edited on ASC, but the **zh-Hans description still opened with "Android 版"** — this is what "still includes" referred to.
- Rewrites the opening line in both locales to describe the app on its own terms:
  - en-US: "meow is a native iOS proxy client built on the meow-rs engine — …"
  - zh-Hans: "meow 是基于 meow-rs 引擎的原生 iOS 代理客户端——…"
- Syncs the root `metadata/` tree with the newer `fastlane/metadata/` copy (one-time-purchase paragraph).
- Live ASC descriptions for both locales were patched to match via the ASC API on 2026-07-11 (verified: no "Android" remains).

## Merge path
Path A (non-code): diff touches only `metadata/` and `fastlane/metadata/` text files — no Swift/Rust/YAML-workflow/project files. Admin rebase-merge without waiting for CI per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)