### PR TITLE
feat(screenshots): -ScreenshotDemo launch flag for populated App Store captures

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026070401</string>
+	<string>2026071101</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>

--- a/App/Sources/AppModelContainer.swift
+++ b/App/Sources/AppModelContainer.swift
@@ -20,6 +20,7 @@ enum AppModelContainer {
             )
             let container = try ModelContainer(for: schema, configurations: config)
             seedProfileForUITestsIfRequested(container)
+            seedScreenshotDemoIfRequested(container)
             return Holder(container: container)
         } catch {
             fatalError("Unable to open SwiftData store: \(error)")
@@ -62,6 +63,69 @@ enum AppModelContainer {
         context.insert(profile)
         try? context.save()
     }
+
+    /// `-ScreenshotDemo` populates the store for the App Store screenshot
+    /// harness (scripts/capture-screenshots.sh): two subscription profiles
+    /// (one selected, so the switch bar shows a name) and a week of daily
+    /// traffic, so captures don't show fresh-install empty states.
+    private static func seedScreenshotDemoIfRequested(_ container: ModelContainer) {
+        let args = ProcessInfo.processInfo.arguments
+        guard args.contains("-UITests"), args.contains("-ScreenshotDemo") else { return }
+        let context = ModelContext(container)
+        context.insert(Profile(
+            name: "Meow Cloud",
+            url: "https://example.com/meow-cloud.yaml",
+            yamlContent: screenshotDemoYAML,
+            isSelected: true,
+            lastUpdated: Date(timeIntervalSinceNow: -25 * 60),
+            txBytes: 486_539_264,
+            rxBytes: 3_842_146_304,
+        ))
+        context.insert(Profile(
+            name: "Home Lab",
+            url: "https://example.com/home-lab.yaml",
+            yamlContent: screenshotDemoYAML,
+            lastUpdated: Date(timeIntervalSinceNow: -2 * 86400),
+        ))
+        // Non-uniform but deterministic per-day bytes so the 7-day chart has
+        // visible shape in every capture.
+        let txMB: [Int64] = [148, 212, 96, 324, 187, 259, 173]
+        let rxMB: [Int64] = [1120, 1730, 640, 2410, 1490, 2050, 1310]
+        for i in 0 ..< 7 {
+            guard let day = Calendar.current.date(byAdding: .day, value: -i, to: .now) else { continue }
+            context.insert(DailyTraffic(
+                date: DailyTraffic.key(for: day),
+                txBytes: txMB[i] * 1_048_576,
+                rxBytes: rxMB[i] * 1_048_576,
+            ))
+        }
+        try? context.save()
+    }
+
+    /// Mirrors `MeowAPI.mockProxies()` so the seeded profiles stay plausible
+    /// if anyone opens the YAML editor during a capture.
+    private static let screenshotDemoYAML = """
+    mode: rule
+    proxies:
+      - { name: "Tokyo 01", type: ss, server: tokyo.example.com, port: 8388, cipher: aes-256-gcm, password: demo }
+      - name: "Singapore 02"
+        type: vless
+        server: sg.example.com
+        port: 443
+        uuid: 9f36c112-be0a-4b3c-9c5f-7d1f04d1a6e3
+      - { name: "US West 03", type: trojan, server: us.example.com, port: 443, password: demo }
+    proxy-groups:
+      - name: Proxy
+        type: select
+        proxies: [Auto, "Tokyo 01", "Singapore 02", "US West 03"]
+      - name: Auto
+        type: url-test
+        url: "http://www.gstatic.com/generate_204"
+        interval: 300
+        proxies: ["Tokyo 01", "Singapore 02", "US West 03"]
+    rules:
+      - MATCH,Proxy
+    """
 
     private static func storeURL() throws -> URL {
         let dir = try FileManager.default

--- a/App/Sources/Services/AppIPCBridge.swift
+++ b/App/Sources/Services/AppIPCBridge.swift
@@ -112,6 +112,16 @@ private extension AppIPCBridge {
     }
 
     func startMockIPC() {
+        if Self.screenshotDemoRequested {
+            currentState = .init(stage: .connected, startedAt: Date(timeIntervalSinceNow: -3600))
+            try? SharedStore.writeState(currentState)
+            currentTraffic = Self.mockTraffic(tick: 0)
+            relayMemstats(currentTraffic)
+            onTrafficDidUpdate?(currentTraffic)
+            configureMockTrafficTask()
+            return
+        }
+
         let persisted = Self.shouldResetMockState ? nil : SharedStore.readState()
         currentState = if let persisted, persisted.errorMessage == nil {
             persisted
@@ -180,6 +190,13 @@ private extension AppIPCBridge {
         let args = ProcessInfo.processInfo.arguments
         guard let i = args.firstIndex(of: "-screenshotTab"), i + 1 < args.count else { return false }
         return args[i + 1] == "traffic"
+    }
+
+    /// Mirrors `VpnManager.screenshotDemoRequested` — the screenshot harness
+    /// launches already connected, with the mock traffic ticker running.
+    nonisolated static var screenshotDemoRequested: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITests") && args.contains("-ScreenshotDemo")
     }
 
     nonisolated static func mockTraffic(tick: Int64) -> TrafficSnapshot {

--- a/App/Sources/Services/MeowAPI.swift
+++ b/App/Sources/Services/MeowAPI.swift
@@ -458,7 +458,7 @@ private extension MeowAPI {
             "Tokyo 01": .init(name: "Tokyo 01", type: "Shadowsocks", now: nil, all: nil, history: history),
             "Singapore 02": .init(
                 name: "Singapore 02",
-                type: "Vmess",
+                type: "VLESS",
                 now: nil,
                 all: nil,
                 history: singaporeHistory,

--- a/App/Sources/Services/VpnManager.swift
+++ b/App/Sources/Services/VpnManager.swift
@@ -356,7 +356,20 @@ private extension VpnManager {
         ProcessInfo.processInfo.arguments.contains("-ResetState")
     }
 
+    /// `-ScreenshotDemo` (with `-UITests`) makes the mock tunnel launch
+    /// already connected, so the App Store screenshot harness captures the
+    /// connected header and a populated Proxy Groups tab instead of the
+    /// fresh-install disconnected state.
+    nonisolated static var screenshotDemoRequested: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITests") && args.contains("-ScreenshotDemo")
+    }
+
     func refreshMockTunnel() {
+        if Self.screenshotDemoRequested {
+            applyMockState(.init(stage: .connected, startedAt: Date(timeIntervalSinceNow: -3600)))
+            return
+        }
         if Self.shouldResetMockState {
             applyMockState(.init(stage: .stopped))
             return

--- a/App/Sources/Views/ProxyGroupsView.swift
+++ b/App/Sources/Views/ProxyGroupsView.swift
@@ -83,6 +83,11 @@ struct ProxyGroupsView: View {
 }
 
 private extension ProxyGroupsView {
+    static var screenshotDemoRequested: Bool {
+        let args = ProcessInfo.processInfo.arguments
+        return args.contains("-UITests") && args.contains("-ScreenshotDemo")
+    }
+
     func refresh() async {
         guard vpnManager.stage == .connected else {
             groups = []
@@ -93,6 +98,11 @@ private extension ProxyGroupsView {
             let resp = try await meowAPI.getProxies()
             groups = ProxyGroupModel.build(from: resp.proxies)
             loadError = nil
+            // Screenshot harness: expand the first group so captures show
+            // member proxies and delay badges, not just collapsed cards.
+            if Self.screenshotDemoRequested, expandedGroupID == nil {
+                expandedGroupID = groups.first?.id
+            }
         } catch {
             loadError = String(
                 localized: "home.error.apiUnavailable",

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>2026070401</string>
+	<string>2026071101</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -43,7 +43,7 @@ targets:
       properties:
         CFBundleDisplayName: meow
         CFBundleShortVersionString: "1.3.2"
-        CFBundleVersion: "2026070401"
+        CFBundleVersion: "2026071101"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -189,7 +189,7 @@ targets:
       properties:
         CFBundleDisplayName: meow Tunnel
         CFBundleShortVersionString: "1.3.2"
-        CFBundleVersion: "2026070401"
+        CFBundleVersion: "2026071101"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider

--- a/scripts/capture-screenshots.sh
+++ b/scripts/capture-screenshots.sh
@@ -64,7 +64,7 @@ for dev in "${DEVICE_NAMES[@]}"; do
             name="${entry%%:*}"; tab="${entry##*:}"
             xcrun simctl terminate "$udid" "$BUNDLE_ID" >/dev/null 2>&1 || true
             xcrun simctl launch "$udid" "$BUNDLE_ID" \
-                -UITests -ResetState \
+                -UITests -ResetState -ScreenshotDemo \
                 -AppleLanguages "($locale)" -AppleLocale "$loc_underscore" \
                 -screenshotTab "$tab" >/dev/null
             sleep 3


### PR DESCRIPTION
## Summary
Apple's 2.3.10 rejection asked for screenshots that highlight the app's main features; the old captures launched with `-ResetState` into a fresh install, so 3 of 4 screens showed empty/disconnected states.

New `-ScreenshotDemo` launch arg (honored only alongside `-UITests`; simulator mock paths only — no production behavior change):
- `AppModelContainer` seeds two subscription profiles (one selected) + 7 days of `DailyTraffic`
- `VpnManager` / `AppIPCBridge` launch the mock tunnel already connected → Proxy Groups populates from the existing `mockProxies()` fixture, mock traffic ticker runs
- `ProxyGroupsView` auto-expands the first group so captures show member proxies with delay badges
- `mockProxies()` Singapore node type `Vmess` → `VLESS` (VMess is not a shipped protocol; keeps screenshots consistent with the description)
- `scripts/capture-screenshots.sh` passes the new flag

Also bumps `CFBundleVersion` to `2026071101` (app + PacketTunnel + project.yml).

All 16 screenshots (iPhone 6.9" + iPad 13", en-US + zh-Hans) recaptured and visually verified: connected header with profile name, populated subscription list, expanded proxy group with delay badges, non-zero traffic tiles + 7-day chart.

## Path B local-CI attestation
1. `swiftformat --lint .` → 0/112 files require formatting ✅
2. `swiftlint --strict` → 0 violations ✅
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests ... -testLanguage en` → 161 tests, 0 failures (56 env-gated skips) ✅
   `... -only-testing:MeowUITests ... -testLanguage en` → 33 executed, 0 failures (23 env-gated skips) ✅
4. `git diff origin/main...HEAD --stat` verified → exactly the 9 intended files (Swift ×5, Info.plist ×2, project.yml, capture script); no accidental additions ✅

No Rust / FFI / workflow files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)