### PR TITLE
fix(geo): version-aware staging so bundled geo assets update on upgrade

### DIFF
--- a/App/Sources/Services/GeoAssetStager.swift
+++ b/App/Sources/Services/GeoAssetStager.swift
@@ -1,14 +1,44 @@
+import CryptoKit
 import Foundation
 import MeowModels
 import os
 
 /// Copies the bundled GeoIP / ASN / geosite databases into
-/// `AppGroup.meowConfigDir` on launch when they are absent there. The Rust
-/// engine reads them from that directory at `meow_engine_start`, so staging
-/// at app launch means the first connect never needs to download anything.
-/// Files already on disk are left alone — re-running the stager does not
-/// clobber a user's later overwrite or a meow-rs `geodata.auto-update`
-/// refresh.
+/// `AppGroup.meowConfigDir` on launch, and keeps them current across app
+/// upgrades. The Rust engine reads them from that directory at
+/// `meow_engine_start` — its own geodata updater is deliberately disabled in
+/// the FFI to stay within the Network Extension memory budget (see
+/// `engine.rs`), so this is the *only* thing that ever refreshes these files.
+///
+/// Every staged file is tracked in a small JSON manifest
+/// (`geo-asset-manifest.json`, alongside the databases) recording, per file,
+/// whether the app or the user owns it and a fingerprint of the bundled
+/// asset that was last staged:
+///
+///   - Missing or zero-byte destination → always (re)staged from the bundle,
+///     regardless of any prior provenance. An empty file has no user content
+///     worth preserving.
+///   - Existing nonzero destination with **no manifest entry** → a
+///     pre-#292 install. No shipped code path lets a user supply their own
+///     Country.mmdb / GeoLite2-ASN.mmdb / geosite.mrs (verified: no Settings
+///     UI, no import flow — the only geo-related user surface is the
+///     `geox-url:` fallback in `EffectiveConfigWriter`, which merely tells
+///     the engine's own — disabled — downloader where to fetch from). So an
+///     unmanifested nonzero file is a stale first-ever-staged bundled copy.
+///     It is replaced once and recorded as `.bundled`, after which normal
+///     version tracking takes over.
+///   - Existing nonzero destination manifested `.bundled` → replaced
+///     atomically (temp file + rename, same directory) only when the
+///     bundled asset's hash has changed since the manifest was last written.
+///     To avoid hashing multi-megabyte `.mmdb`/`.mrs` files on every launch,
+///     the manifest caches the app version the hash was computed under; the
+///     bundled asset is only re-hashed when that version differs from the
+///     running app's.
+///   - Existing nonzero destination manifested `.user` → never touched.
+///     Nothing in the shipped app sets this provenance today, but the
+///     manifest format supports it so a future user-override path (or
+///     manual edit of the manifest) is respected rather than silently
+///     overwritten.
 enum GeoAssetStager {
     private static let log = Logger(subsystem: "com.tangzixiang.meow", category: "geo-asset-stager")
 
@@ -21,38 +51,201 @@ enum GeoAssetStager {
         "geosite.mrs",
     ]
 
-    static func stageIfNeeded() {
-        let destDir = AppGroup.meowConfigDir
+    private static let manifestFileName = "geo-asset-manifest.json"
+
+    enum Provenance: String, Codable {
+        case bundled
+        case user
+    }
+
+    struct ManifestEntry: Codable, Equatable {
+        var provenance: Provenance
+        /// Hex SHA-256 of the bundled asset as of the last time it was
+        /// staged (or confirmed unchanged).
+        var bundledHash: String
+        /// `CFBundleShortVersionString+CFBundleVersion` cached alongside
+        /// `bundledHash` so an unchanged app build never re-hashes the
+        /// bundled file — only a version change triggers a re-check.
+        var appVersion: String
+    }
+
+    struct Manifest: Codable {
+        var entries: [String: ManifestEntry] = [:]
+    }
+
+    /// - Parameters:
+    ///   - destDir: Directory staged assets live in. Defaults to the real
+    ///     App Group config directory; tests inject a temp directory.
+    ///   - sourceDir: When non-nil, bundled assets are read from this
+    ///     directory instead of `Bundle.main` — how tests supply fixture
+    ///     content. Production callers leave this `nil`.
+    ///   - appVersion: Cheap fingerprint of "which build is running", used
+    ///     to skip re-hashing unchanged bundled assets. Defaults to the
+    ///     real app's `CFBundleShortVersionString`/`CFBundleVersion`.
+    static func stageIfNeeded(
+        destDir: URL = AppGroup.meowConfigDir,
+        sourceDir: URL? = nil,
+        appVersion: String = currentAppVersion(),
+    ) {
         do {
             try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
         } catch {
-            log.error("create meowConfigDir failed: \(error.localizedDescription, privacy: .public)")
+            log.error("create dest dir failed: \(error.localizedDescription, privacy: .public)")
             return
         }
 
-        for name in assets {
-            let dest = destDir.appending(path: name)
-            let existingSize = (try? FileManager.default.attributesOfItem(atPath: dest.path)[.size] as? Int) ?? 0
-            if existingSize > 0 { continue }
+        let manifestURL = destDir.appending(path: manifestFileName)
+        var manifest = loadManifest(at: manifestURL)
 
-            guard let src = Bundle.main.url(forResource: name, withExtension: nil, subdirectory: "GeoData")
-                ?? Bundle.main.url(forResource: name, withExtension: nil)
-            else {
+        for name in assets {
+            guard let src = sourceURL(for: name, sourceDir: sourceDir) else {
                 log.error("bundle missing \(name, privacy: .public)")
                 continue
             }
-
-            do {
-                if FileManager.default.fileExists(atPath: dest.path) {
-                    try FileManager.default.removeItem(at: dest)
-                }
-                try FileManager.default.copyItem(at: src, to: dest)
-                log.notice("staged \(name, privacy: .public)")
-            } catch {
-                log.error(
-                    "stage \(name, privacy: .public) failed: \(error.localizedDescription, privacy: .public)",
-                )
-            }
+            let dest = destDir.appending(path: name)
+            processAsset(name: name, src: src, dest: dest, manifest: &manifest, appVersion: appVersion)
         }
+
+        saveManifest(manifest, to: manifestURL)
+    }
+
+    // MARK: - Per-asset staging
+
+    private static func processAsset(
+        name: String,
+        src: URL,
+        dest: URL,
+        manifest: inout Manifest,
+        appVersion: String,
+    ) {
+        guard fileSize(at: dest) > 0 else {
+            // Missing or corrupt/zero-byte destination: nothing to preserve,
+            // stage fresh regardless of any prior manifest entry.
+            stageFresh(name: name, src: src, dest: dest, manifest: &manifest, appVersion: appVersion)
+            return
+        }
+
+        guard let entry = manifest.entries[name] else {
+            // Existing file predates the manifest. See the type-level doc
+            // comment for why this is treated as an app-managed copy rather
+            // than a user override.
+            log.notice("migrating unmanifested \(name, privacy: .public) to app-managed")
+            stageFresh(name: name, src: src, dest: dest, manifest: &manifest, appVersion: appVersion)
+            return
+        }
+
+        guard entry.provenance == .bundled else {
+            log.notice("skipping user-managed \(name, privacy: .public)")
+            return
+        }
+
+        guard entry.appVersion != appVersion else {
+            // Same build we last checked under — the bundled asset can't
+            // have changed without a new build. Skip hashing entirely.
+            return
+        }
+
+        guard let bundledHash = try? sha256Hex(of: src) else {
+            log.error("hash bundled \(name, privacy: .public) failed")
+            return
+        }
+
+        guard bundledHash != entry.bundledHash else {
+            // Bundle content is unchanged despite the version bump — just
+            // refresh the cached version so we don't re-hash again until
+            // the *next* version bump.
+            manifest.entries[name]?.appVersion = appVersion
+            return
+        }
+
+        do {
+            try atomicReplace(src: src, dest: dest)
+            manifest.entries[name] = ManifestEntry(
+                provenance: .bundled, bundledHash: bundledHash, appVersion: appVersion,
+            )
+            log.notice("upgraded \(name, privacy: .public)")
+        } catch {
+            log.error("upgrade \(name, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private static func stageFresh(
+        name: String,
+        src: URL,
+        dest: URL,
+        manifest: inout Manifest,
+        appVersion: String,
+    ) {
+        do {
+            let bundledHash = try sha256Hex(of: src)
+            try atomicReplace(src: src, dest: dest)
+            manifest.entries[name] = ManifestEntry(
+                provenance: .bundled, bundledHash: bundledHash, appVersion: appVersion,
+            )
+            log.notice("staged \(name, privacy: .public)")
+        } catch {
+            log.error("stage \(name, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Copies `src` to a temp file in `dest`'s own directory, then renames
+    /// it over `dest`. Same-directory temp + rename keeps the swap atomic
+    /// (single filesystem, single `rename()` syscall under the hood) so a
+    /// reader never observes a partially-written destination file.
+    private static func atomicReplace(src: URL, dest: URL) throws {
+        let tmp = dest.deletingLastPathComponent()
+            .appending(path: ".\(dest.lastPathComponent).staging-\(UUID().uuidString)")
+        try FileManager.default.copyItem(at: src, to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        _ = try FileManager.default.replaceItemAt(dest, withItemAt: tmp)
+    }
+
+    // MARK: - Sources
+
+    private static func sourceURL(for name: String, sourceDir: URL?) -> URL? {
+        if let sourceDir {
+            let url = sourceDir.appending(path: name)
+            return FileManager.default.fileExists(atPath: url.path) ? url : nil
+        }
+        return Bundle.main.url(forResource: name, withExtension: nil, subdirectory: "GeoData")
+            ?? Bundle.main.url(forResource: name, withExtension: nil)
+    }
+
+    static func currentAppVersion(bundle: Bundle = .main) -> String {
+        let short = (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0.0"
+        let build = (bundle.infoDictionary?["CFBundleVersion"] as? String) ?? "0"
+        return "\(short)+\(build)"
+    }
+
+    // MARK: - Manifest persistence
+
+    private static func loadManifest(at url: URL) -> Manifest {
+        guard let data = try? Data(contentsOf: url),
+              let manifest = try? JSONDecoder().decode(Manifest.self, from: data)
+        else {
+            return Manifest()
+        }
+        return manifest
+    }
+
+    private static func saveManifest(_ manifest: Manifest, to url: URL) {
+        do {
+            let data = try JSONEncoder().encode(manifest)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            log.error("write manifest failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Filesystem helpers
+
+    private static func fileSize(at url: URL) -> Int {
+        (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
+    }
+
+    private static func sha256Hex(of url: URL) throws -> String {
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/MeowTests/Services/GeoAssetStagerTests.swift
+++ b/MeowTests/Services/GeoAssetStagerTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+@testable import meow_ios
+import Testing
+
+/// `GeoAssetStager` is the only thing that ever refreshes the bundled
+/// Country.mmdb / GeoLite2-ASN.mmdb / geosite.mrs on an existing install —
+/// the Rust engine's own geodata updater is deliberately disabled to stay
+/// within the Network Extension memory budget (issue #292). Each test
+/// stands up its own temp "bundle" and "App Group" directory so nothing
+/// touches the real `AppGroup.meowConfigDir` or `Bundle.main`.
+@Suite("GeoAssetStager", .tags(.service))
+struct GeoAssetStagerTests {
+    /// Files `GeoAssetStager` knows how to stage. Kept in sync with the
+    /// private `assets` list inside the stager itself.
+    private static let assetNames = ["Country.mmdb", "GeoLite2-ASN.mmdb", "geosite.mrs"]
+
+    private func makeTempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appending(path: "GeoAssetStagerTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Writes all three asset names into `dir` with `content`, so a run
+    /// against `dir` as the `sourceDir` never logs a "bundle missing" for
+    /// the files this test isn't focused on.
+    private func writeBundle(at dir: URL, content: String) throws {
+        for name in Self.assetNames {
+            try content.write(to: dir.appending(path: name), atomically: true, encoding: .utf8)
+        }
+    }
+
+    private func readManifest(in destDir: URL) -> GeoAssetStager.Manifest? {
+        guard let data = try? Data(contentsOf: destDir.appending(path: "geo-asset-manifest.json")) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(GeoAssetStager.Manifest.self, from: data)
+    }
+
+    @Test
+    func `first install stages every bundled asset into an empty dest dir`() throws {
+        let bundleDir = makeTempDir()
+        let destDir = makeTempDir()
+        try writeBundle(at: bundleDir, content: "v1")
+
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.0+1")
+
+        for name in Self.assetNames {
+            let staged = try String(contentsOf: destDir.appending(path: name), encoding: .utf8)
+            #expect(staged == "v1")
+        }
+        let manifest = try #require(readManifest(in: destDir))
+        for name in Self.assetNames {
+            let entry = try #require(manifest.entries[name])
+            #expect(entry.provenance == .bundled)
+            #expect(entry.appVersion == "1.0+1")
+        }
+    }
+
+    @Test
+    func `unchanged bundle content is never rewritten, even across a version bump`() throws {
+        let bundleDir = makeTempDir()
+        let destDir = makeTempDir()
+        try writeBundle(at: bundleDir, content: "same-content")
+
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.0+1")
+        let dest = destDir.appending(path: "Country.mmdb")
+        let firstStagedAt = try #require(
+            try FileManager.default.attributesOfItem(atPath: dest.path)[.modificationDate] as? Date,
+        )
+
+        // Re-run under the SAME version: should short-circuit before even
+        // looking at file content (cheap-fingerprint path).
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.0+1")
+        // Re-run under a NEW version but with byte-identical bundle content:
+        // hash matches, so still no rewrite — only the cached version moves.
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.1+2")
+
+        let lastModifiedAt = try #require(
+            try FileManager.default.attributesOfItem(atPath: dest.path)[.modificationDate] as? Date,
+        )
+        #expect(firstStagedAt == lastModifiedAt)
+
+        let manifest = try #require(readManifest(in: destDir))
+        let entry = try #require(manifest.entries["Country.mmdb"])
+        #expect(entry.appVersion == "1.1+2")
+    }
+
+    @Test
+    func `upgraded bundle content replaces the app-managed destination`() throws {
+        let bundleDir = makeTempDir()
+        let destDir = makeTempDir()
+        try writeBundle(at: bundleDir, content: "v1")
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.0+1")
+
+        // Ship a new build with newer bundled content.
+        try writeBundle(at: bundleDir, content: "v2-newer-geodata")
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.1+2")
+
+        for name in Self.assetNames {
+            let staged = try String(contentsOf: destDir.appending(path: name), encoding: .utf8)
+            #expect(staged == "v2-newer-geodata")
+        }
+        let manifest = try #require(readManifest(in: destDir))
+        let entry = try #require(manifest.entries["Country.mmdb"])
+        #expect(entry.appVersion == "1.1+2")
+    }
+
+    @Test
+    func `corrupt zero-byte destination is re-staged regardless of manifest state`() throws {
+        let bundleDir = makeTempDir()
+        let destDir = makeTempDir()
+        try writeBundle(at: bundleDir, content: "v1")
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.0+1")
+
+        // Simulate corruption: truncate one staged file to zero bytes, but
+        // leave its manifest entry (and cached version) untouched — the
+        // cheap-fingerprint short-circuit must not win over an empty file.
+        try Data().write(to: destDir.appending(path: "Country.mmdb"))
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.0+1")
+
+        let staged = try String(contentsOf: destDir.appending(path: "Country.mmdb"), encoding: .utf8)
+        #expect(staged == "v1")
+    }
+
+    @Test
+    func `user-managed provenance is preserved even when the bundle changes`() throws {
+        let bundleDir = makeTempDir()
+        let destDir = makeTempDir()
+        try writeBundle(at: bundleDir, content: "v1")
+
+        // Simulate a user-supplied override recorded in the manifest ahead
+        // of time (no shipped UI does this today; the format supports it).
+        try "user-supplied-content".write(
+            to: destDir.appending(path: "Country.mmdb"), atomically: true, encoding: .utf8,
+        )
+        var manifest = GeoAssetStager.Manifest()
+        manifest.entries["Country.mmdb"] = GeoAssetStager.ManifestEntry(
+            provenance: .user, bundledHash: "irrelevant", appVersion: "0.0+0",
+        )
+        let data = try JSONEncoder().encode(manifest)
+        try data.write(to: destDir.appending(path: "geo-asset-manifest.json"))
+
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.1+2")
+
+        let staged = try String(contentsOf: destDir.appending(path: "Country.mmdb"), encoding: .utf8)
+        #expect(staged == "user-supplied-content")
+        let after = try #require(readManifest(in: destDir))
+        #expect(after.entries["Country.mmdb"]?.provenance == .user)
+    }
+
+    @Test
+    func `legacy unmanifested nonzero file is migrated to app-managed and staged once`() throws {
+        let bundleDir = makeTempDir()
+        let destDir = makeTempDir()
+        try writeBundle(at: bundleDir, content: "v2-newer-geodata")
+
+        // Simulate a pre-#292 install: a nonzero destination file with no
+        // manifest at all (the old "any nonzero file wins" behavior never
+        // wrote one).
+        try "stale-first-ever-staged-copy".write(
+            to: destDir.appending(path: "Country.mmdb"), atomically: true, encoding: .utf8,
+        )
+
+        GeoAssetStager.stageIfNeeded(destDir: destDir, sourceDir: bundleDir, appVersion: "1.1+2")
+
+        let staged = try String(contentsOf: destDir.appending(path: "Country.mmdb"), encoding: .utf8)
+        #expect(staged == "v2-newer-geodata")
+        let manifest = try #require(readManifest(in: destDir))
+        #expect(manifest.entries["Country.mmdb"]?.provenance == .bundled)
+    }
+}

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0AAE287B7127912BEE7EFC15 /* HomeScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59B5D27EF37B635FC5B38AA /* HomeScreenTests.swift */; };
 		0B13BCBE3F3A575D7E213399 /* TunnelLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB11E2BC5612E27CCE83B0DC /* TunnelLifecycleTests.swift */; };
 		0BDA436570A2C655E8210F0C /* TunnelSettingsLANExclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703008DEDF15E37B8C951A9A /* TunnelSettingsLANExclusionTests.swift */; };
+		0D7669C4305C607B8C449A54 /* GeoAssetStagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8C1AC6AD4590D6827E6188 /* GeoAssetStagerTests.swift */; };
 		0F59DC382F259493E472348F /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819D62E17DBC5BC82869FA81 /* URLProtocolStub.swift */; };
 		1413B423DEE5A4AE17B4F677 /* DiagnosticsLabelParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51C2BC68B7800884B68643F /* DiagnosticsLabelParserTests.swift */; };
 		16FA48C705C2691763DE4187 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8895187DE158A91BFC1775BE /* Localizable.strings */; };
@@ -253,6 +254,7 @@
 		71FF15AE48B5E9FFE60B4051 /* PacketTunnelProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PacketTunnelProvider.m; sourceTree = "<group>"; };
 		729BDB9DF0375708DCD8F84E /* TrafficAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficAccumulatorTests.swift; sourceTree = "<group>"; };
 		797EA53C272DDA3EC6E73E6F /* MWDarwinBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWDarwinBridge.h; sourceTree = "<group>"; };
+		7D8C1AC6AD4590D6827E6188 /* GeoAssetStagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoAssetStagerTests.swift; sourceTree = "<group>"; };
 		7D936CF5D2CCA1B2D180C2D6 /* AppShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShellTests.swift; sourceTree = "<group>"; };
 		7ED84393AA4FF1CADF9FCC53 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		819D62E17DBC5BC82869FA81 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
@@ -477,6 +479,7 @@
 		546289FB1F7F3C7197D240BC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				7D8C1AC6AD4590D6827E6188 /* GeoAssetStagerTests.swift */,
 				F5B378E3EF2591C9CD059E98 /* ShadowsocksAddServiceTests.swift */,
 				B306CE837FA7A17D7D561877 /* SubscriptionDeepLinkTests.swift */,
 				A43280DA576025F244CD1432 /* SubscriptionServiceTests.swift */,
@@ -1126,6 +1129,7 @@
 				1413B423DEE5A4AE17B4F677 /* DiagnosticsLabelParserTests.swift in Sources */,
 				9D59A8F980E180CECE858F27 /* DnsTests.swift in Sources */,
 				74FE3E67A25CF1CE3E141EE2 /* EmojiGroupSelectNodeTests.swift in Sources */,
+				0D7669C4305C607B8C449A54 /* GeoAssetStagerTests.swift in Sources */,
 				1DEF3FB14FBD667C00541BFF /* IdentifierSlugTests.swift in Sources */,
 				5915355710B88CF6038756E6 /* KeychainStoreTests.swift in Sources */,
 				E64DA5B39E08AF0DF25BFCBC /* LocalizableParityTests.swift in Sources */,


### PR DESCRIPTION
## Summary

`GeoAssetStager` used to skip any destination file whose size was nonzero, which meant an existing install kept the *first* `Country.mmdb` / `GeoLite2-ASN.mmdb` / `geosite.mrs` it ever staged. Since the FFI deliberately disables the engine's own geodata updater to stay within the NE memory budget (`engine.rs`), shipping newer bundled assets in an app update had no effect on upgrades.

This PR makes the stager version-aware:

- **Manifest.** A small JSON manifest (`geo-asset-manifest.json`, stored alongside the databases in `AppGroup.meowConfigDir`) records, per file: `provenance` (`bundled` | `user`), the SHA-256 of the bundled asset that was staged (`bundledHash`), and the app version (`CFBundleShortVersionString+CFBundleVersion`) the hash was computed under (`appVersion`).
- **Staging policy** (runs at app launch, in the app process only — never in the extension):
  - Missing or zero-byte destination → stage from the bundle and record.
  - Manifested `bundled` + bundled hash changed → **atomic replace** (copy to a temp file in the same directory, then `replaceItemAt` rename) and manifest update.
  - Manifested `user` → never touched.
- **Cheap fingerprint.** The multi-MB bundled databases are only re-hashed when the running app version differs from the manifest's cached `appVersion`; on an unchanged build the stager does a single `stat` per file and exits. If a version bump ships byte-identical assets, the hash comparison prevents a rewrite and only the cached version advances.

## Migration decision (existing installs, no manifest)

A nonzero destination file with **no manifest entry** is treated as **app-managed**: it is replaced once from the current bundle and recorded as `bundled`, after which normal version tracking applies.

Rationale: I searched the codebase and docs for any user-facing path that lets a user supply their own geo databases — there is none. No Settings UI, no file-import flow, and no document type touches these files. The only geo-related user surface is the `geox-url:` fallback `EffectiveConfigWriter` injects into the effective config, which merely tells the engine's *disabled* downloader where to fetch from (see the `run_on_startup` removal note in `core/rust/meow-ios-ffi/src/engine.rs`). So an unmanifested nonzero file can only be a stale copy the app itself staged before this PR — exactly the population issue #292 wants fixed. The `user` provenance is still honored by the stager (and covered by tests) so a future override path — or a manual manifest edit by an advanced user — is respected rather than clobbered.

## Tests

New `MeowTests/Services/GeoAssetStagerTests.swift` (temp directories + injectable `destDir`/`sourceDir`/`appVersion`, no real App Group or `Bundle.main` involved):

- first install (empty dir) → all three assets staged + manifest written
- unchanged bundle → no rewrite across same-version relaunch **and** across a version bump with identical bytes (mtime unchanged; cached version advances)
- upgraded bundle → destination replaced, manifest updated
- corrupt/zero-byte destination → re-staged even though the manifest's cached version matches
- user-managed provenance → preserved even when the bundle changes
- legacy unmanifested nonzero file → migrated to app-managed and replaced once

Fixes #292

## Local CI attestation (CLAUDE.md Path B)

- [x] `swiftformat --lint .` → `0/113 files require formatting` (0 violations)
- [x] `swiftlint --strict` → `Done linting! Found 0 violations, 0 serious in 100 files.`
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,id=563DC80C-2BAB-4D2D-8355-C03EBFF82C17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → `** TEST SUCCEEDED **` — MeowTests: `Test run with 167 tests in 32 suites passed after 29.701 seconds` (includes the new `GeoAssetStager` suite: `Suite "GeoAssetStager" passed after 0.084 seconds`); MeowIntegrationTests: `Test run with 26 tests in 4 suites passed after 0.081 seconds`
- [x] `git diff origin/main...HEAD --stat` → only `App/Sources/Services/GeoAssetStager.swift`, `MeowTests/Services/GeoAssetStagerTests.swift`, `meow-ios.xcodeproj/project.pbxproj` (regenerated via `scripts/generate-xcodeproj.sh` for the new test file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
