### PR TITLE
Fix profile sync, traffic history, log retargeting, and deep-link imports

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -91,6 +91,21 @@
 "subscriptions.toolbar.addShadowsocks" = "Add Shadowsocks Server";
 
 
+/* Deep-link import confirmation (meow://connect) */
+"deepLinkImport.nav.title" = "Import Subscription";
+"deepLinkImport.section.subscription" = "This link wants to add:";
+"deepLinkImport.field.name" = "Name";
+"deepLinkImport.field.host" = "Host";
+"deepLinkImport.warning.insecure" = "Insecure connection — this profile can be tampered with in transit. Prefer an https:// link if the provider offers one.";
+"deepLinkImport.warning.acknowledge" = "I understand the risk of importing over HTTP";
+"deepLinkImport.notice.duplicate" = "A subscription with this URL is already imported. Continuing will update it in place instead of adding a duplicate.";
+"deepLinkImport.button.import" = "Import";
+"deepLinkImport.button.update" = "Update Existing Subscription";
+"deepLinkImport.button.importAndActivate" = "Import & Activate";
+"a11y.deepLinkImport.cancel" = "Cancel import";
+"deepLinkImport.a11y.url %@" = "Subscription URL: %@";
+
+
 /* Add Shadowsocks server sheet */
 "ssAdd.nav.title" = "Add Shadowsocks";
 "ssAdd.section.link" = "Link";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -97,6 +97,21 @@
 "subscriptions.toolbar.addShadowsocks" = "添加 Shadowsocks 服务器";
 
 
+/* Deep-link import confirmation (meow://connect) */
+"deepLinkImport.nav.title" = "导入订阅";
+"deepLinkImport.section.subscription" = "此链接想要添加：";
+"deepLinkImport.field.name" = "名称";
+"deepLinkImport.field.host" = "主机";
+"deepLinkImport.warning.insecure" = "不安全的连接 — 此配置在传输过程中可能被篡改。如果服务商提供 https:// 链接，请优先使用。";
+"deepLinkImport.warning.acknowledge" = "我了解通过 HTTP 导入的风险";
+"deepLinkImport.notice.duplicate" = "已导入过此网址对应的订阅。继续操作将就地更新它，而不会新增重复项。";
+"deepLinkImport.button.import" = "导入";
+"deepLinkImport.button.update" = "更新现有订阅";
+"deepLinkImport.button.importAndActivate" = "导入并激活";
+"a11y.deepLinkImport.cancel" = "取消导入";
+"deepLinkImport.a11y.url %@" = "订阅网址：%@";
+
+
 /* Add Shadowsocks server sheet */
 "ssAdd.nav.title" = "添加 Shadowsocks";
 "ssAdd.section.link" = "链接";

--- a/App/Sources/Models/DailyTraffic.swift
+++ b/App/Sources/Models/DailyTraffic.swift
@@ -18,6 +18,7 @@ final class DailyTraffic {
     static func key(for date: Date, calendar: Calendar = .current) -> String {
         let formatter = DateFormatter()
         formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: date)

--- a/App/Sources/Services/DailyTrafficAccumulator.swift
+++ b/App/Sources/Services/DailyTrafficAccumulator.swift
@@ -13,15 +13,28 @@ import SwiftData
 /// (via the shared-container snapshot + `.traffic` Darwin notification). We
 /// diff successive snapshots and add the delta to today's bucket. Edge cases:
 ///
-/// - **Engine restart** — new cumulative is lower than the previous anchor.
-///   We re-anchor to the new value and skip the delta (otherwise a restart
-///   would produce a large negative delta and appear as traffic loss).
-/// - **Midnight rollover** — the bucket key is recomputed on every write via
-///   `DailyTraffic.key(for: .now)`, so the first delta after 00:00 naturally
-///   lands in the new day's bucket without a scheduler.
+/// - **Engine restart mid-session** — new cumulative is lower than the
+///   previous in-memory anchor. We re-anchor to the new value and skip the
+///   delta (otherwise a restart would produce a large negative delta and
+///   appear as traffic loss).
+/// - **Midnight rollover during a live tick** — ticks arrive every ~500ms, so
+///   the bucket key recomputed on every write via `DailyTraffic.key(for:)`
+///   naturally lands in the new day's bucket without a scheduler.
+/// - **App relaunch while the tunnel kept running** (issue #291) — this
+///   accumulator only lives in the app process. The extension keeps counting
+///   while the app is suspended or terminated, so the *first* snapshot after
+///   a fresh launch used to be anchored with zero delta, silently dropping
+///   every byte transferred while the app was dead. We now persist a
+///   reconciliation baseline (`TrafficBaseline`) to the App Group on every
+///   ingest, and on the first ingest after `start()` we diff against that
+///   baseline instead of just anchoring — see `reconcileAfterRelaunch`.
 @MainActor
 final class DailyTrafficAccumulator {
     private let modelContext: ModelContext
+    private let snapshotProvider: TrafficSnapshotProviding
+    private let baselineStore: TrafficBaselineStoring
+    private let calendar: Calendar
+    private let now: () -> Date
     private let log = Logger(subsystem: "com.tangzixiang.meow.app", category: "daily-traffic")
 
     private var lastUp: Int64 = 0
@@ -29,13 +42,24 @@ final class DailyTrafficAccumulator {
     private var haveAnchor = false
     private var observer: DarwinObserver?
 
-    init(modelContext: ModelContext) {
+    init(
+        modelContext: ModelContext,
+        snapshotProvider: TrafficSnapshotProviding = SharedStoreSnapshotProvider(),
+        baselineStore: TrafficBaselineStoring = SharedStoreTrafficBaselineStore(),
+        calendar: Calendar = .current,
+        now: @escaping () -> Date = Date.init,
+    ) {
         self.modelContext = modelContext
+        self.snapshotProvider = snapshotProvider
+        self.baselineStore = baselineStore
+        self.calendar = calendar
+        self.now = now
     }
 
     func start() {
-        // Seed the anchor from whatever's currently in the shared store so the
-        // first post-start delta doesn't double-count the cumulative counter.
+        // The first ingest after start() reconciles against whatever
+        // baseline survived from the previous process instead of just
+        // anchoring — see `reconcileAfterRelaunch`.
         ingestCurrent()
         observer = DarwinBridge.addObserver(for: .traffic) { [weak self] in
             Task { @MainActor in self?.ingestCurrent() }
@@ -47,18 +71,36 @@ final class DailyTrafficAccumulator {
         observer = nil
     }
 
-    private func ingestCurrent() {
-        guard let snapshot = SharedStore.readTraffic() else { return }
+    /// Not private: `TrafficAccumulatorTests` calls this directly to
+    /// simulate a `.traffic` Darwin-notification tick without wiring the
+    /// real notification path.
+    func ingestCurrent() {
+        guard let snapshot = snapshotProvider.currentSnapshot() else { return }
+        let generation = snapshotProvider.currentGeneration()
+        let timestamp = now()
+
         defer {
             lastUp = snapshot.uploadBytes
             lastDown = snapshot.downloadBytes
             haveAnchor = true
+            // Persist the fresh baseline on every ingest (not just at
+            // start()) so a later app kill reconciles from a near-real-time
+            // anchor rather than replaying bytes already credited in this
+            // session.
+            baselineStore.saveBaseline(TrafficBaseline(
+                uploadBytes: snapshot.uploadBytes,
+                downloadBytes: snapshot.downloadBytes,
+                generation: generation,
+                capturedAt: timestamp,
+            ))
         }
 
-        // First snapshot after start(): just anchor, no delta yet.
-        guard haveAnchor else { return }
+        guard haveAnchor else {
+            reconcileAfterRelaunch(current: snapshot, generation: generation, at: timestamp)
+            return
+        }
 
-        // Counter reset (engine restart). Re-anchor, don't back-fill.
+        // Counter reset (engine restart) mid-session. Re-anchor, don't back-fill.
         if snapshot.uploadBytes < lastUp || snapshot.downloadBytes < lastDown {
             log.notice("counter reset detected — re-anchoring without writing a delta")
             return
@@ -66,9 +108,70 @@ final class DailyTrafficAccumulator {
 
         let deltaUp = snapshot.uploadBytes - lastUp
         let deltaDown = snapshot.downloadBytes - lastDown
-        if deltaUp == 0, deltaDown == 0 { return }
+        creditToday(deltaUp: deltaUp, deltaDown: deltaDown, at: timestamp)
+    }
 
-        let key = DailyTraffic.key(for: .now)
+    /// Handles the first snapshot ingested since this accumulator instance
+    /// was created — i.e. right after `start()`, which for the app this is
+    /// always either a fresh install or a relaunch. Reconciles the persisted
+    /// baseline (if any) against the current cumulative counters:
+    ///
+    /// - No persisted baseline → nothing to reconcile (fresh install, or the
+    ///   app has never ingested a snapshot before). Anchor only.
+    /// - Persisted baseline with a *different* (or unknown) engine
+    ///   generation → the extension's engine was stopped and restarted since
+    ///   the baseline was captured, so the counters may have reset. We never
+    ///   diff across a generation change — anchor only.
+    /// - Persisted baseline with the *same* generation but counters that
+    ///   went backwards → shouldn't happen for a continuously-running
+    ///   engine, but if it does we anchor only rather than risk a negative
+    ///   delta.
+    /// - Persisted baseline with the same generation and counters that
+    ///   advanced → the engine kept counting while the app was dead. Credit
+    ///   the delta to history, attributed across the day(s) the offline
+    ///   interval spanned (see `TrafficDaySplit`).
+    private func reconcileAfterRelaunch(current: TrafficSnapshot, generation: Date?, at timestamp: Date) {
+        guard let baseline = baselineStore.loadBaseline() else { return }
+
+        guard
+            let baselineGeneration = baseline.generation,
+            let generation,
+            generation == baselineGeneration
+        else {
+            log.notice("engine generation changed since last run — anchoring without a relaunch delta")
+            return
+        }
+
+        guard current.uploadBytes >= baseline.uploadBytes, current.downloadBytes >= baseline.downloadBytes else {
+            log.notice("counters went backwards for an unchanged engine generation — anchoring without a delta")
+            return
+        }
+
+        let deltaUp = current.uploadBytes - baseline.uploadBytes
+        let deltaDown = current.downloadBytes - baseline.downloadBytes
+        guard deltaUp != 0 || deltaDown != 0 else { return }
+
+        log.notice(
+            "crediting offline bytes: up=\(deltaUp, privacy: .public) down=\(deltaDown, privacy: .public)",
+        )
+
+        for credit in TrafficDaySplit.credits(
+            deltaUp: deltaUp,
+            deltaDown: deltaDown,
+            from: baseline.capturedAt,
+            to: timestamp,
+            calendar: calendar,
+        ) {
+            writeBucket(key: credit.key, up: credit.up, down: credit.down)
+        }
+    }
+
+    private func creditToday(deltaUp: Int64, deltaDown: Int64, at timestamp: Date) {
+        guard deltaUp != 0 || deltaDown != 0 else { return }
+        writeBucket(key: DailyTraffic.key(for: timestamp, calendar: calendar), up: deltaUp, down: deltaDown)
+    }
+
+    private func writeBucket(key: String, up: Int64, down: Int64) {
         let predicate = #Predicate<DailyTraffic> { $0.date == key }
         let descriptor = FetchDescriptor<DailyTraffic>(predicate: predicate)
         do {
@@ -79,11 +182,135 @@ final class DailyTrafficAccumulator {
                 entry = DailyTraffic(date: key)
                 modelContext.insert(entry)
             }
-            entry.txBytes += deltaUp
-            entry.rxBytes += deltaDown
+            entry.txBytes += up
+            entry.rxBytes += down
             try modelContext.save()
         } catch {
             log.error("bucket write failed: \(error.localizedDescription, privacy: .public)")
         }
+    }
+}
+
+/// Abstracts the extension's shared-container traffic snapshot so tests can
+/// supply canned sequences without touching the real App Group (which
+/// `fatalError`s without the App Group entitlement).
+protocol TrafficSnapshotProviding {
+    func currentSnapshot() -> TrafficSnapshot?
+    /// The engine-generation identity associated with `currentSnapshot()` —
+    /// see `TrafficBaseline.generation`.
+    func currentGeneration() -> Date?
+}
+
+/// Production `TrafficSnapshotProviding`: reads the extension's live traffic
+/// snapshot and `VpnState.startedAt` from the shared container.
+struct SharedStoreSnapshotProvider: TrafficSnapshotProviding {
+    func currentSnapshot() -> TrafficSnapshot? {
+        SharedStore.readTraffic()
+    }
+
+    func currentGeneration() -> Date? {
+        SharedStore.readState()?.startedAt
+    }
+}
+
+/// Abstracts persistence of `DailyTrafficAccumulator`'s reconciliation
+/// baseline so tests can substitute in-memory storage instead of the real
+/// App Group `UserDefaults` suite.
+protocol TrafficBaselineStoring {
+    func loadBaseline() -> TrafficBaseline?
+    func saveBaseline(_ baseline: TrafficBaseline)
+}
+
+/// Production `TrafficBaselineStoring`: the App Group `UserDefaults` suite,
+/// via `SharedStore`.
+struct SharedStoreTrafficBaselineStore: TrafficBaselineStoring {
+    func loadBaseline() -> TrafficBaseline? {
+        SharedStore.readTrafficBaseline()
+    }
+
+    func saveBaseline(_ baseline: TrafficBaseline) {
+        try? SharedStore.writeTrafficBaseline(baseline)
+    }
+}
+
+/// The midnight-attribution policy for crediting a byte delta that may span
+/// an offline interval longer than a single day.
+///
+/// We don't know *when* within `[start, end)` the bytes actually moved —
+/// the extension only exposes a cumulative counter, not per-day buckets —
+/// so we attribute the delta to each calendar day proportionally by the
+/// fraction of wall-clock time that fell on that day. This degrades to "all
+/// of it on today" for same-day intervals (the overwhelmingly common case:
+/// every live tick, and most relaunches), and only actually splits across
+/// multiple `DailyTraffic` rows when an offline gap crossed midnight.
+/// Rounding remainders are assigned to the final day in the split so the
+/// sum of credited bytes always exactly equals the input delta — we never
+/// fabricate or lose bytes.
+enum TrafficDaySplit {
+    /// One `DailyTraffic` bucket's share of a split delta.
+    struct DayCredit: Equatable {
+        var key: String
+        var up: Int64
+        var down: Int64
+    }
+
+    static func credits(
+        deltaUp: Int64,
+        deltaDown: Int64,
+        from start: Date,
+        to end: Date,
+        calendar: Calendar,
+    ) -> [DayCredit] {
+        guard deltaUp != 0 || deltaDown != 0 else { return [] }
+
+        let fractions = dayFractions(from: start, to: end, calendar: calendar)
+        guard fractions.count > 1 else {
+            return fractions.map { DayCredit(key: $0.key, up: deltaUp, down: deltaDown) }
+        }
+
+        let upShares = split(deltaUp, fractions: fractions.map(\.fraction))
+        let downShares = split(deltaDown, fractions: fractions.map(\.fraction))
+        return fractions.indices.map { index in
+            DayCredit(key: fractions[index].key, up: upShares[index], down: downShares[index])
+        }
+    }
+
+    private static func dayFractions(
+        from start: Date,
+        to end: Date,
+        calendar: Calendar,
+    ) -> [(key: String, fraction: Double)] {
+        guard end > start else {
+            return [(DailyTraffic.key(for: end, calendar: calendar), 1.0)]
+        }
+
+        let total = end.timeIntervalSince(start)
+        var result: [(String, Double)] = []
+        var cursor = start
+        while cursor < end {
+            let dayStart = calendar.startOfDay(for: cursor)
+            let nextDayStart = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? end
+            let segmentEnd = min(nextDayStart, end)
+            let fraction = segmentEnd.timeIntervalSince(cursor) / total
+            result.append((DailyTraffic.key(for: cursor, calendar: calendar), fraction))
+            cursor = segmentEnd
+        }
+        return result
+    }
+
+    private static func split(_ total: Int64, fractions: [Double]) -> [Int64] {
+        guard total != 0 else { return fractions.map { _ in 0 } }
+        var shares: [Int64] = []
+        var allocated: Int64 = 0
+        for (index, fraction) in fractions.enumerated() {
+            if index == fractions.count - 1 {
+                shares.append(total - allocated)
+            } else {
+                let share = Int64((Double(total) * fraction).rounded())
+                shares.append(share)
+                allocated += share
+            }
+        }
+        return shares
     }
 }

--- a/App/Sources/Services/DeepLinkImportConfirmation.swift
+++ b/App/Sources/Services/DeepLinkImportConfirmation.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Decision data for the in-app confirmation shown before a `meow://connect`
+/// deep link is allowed to fetch or activate anything (issue #293 — a
+/// crafted link must never import, let alone activate, a proxy profile
+/// unattended).
+///
+/// Built once per incoming deep link via `make(for:existingProfiles:)`, a
+/// pure function with no networking or persistence, so the decision logic
+/// (host / name / HTTPS / duplicate detection) is unit-testable without
+/// SwiftUI or a live `ModelContext`. `ContentView` presents this as a sheet
+/// and reduces the user's choice through `DeepLinkImportCoordinator`.
+struct DeepLinkImportConfirmation: Identifiable, Equatable {
+    let id = UUID()
+    let link: SubscriptionDeepLink
+    /// Set when a profile already exists with this exact subscription URL —
+    /// the confirmation offers "update in place" instead of a duplicate add,
+    /// so a replayed/duplicate deep link can't silently accumulate profiles.
+    let existingProfileID: UUID?
+
+    var subscriptionURL: URL {
+        link.subscriptionURL
+    }
+
+    var host: String {
+        link.subscriptionURL.host ?? link.subscriptionURL.absoluteString
+    }
+
+    var name: String {
+        link.name
+    }
+
+    /// Plain HTTP is still accepted (some subscription hosts don't offer
+    /// TLS), but the confirmation must call it out prominently — the
+    /// profile can be tampered with in transit.
+    var isInsecure: Bool {
+        link.subscriptionURL.scheme?.lowercased() == "http"
+    }
+
+    var isDuplicate: Bool {
+        existingProfileID != nil
+    }
+
+    /// The deep link asked for `select=1`. This only controls whether the
+    /// confirmation *offers* a separate "Import & Activate" action — the
+    /// query parameter never activates anything by itself; only an explicit
+    /// tap on that action does.
+    var requestsActivation: Bool {
+        link.autoSelect
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.link == rhs.link && lhs.existingProfileID == rhs.existingProfileID
+    }
+
+    /// - Parameter existingProfiles: `(id, url)` pairs for every profile
+    ///   already imported, used only to detect a replayed subscription URL.
+    ///   Kept as plain tuples (rather than taking `[Profile]` / a
+    ///   `ModelContext` directly) so this stays a pure function callable
+    ///   from unit tests with no SwiftData store.
+    static func make(
+        for link: SubscriptionDeepLink,
+        existingProfiles: [(id: UUID, url: String)],
+    ) -> Self {
+        let existingProfileID = existingProfiles.first { $0.url == link.subscriptionURL.absoluteString }?.id
+        return DeepLinkImportConfirmation(link: link, existingProfileID: existingProfileID)
+    }
+}
+
+/// Action chosen from the deep-link confirmation sheet.
+enum DeepLinkConfirmationAction: Equatable {
+    case cancel
+    case importOnly
+    case importAndActivate
+}
+
+/// Executes the user's choice from the confirmation sheet against
+/// `SubscriptionService`. Kept separate from the view so the import /
+/// activate / no-op behavior is unit-testable without UIKit or SwiftUI.
+@MainActor
+struct DeepLinkImportCoordinator {
+    let subscriptionService: SubscriptionService
+
+    /// - Parameter existingProfile: the profile matching
+    ///   `confirmation.existingProfileID`, looked up by the caller (e.g. from
+    ///   a `@Query` result) since this type has no `ModelContext` of its own.
+    /// - Returns: the imported/updated profile, or `nil` for `.cancel` (no
+    ///   fetch, import, or activation happens in that case).
+    @discardableResult
+    func resolve(
+        _ confirmation: DeepLinkImportConfirmation,
+        action: DeepLinkConfirmationAction,
+        existingProfile: Profile?,
+    ) async throws -> Profile? {
+        guard action != .cancel else { return nil }
+
+        let profile: Profile = if let existingProfile {
+            try await refreshed(existingProfile)
+        } else {
+            try await subscriptionService.add(
+                name: confirmation.name,
+                url: confirmation.subscriptionURL.absoluteString,
+            )
+        }
+
+        // Defense in depth: only an explicit `.importAndActivate` tap on a
+        // confirmation that actually offered it may select the profile.
+        // `select=1` alone (requestsActivation) never reaches this path.
+        if action == .importAndActivate, confirmation.requestsActivation {
+            try subscriptionService.select(profile)
+        }
+        return profile
+    }
+
+    private func refreshed(_ profile: Profile) async throws -> Profile {
+        try await subscriptionService.refresh(profile)
+        return profile
+    }
+}

--- a/App/Sources/Services/MeowAPI+Mock.swift
+++ b/App/Sources/Services/MeowAPI+Mock.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// Simulator-only mock responses for `MeowAPI`. There is no meow engine
+/// running in the simulator, so every endpoint returns canned fixtures
+/// instead of hitting the loopback REST API. Split out of `MeowAPI.swift`
+/// to keep that file under the repo's file-length lint budget.
+extension MeowAPI {
+    static var usesMockTransport: Bool {
+        #if targetEnvironment(simulator)
+            true
+        #else
+            false
+        #endif
+    }
+
+    static func mockProxies() -> ProxiesResponse {
+        let history: [Proxy.History] = [
+            .init(delay: 82),
+            .init(delay: 76),
+        ]
+        let singaporeHistory: [Proxy.History] = [
+            .init(delay: 138),
+            .init(delay: 121),
+        ]
+        let westHistory: [Proxy.History] = [
+            .init(delay: 192),
+            .init(delay: 168),
+        ]
+        let proxies: [String: Proxy] = [
+            "GLOBAL": .init(
+                name: "GLOBAL",
+                type: "Selector",
+                now: "Auto",
+                all: ["Auto", "Tokyo 01", "Singapore 02", "US West 03", "DIRECT"],
+                history: nil,
+            ),
+            "Proxy": .init(
+                name: "Proxy",
+                type: "Selector",
+                now: "Auto",
+                all: ["Auto", "Tokyo 01", "Singapore 02", "US West 03"],
+                history: nil,
+            ),
+            "Auto": .init(
+                name: "Auto",
+                type: "URLTest",
+                now: "Tokyo 01",
+                all: ["Tokyo 01", "Singapore 02", "US West 03"],
+                history: nil,
+            ),
+            "Tokyo 01": .init(name: "Tokyo 01", type: "Shadowsocks", now: nil, all: nil, history: history),
+            "Singapore 02": .init(
+                name: "Singapore 02",
+                type: "VLESS",
+                now: nil,
+                all: nil,
+                history: singaporeHistory,
+            ),
+            "US West 03": .init(name: "US West 03", type: "Trojan", now: nil, all: nil, history: westHistory),
+            "DIRECT": .init(name: "DIRECT", type: "Direct", now: nil, all: nil, history: nil),
+        ]
+        return .init(proxies: proxies)
+    }
+
+    static func mockDelay(for proxy: String) -> Int {
+        switch proxy {
+        case "Tokyo 01": 76
+        case "Singapore 02": 121
+        case "US West 03": 168
+        default: 94
+        }
+    }
+
+    static func mockGroupDelay(for group: String) -> [String: Int] {
+        let members = mockProxies().proxies[group]?.all ?? []
+        return Dictionary(uniqueKeysWithValues: members.map { ($0, mockDelay(for: $0)) })
+    }
+
+    static func mockConnections() -> ConnectionsResponse {
+        .init(
+            downloadTotal: 3_842_146_304,
+            uploadTotal: 486_539_264,
+            connections: [
+                .init(
+                    id: "sim-1",
+                    metadata: .init(
+                        network: "tcp",
+                        type: "HTTP",
+                        sourceIP: "10.0.0.2",
+                        destinationIP: "142.250.72.14",
+                        destinationPort: "443",
+                        host: "www.gstatic.com",
+                    ),
+                    upload: 42496,
+                    download: 384_000,
+                    start: "2026-06-28T09:41:00Z",
+                    chains: ["Tokyo 01", "Proxy"],
+                    rule: "DOMAIN-SUFFIX",
+                    rulePayload: "gstatic.com",
+                ),
+                .init(
+                    id: "sim-2",
+                    metadata: .init(
+                        network: "tcp",
+                        type: "HTTPS",
+                        sourceIP: "10.0.0.2",
+                        destinationIP: "140.82.112.4",
+                        destinationPort: "443",
+                        host: "github.com",
+                    ),
+                    upload: 18944,
+                    download: 96512,
+                    start: "2026-06-28T09:41:07Z",
+                    chains: ["Auto", "Proxy"],
+                    rule: "MATCH",
+                    rulePayload: "",
+                ),
+            ],
+        )
+    }
+
+    static func mockRules() -> RulesResponse {
+        .init(rules: [
+            .init(type: "DOMAIN-SUFFIX", payload: "apple.com", proxy: "DIRECT"),
+            .init(type: "DOMAIN-SUFFIX", payload: "github.com", proxy: "Proxy"),
+            .init(type: "GEOIP", payload: "CN", proxy: "DIRECT"),
+            .init(type: "MATCH", payload: "", proxy: "Proxy"),
+        ])
+    }
+
+    static func mockProviders() -> ProvidersResponse {
+        let proxies = mockProxies().proxies
+        let providerProxies = ["Tokyo 01", "Singapore 02", "US West 03"].compactMap { proxies[$0] }
+        return .init(providers: [
+            "Demo": .init(
+                name: "Demo",
+                type: "Proxy",
+                vehicleType: "HTTP",
+                proxies: providerProxies,
+            ),
+        ])
+    }
+
+    static func mockDnsResults(search: String?) -> [DnsResult] {
+        let all: [DnsResult] = [
+            .init(name: "www.gstatic.com", ips: ["142.250.72.14"], fromServer: "119.29.29.29", ttl: 298),
+            .init(name: "github.com", ips: ["140.82.112.4"], fromServer: "223.5.5.5", ttl: 412),
+            .init(name: "api.github.com", ips: ["140.82.112.5"], fromServer: "223.5.5.5", ttl: 389),
+            .init(name: "apple.com", ips: ["17.253.144.10"], fromServer: "system", ttl: 600),
+        ]
+        guard let search, !search.isEmpty else { return all }
+        return all.filter { $0.name.localizedCaseInsensitiveContains(search) }
+    }
+
+    static func mockLogStream(level: String) -> AsyncThrowingStream<LogEntry, Error> {
+        AsyncThrowingStream { continuation in
+            let entries = [
+                LogEntry(type: level, payload: "simulator mock engine ready"),
+                LogEntry(type: "debug", payload: "mock controller served /proxies"),
+                LogEntry(type: "info", payload: "traffic snapshot updated"),
+            ]
+            let task = Task {
+                var index = 0
+                while !Task.isCancelled {
+                    continuation.yield(entries[index % entries.count])
+                    index += 1
+                    try? await Task.sleep(for: .seconds(1))
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}

--- a/App/Sources/Services/MeowAPI.swift
+++ b/App/Sources/Services/MeowAPI.swift
@@ -3,15 +3,71 @@ import MeowIPC
 import NetworkExtension
 import os
 
+/// Seam over `URLSessionWebSocketTask` so `streamLogs`'s reconnect loop can be
+/// driven by a fake transport in tests (see `MeowAPITests`) without opening a
+/// real socket. `URLSessionWebSocketTask` already satisfies this shape, so no
+/// wrapper type is needed on the production path — see the `extension` below.
+protocol MeowWebSocketTransport: Sendable {
+    func resume()
+    func receive() async throws -> URLSessionWebSocketTask.Message
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?)
+}
+
+extension URLSessionWebSocketTask: MeowWebSocketTransport {}
+
+/// Thread-safe holder for the mutable port/secret credentials the engine
+/// mints once the tunnel connects (see `MeowAPI.updateCredentials`). On a
+/// fresh install `MeowAPI` starts unconfigured (port 0); every request, and
+/// each `streamLogs` reconnect iteration, reads a fresh `baseURL`/`secret`/
+/// `snapshot` here instead of caching one, so a credential update retargets
+/// in-flight requests and streams instead of leaving them pinned to the old
+/// port forever (#290).
+private final class MeowAPICredentials: @unchecked Sendable {
+    private struct Values {
+        var baseURL: URL
+        var secret: String
+    }
+
+    private let lock: OSAllocatedUnfairLock<Values>
+
+    init(port: Int, secret: String) {
+        lock = OSAllocatedUnfairLock(initialState: Values(baseURL: Self.url(forPort: port), secret: secret))
+    }
+
+    var baseURL: URL {
+        lock.withLock { $0.baseURL }
+    }
+
+    var secret: String {
+        lock.withLock { $0.secret }
+    }
+
+    var snapshot: (baseURL: URL, secret: String) {
+        lock.withLock { ($0.baseURL, $0.secret) }
+    }
+
+    func update(port: Int, secret: String) {
+        lock.withLock { $0 = Values(baseURL: Self.url(forPort: port), secret: secret) }
+    }
+
+    private static func url(forPort port: Int) -> URL {
+        URL(string: "http://127.0.0.1:\(port)")!
+    }
+}
+
 /// REST client for the meow external-controller that runs inside the
 /// packet-tunnel extension on a random loopback port. The URLSession requests
 /// are issued from the main app process; iOS routes loopback traffic correctly
 /// even when the tunnel is active.
 @Observable
 final class MeowAPI: @unchecked Sendable {
-    private var baseURL: URL
-    private var secret: String
+    private let credentials: MeowAPICredentials
     private let session: URLSession
+    /// Creates the transport for `streamLogs`'s WebSocket upgrade. Defaults to
+    /// `session.webSocketTask(with:)`; tests inject a fake transport to
+    /// observe reconnect attempts without a real socket.
+    private let webSocketTaskFactory: @Sendable (URLRequest) -> MeowWebSocketTransport
+    private let usesInjectedWebSocketTransport: Bool
     // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
     // Mirrors the ingress-instrumentation pattern kept around #54.
     private let log = Logger(subsystem: "com.tangzixiang.meow.app", category: "meow-api")
@@ -39,10 +95,12 @@ final class MeowAPI: @unchecked Sendable {
         port: Int = 0,
         secret: String = "",
         session: URLSession = .shared,
+        webSocketTaskFactory: (@Sendable (URLRequest) -> MeowWebSocketTransport)? = nil,
     ) {
-        baseURL = URL(string: "http://127.0.0.1:\(port)")!
-        self.secret = secret
+        credentials = MeowAPICredentials(port: port, secret: secret)
         self.session = session
+        usesInjectedWebSocketTransport = webSocketTaskFactory != nil
+        self.webSocketTaskFactory = webSocketTaskFactory ?? { req in session.webSocketTask(with: req) }
     }
 
     /// Point the client at the port/secret the engine actually bound. On a
@@ -50,10 +108,14 @@ final class MeowAPI: @unchecked Sendable {
     /// first constructed (no tunnel has started), so the initial instance
     /// is intentionally unconfigured; once the extension mints credentials on
     /// connect, the app calls this to retarget before issuing requests.
-    /// No-op when `port`/`secret` are unchanged.
+    ///
+    /// Safe to call while `streamLogs`'s reconnect loop is running: the loop
+    /// recomputes its target from `credentials` on every retry iteration
+    /// (never once up front), so an in-flight socket's *next* reconnect
+    /// attempt — after its current attempt fails or is torn down — picks up
+    /// the new port/secret without needing an app relaunch.
     func updateCredentials(port: Int, secret: String) {
-        baseURL = URL(string: "http://127.0.0.1:\(port)")!
-        self.secret = secret
+        credentials.update(port: port, secret: secret)
     }
 
     // MARK: - Endpoints
@@ -165,7 +227,7 @@ final class MeowAPI: @unchecked Sendable {
 
         struct Resp: Decodable { let delay: Int? }
         let target = try Self.buildTestDelayURL(
-            base: baseURL,
+            base: credentials.baseURL,
             path: "/proxies/\(proxy.urlEscaped)/delay",
             url: url,
             timeout: timeout,
@@ -194,7 +256,7 @@ final class MeowAPI: @unchecked Sendable {
         }
 
         let target = try Self.buildTestDelayURL(
-            base: baseURL,
+            base: credentials.baseURL,
             path: "/group/\(group.urlEscaped)/delay",
             url: url,
             timeout: timeout,
@@ -248,7 +310,7 @@ final class MeowAPI: @unchecked Sendable {
     /// 204 on success; fresh delays are surfaced on the next `getProviders()`.
     func healthCheckProvider(name: String) async throws {
         if Self.usesMockTransport { return }
-        let url = baseURL.appending(path: "/providers/proxies/\(name.urlEscaped)/healthcheck")
+        let url = credentials.baseURL.appending(path: "/providers/proxies/\(name.urlEscaped)/healthcheck")
         #if DEBUG
             // DIAGNOSTIC: remove once Logs/Connections views are stable in v1.0.
             log.info("HTTP GET \(url.absoluteString, privacy: .public)")
@@ -261,26 +323,34 @@ final class MeowAPI: @unchecked Sendable {
     /// Stream meow logs via WebSocket with auto-reconnect.
     /// Caller owns the AsyncStream — it stops when the task is cancelled.
     func streamLogs(level: String = "info") -> AsyncThrowingStream<LogEntry, Error> {
-        if Self.usesMockTransport {
+        if Self.usesMockTransport, !usesInjectedWebSocketTransport {
             return Self.mockLogStream(level: level)
         }
 
         return AsyncThrowingStream { continuation in
             let log = self.log
             let task = Task {
-                let url = baseURL
-                    .appending(path: "/logs")
-                    .appending(queryItems: [.init(name: "level", value: level)])
                 var backoff: UInt64 = 1
                 while !Task.isCancelled {
+                    // Recompute the target from the CURRENT credentials on
+                    // every iteration — not once before the loop. A fresh
+                    // install starts this loop against port 0 before the
+                    // tunnel ever connects; `updateCredentials` retargets
+                    // `credentials` once the engine mints real ones, and this
+                    // snapshot is what makes the *next* retry pick that up
+                    // instead of looping against 127.0.0.1:0 forever (#290).
+                    let snapshot = credentials.snapshot
+                    let url = snapshot.baseURL
+                        .appending(path: "/logs")
+                        .appending(queryItems: [.init(name: "level", value: level)])
                     var req = URLRequest(url: url)
-                    if !secret.isEmpty {
-                        req.setValue("Bearer \(secret)", forHTTPHeaderField: "Authorization")
+                    if !snapshot.secret.isEmpty {
+                        req.setValue("Bearer \(snapshot.secret)", forHTTPHeaderField: "Authorization")
                     }
                     #if DEBUG
                         log.info("WS upgrade \(url.absoluteString, privacy: .public)")
                     #endif
-                    let ws = session.webSocketTask(with: req)
+                    let ws = webSocketTaskFactory(req)
                     ws.resume()
                     do {
                         backoff = 1
@@ -313,7 +383,7 @@ final class MeowAPI: @unchecked Sendable {
     // MARK: - Helpers
 
     private func get<T: Decodable>(_ path: String, queryItems: [URLQueryItem] = []) async throws -> T {
-        var url = baseURL.appending(path: path)
+        var url = credentials.baseURL.appending(path: path)
         if !queryItems.isEmpty {
             url = url.appending(queryItems: queryItems)
         }
@@ -328,7 +398,7 @@ final class MeowAPI: @unchecked Sendable {
     }
 
     private func put(_ path: String, body: [String: String]) async throws {
-        let url = baseURL.appending(path: path)
+        let url = credentials.baseURL.appending(path: path)
         var req = request(for: url)
         req.httpMethod = "PUT"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -345,7 +415,7 @@ final class MeowAPI: @unchecked Sendable {
     }
 
     private func patch(_ path: String, body: [String: String]) async throws {
-        let url = baseURL.appending(path: path)
+        let url = credentials.baseURL.appending(path: path)
         var req = request(for: url)
         req.httpMethod = "PATCH"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -359,7 +429,7 @@ final class MeowAPI: @unchecked Sendable {
     }
 
     private func delete(_ path: String) async throws {
-        let url = baseURL.appending(path: path)
+        let url = credentials.baseURL.appending(path: path)
         var req = request(for: url)
         req.httpMethod = "DELETE"
         #if DEBUG
@@ -385,8 +455,8 @@ final class MeowAPI: @unchecked Sendable {
 
     private func request(for url: URL) -> URLRequest {
         var req = URLRequest(url: url)
-        if !secret.isEmpty {
-            req.setValue("Bearer \(secret)", forHTTPHeaderField: "Authorization")
+        if !credentials.secret.isEmpty {
+            req.setValue("Bearer \(credentials.secret)", forHTTPHeaderField: "Authorization")
         }
         return req
     }
@@ -408,173 +478,5 @@ enum MeowAPIError: Error {
 private extension String {
     var urlEscaped: String {
         addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self
-    }
-}
-
-private extension MeowAPI {
-    static var usesMockTransport: Bool {
-        #if targetEnvironment(simulator)
-            true
-        #else
-            false
-        #endif
-    }
-
-    static func mockProxies() -> ProxiesResponse {
-        let history: [Proxy.History] = [
-            .init(delay: 82),
-            .init(delay: 76),
-        ]
-        let singaporeHistory: [Proxy.History] = [
-            .init(delay: 138),
-            .init(delay: 121),
-        ]
-        let westHistory: [Proxy.History] = [
-            .init(delay: 192),
-            .init(delay: 168),
-        ]
-        let proxies: [String: Proxy] = [
-            "GLOBAL": .init(
-                name: "GLOBAL",
-                type: "Selector",
-                now: "Auto",
-                all: ["Auto", "Tokyo 01", "Singapore 02", "US West 03", "DIRECT"],
-                history: nil,
-            ),
-            "Proxy": .init(
-                name: "Proxy",
-                type: "Selector",
-                now: "Auto",
-                all: ["Auto", "Tokyo 01", "Singapore 02", "US West 03"],
-                history: nil,
-            ),
-            "Auto": .init(
-                name: "Auto",
-                type: "URLTest",
-                now: "Tokyo 01",
-                all: ["Tokyo 01", "Singapore 02", "US West 03"],
-                history: nil,
-            ),
-            "Tokyo 01": .init(name: "Tokyo 01", type: "Shadowsocks", now: nil, all: nil, history: history),
-            "Singapore 02": .init(
-                name: "Singapore 02",
-                type: "VLESS",
-                now: nil,
-                all: nil,
-                history: singaporeHistory,
-            ),
-            "US West 03": .init(name: "US West 03", type: "Trojan", now: nil, all: nil, history: westHistory),
-            "DIRECT": .init(name: "DIRECT", type: "Direct", now: nil, all: nil, history: nil),
-        ]
-        return .init(proxies: proxies)
-    }
-
-    static func mockDelay(for proxy: String) -> Int {
-        switch proxy {
-        case "Tokyo 01": 76
-        case "Singapore 02": 121
-        case "US West 03": 168
-        default: 94
-        }
-    }
-
-    static func mockGroupDelay(for group: String) -> [String: Int] {
-        let members = mockProxies().proxies[group]?.all ?? []
-        return Dictionary(uniqueKeysWithValues: members.map { ($0, mockDelay(for: $0)) })
-    }
-
-    static func mockConnections() -> ConnectionsResponse {
-        .init(
-            downloadTotal: 3_842_146_304,
-            uploadTotal: 486_539_264,
-            connections: [
-                .init(
-                    id: "sim-1",
-                    metadata: .init(
-                        network: "tcp",
-                        type: "HTTP",
-                        sourceIP: "10.0.0.2",
-                        destinationIP: "142.250.72.14",
-                        destinationPort: "443",
-                        host: "www.gstatic.com",
-                    ),
-                    upload: 42496,
-                    download: 384_000,
-                    start: "2026-06-28T09:41:00Z",
-                    chains: ["Tokyo 01", "Proxy"],
-                    rule: "DOMAIN-SUFFIX",
-                    rulePayload: "gstatic.com",
-                ),
-                .init(
-                    id: "sim-2",
-                    metadata: .init(
-                        network: "tcp",
-                        type: "HTTPS",
-                        sourceIP: "10.0.0.2",
-                        destinationIP: "140.82.112.4",
-                        destinationPort: "443",
-                        host: "github.com",
-                    ),
-                    upload: 18944,
-                    download: 96512,
-                    start: "2026-06-28T09:41:07Z",
-                    chains: ["Auto", "Proxy"],
-                    rule: "MATCH",
-                    rulePayload: "",
-                ),
-            ],
-        )
-    }
-
-    static func mockRules() -> RulesResponse {
-        .init(rules: [
-            .init(type: "DOMAIN-SUFFIX", payload: "apple.com", proxy: "DIRECT"),
-            .init(type: "DOMAIN-SUFFIX", payload: "github.com", proxy: "Proxy"),
-            .init(type: "GEOIP", payload: "CN", proxy: "DIRECT"),
-            .init(type: "MATCH", payload: "", proxy: "Proxy"),
-        ])
-    }
-
-    static func mockProviders() -> ProvidersResponse {
-        let proxies = mockProxies().proxies
-        let providerProxies = ["Tokyo 01", "Singapore 02", "US West 03"].compactMap { proxies[$0] }
-        return .init(providers: [
-            "Demo": .init(
-                name: "Demo",
-                type: "Proxy",
-                vehicleType: "HTTP",
-                proxies: providerProxies,
-            ),
-        ])
-    }
-
-    static func mockDnsResults(search: String?) -> [DnsResult] {
-        let all: [DnsResult] = [
-            .init(name: "www.gstatic.com", ips: ["142.250.72.14"], fromServer: "119.29.29.29", ttl: 298),
-            .init(name: "github.com", ips: ["140.82.112.4"], fromServer: "223.5.5.5", ttl: 412),
-            .init(name: "api.github.com", ips: ["140.82.112.5"], fromServer: "223.5.5.5", ttl: 389),
-            .init(name: "apple.com", ips: ["17.253.144.10"], fromServer: "system", ttl: 600),
-        ]
-        guard let search, !search.isEmpty else { return all }
-        return all.filter { $0.name.localizedCaseInsensitiveContains(search) }
-    }
-
-    static func mockLogStream(level: String) -> AsyncThrowingStream<LogEntry, Error> {
-        AsyncThrowingStream { continuation in
-            let entries = [
-                LogEntry(type: level, payload: "simulator mock engine ready"),
-                LogEntry(type: "debug", payload: "mock controller served /proxies"),
-                LogEntry(type: "info", payload: "traffic snapshot updated"),
-            ]
-            let task = Task {
-                var index = 0
-                while !Task.isCancelled {
-                    continuation.yield(entries[index % entries.count])
-                    index += 1
-                    try? await Task.sleep(for: .seconds(1))
-                }
-            }
-            continuation.onTermination = { _ in task.cancel() }
-        }
     }
 }

--- a/App/Sources/Services/SubscriptionService.swift
+++ b/App/Sources/Services/SubscriptionService.swift
@@ -12,15 +12,29 @@ final class SubscriptionService {
     private let modelContext: ModelContext
     private let session: URLSession
     private let converter: SubscriptionConverter
+    /// Directory + file the active config is written to. Defaults to the
+    /// real App Group container; tests inject a temporary directory so they
+    /// never touch the shared container (see `SubscriptionServiceTests`).
+    private let activeConfigDirectory: () -> URL
+    private let activeConfigURL: () -> URL
+    /// Suite the selected-profile preference is persisted to. Defaults to
+    /// the App Group suite; injectable for the same reason as above.
+    private let preferences: UserDefaults
 
     init(
         modelContext: ModelContext,
         session: URLSession = .shared,
         converter: SubscriptionConverter = ClashYAMLConverter(),
+        activeConfigDirectory: @escaping () -> URL = { AppGroup.containerURL },
+        activeConfigURL: @escaping () -> URL = { AppGroup.configURL },
+        preferences: UserDefaults = AppGroup.defaults,
     ) {
         self.modelContext = modelContext
         self.session = session
         self.converter = converter
+        self.activeConfigDirectory = activeConfigDirectory
+        self.activeConfigURL = activeConfigURL
+        self.preferences = preferences
     }
 
     // MARK: - CRUD
@@ -65,13 +79,7 @@ final class SubscriptionService {
         try MeowConfigValidator.validate(yaml)
 
         if let generated {
-            generated.yamlBackup = generated.yamlContent
-            generated.yamlContent = yaml
-            generated.lastUpdated = .now
-            try modelContext.save()
-            if generated.isSelected {
-                try writeActiveConfig(generated)
-            }
+            try updateContent(generated, yaml: yaml, lastUpdated: .now)
             return generated
         }
         let name = String(
@@ -84,16 +92,42 @@ final class SubscriptionService {
         return profile
     }
 
+    /// Refetch `profile`'s remote body and persist it. If `profile` is the
+    /// selected profile, atomically refreshes the active config file too —
+    /// refreshing an inactive profile only updates SwiftData.
     func refresh(_ profile: Profile) async throws {
         guard !profile.url.isEmpty else { throw SubscriptionError.invalidURL }
         let yaml = try await fetchAndNormalize(url: profile.url)
-        profile.yamlBackup = profile.yamlContent
-        profile.yamlContent = yaml
-        profile.lastUpdated = .now
-        try modelContext.save()
+        try updateContent(profile, yaml: yaml, lastUpdated: .now)
     }
 
+    /// Deletes `profile`. If it was the selected profile, this clears the
+    /// selected-profile preference and removes the active config file
+    /// rather than guessing a replacement — `writeEffectiveConfigWithPrefs`
+    /// (`PacketTunnel/Sources/MWTunnelEngine.m`) already fails coherently
+    /// (returns an error, doesn't crash) when `config.yaml` is absent, and
+    /// every "current selection" query in the UI (`SubscriptionsView`,
+    /// `HomeView`, `RulesView`, `ProxyGroupsView`, `GlobalVpnSwitchBar`)
+    /// already renders an empty/no-selection state when `isSelected` matches
+    /// nothing, so "no profile selected" is a well-supported state rather
+    /// than an edge case to special-case around.
     func delete(_ profile: Profile) throws {
+        let wasSelected = profile.isSelected
+        if wasSelected {
+            let previousPreference = preferences.string(forKey: PreferenceKey.selectedProfileID)
+            preferences.removeObject(forKey: PreferenceKey.selectedProfileID)
+            do {
+                try clearActiveConfig()
+            } catch {
+                // Active file couldn't be cleared — restore the preference and
+                // leave the profile in place rather than deleting it out from
+                // under a `config.yaml` that still references it.
+                if let previousPreference {
+                    preferences.set(previousPreference, forKey: PreferenceKey.selectedProfileID)
+                }
+                throw error
+            }
+        }
         modelContext.delete(profile)
         try modelContext.save()
     }
@@ -111,18 +145,70 @@ final class SubscriptionService {
     func select(_ profile: Profile) throws {
         let fetch = FetchDescriptor<Profile>()
         let all = try modelContext.fetch(fetch)
+        let previousSelectedIDs = Set(all.filter(\.isSelected).map(\.id))
+        let previousPreference = preferences.string(forKey: PreferenceKey.selectedProfileID)
         for p in all {
             p.isSelected = (p.id == profile.id)
         }
-        AppGroup.defaults.set(profile.id.uuidString, forKey: PreferenceKey.selectedProfileID)
-        try modelContext.save()
-        try writeActiveConfig(profile)
+        preferences.set(profile.id.uuidString, forKey: PreferenceKey.selectedProfileID)
+        do {
+            try modelContext.save()
+            try writeActiveConfig(profile)
+        } catch {
+            for p in all {
+                p.isSelected = previousSelectedIDs.contains(p.id)
+            }
+            if let previousPreference {
+                preferences.set(previousPreference, forKey: PreferenceKey.selectedProfileID)
+            } else {
+                preferences.removeObject(forKey: PreferenceKey.selectedProfileID)
+            }
+            try? modelContext.save()
+            throw error
+        }
+    }
+
+    /// Persist a new YAML body for `profile` — from a subscription refresh
+    /// or a manual YAML/rules edit — and, only when `profile` is currently
+    /// selected, atomically rewrite the active config file to match. Editing
+    /// or refreshing an inactive profile therefore never touches
+    /// `config.yaml`. Rolls the SwiftData change back if the active-file
+    /// write fails, so the two never diverge.
+    func updateContent(_ profile: Profile, yaml: String, lastUpdated: Date? = nil) throws {
+        let previousContent = profile.yamlContent
+        let previousBackup = profile.yamlBackup
+        let previousLastUpdated = profile.lastUpdated
+        profile.yamlBackup = profile.yamlContent
+        profile.yamlContent = yaml
+        if let lastUpdated {
+            profile.lastUpdated = lastUpdated
+        }
+        do {
+            try modelContext.save()
+            if profile.isSelected {
+                try writeActiveConfig(profile)
+            }
+        } catch {
+            profile.yamlContent = previousContent
+            profile.yamlBackup = previousBackup
+            profile.lastUpdated = previousLastUpdated
+            try? modelContext.save()
+            throw error
+        }
     }
 
     func writeActiveConfig(_ profile: Profile) throws {
-        let dir = AppGroup.containerURL
+        let dir = activeConfigDirectory()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        try profile.yamlContent.write(to: AppGroup.configURL, atomically: true, encoding: .utf8)
+        try profile.yamlContent.write(to: activeConfigURL(), atomically: true, encoding: .utf8)
+    }
+
+    /// Removes the active config file, if present. Used when the selected
+    /// profile is deleted so `config.yaml` never outlives its profile.
+    func clearActiveConfig() throws {
+        let url = activeConfigURL()
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        try FileManager.default.removeItem(at: url)
     }
 
     // MARK: - Fetch + normalize

--- a/App/Sources/Views/ContentView.swift
+++ b/App/Sources/Views/ContentView.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 /// Top-level tabs. Raw values double as the `-screenshotTab <value>` launch
@@ -10,9 +11,15 @@ enum ContentTab: String {
 struct ContentView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(SubscriptionService.self) private var subscriptionService
+    @Query private var profiles: [Profile]
     @State private var showDiagnostics = false
     @State private var importError: String?
     @State private var selectedTab: ContentTab = initialTab()
+    /// The confirmation currently on screen for a `meow://connect` deep
+    /// link, if any. A second deep link arriving while one is already
+    /// pending replaces it rather than stacking a second sheet (issue #293).
+    @State private var pendingDeepLinkConfirmation: DeepLinkImportConfirmation?
+    @State private var importingDeepLinkURLs: Set<String> = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -46,7 +53,19 @@ struct ContentView: View {
                 return
             }
             if let link = SubscriptionDeepLink.parse(url) {
-                Task { await handleSubscriptionImport(link) }
+                // Never fetch or import here — only build the confirmation.
+                // Replacing any already-pending confirmation (rather than
+                // stacking a second sheet) keeps a burst of replayed deep
+                // links from crashing or queuing indefinitely.
+                pendingDeepLinkConfirmation = DeepLinkImportConfirmation.make(
+                    for: link,
+                    existingProfiles: profiles.map { ($0.id, $0.url) },
+                )
+            }
+        }
+        .sheet(item: $pendingDeepLinkConfirmation) { confirmation in
+            DeepLinkConfirmationSheet(confirmation: confirmation) { action in
+                Task { await handleDeepLinkConfirmation(confirmation, action: action) }
             }
         }
         .fullScreenCover(isPresented: $showDiagnostics) {
@@ -81,15 +100,21 @@ struct ContentView: View {
     }
 
     @MainActor
-    private func handleSubscriptionImport(_ link: SubscriptionDeepLink) async {
+    private func handleDeepLinkConfirmation(
+        _ confirmation: DeepLinkImportConfirmation,
+        action: DeepLinkConfirmationAction,
+    ) async {
+        let url = confirmation.subscriptionURL.absoluteString
+        guard !importingDeepLinkURLs.contains(url) else { return }
+        importingDeepLinkURLs.insert(url)
+        defer { importingDeepLinkURLs.remove(url) }
+
+        let coordinator = DeepLinkImportCoordinator(subscriptionService: subscriptionService)
+        let existingProfile = confirmation.existingProfileID.flatMap { id in
+            profiles.first { $0.id == id }
+        }
         do {
-            let profile = try await subscriptionService.add(
-                name: link.name,
-                url: link.subscriptionURL.absoluteString,
-            )
-            if link.autoSelect {
-                try subscriptionService.select(profile)
-            }
+            try await coordinator.resolve(confirmation, action: action, existingProfile: existingProfile)
         } catch {
             importError = error.localizedDescription
         }

--- a/App/Sources/Views/DeepLinkConfirmationSheet.swift
+++ b/App/Sources/Views/DeepLinkConfirmationSheet.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// Confirmation shown before a `meow://connect` deep link is allowed to
+/// fetch or activate anything (issue #293). Import-only is the primary,
+/// safe-by-default action; "Import & Activate" only appears when the deep
+/// link requested `select=1`, and even then it takes a separate, explicit
+/// tap — the link's `select=1` never activates a profile by itself.
+struct DeepLinkConfirmationSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var acknowledgedInsecureTransport = false
+    let confirmation: DeepLinkImportConfirmation
+    let onAction: (DeepLinkConfirmationAction) -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    LabeledContent("deepLinkImport.field.name", value: confirmation.name)
+                    LabeledContent("deepLinkImport.field.host", value: confirmation.host)
+                    Text(confirmation.subscriptionURL.absoluteString)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .accessibilityLabel(
+                            Text("deepLinkImport.a11y.url \(confirmation.subscriptionURL.absoluteString)"),
+                        )
+                } header: {
+                    Text("deepLinkImport.section.subscription")
+                }
+
+                if confirmation.isInsecure {
+                    Section {
+                        Label("deepLinkImport.warning.insecure", systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(AppTheme.warning)
+                        Toggle(
+                            "deepLinkImport.warning.acknowledge",
+                            isOn: $acknowledgedInsecureTransport,
+                        )
+                        .accessibilityIdentifier("deepLinkImport.insecureAcknowledgement")
+                    }
+                }
+
+                if confirmation.isDuplicate {
+                    Section {
+                        Text("deepLinkImport.notice.duplicate")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section {
+                    Button {
+                        onAction(.importOnly)
+                        dismiss()
+                    } label: {
+                        Text(confirmation.isDuplicate
+                            ? "deepLinkImport.button.update"
+                            : "deepLinkImport.button.import")
+                    }
+                    .disabled(confirmation.isInsecure && !acknowledgedInsecureTransport)
+                    .accessibilityIdentifier("deepLinkImport.importButton")
+
+                    if confirmation.requestsActivation {
+                        Button {
+                            onAction(.importAndActivate)
+                            dismiss()
+                        } label: {
+                            Text("deepLinkImport.button.importAndActivate")
+                        }
+                        .disabled(confirmation.isInsecure && !acknowledgedInsecureTransport)
+                        .accessibilityIdentifier("deepLinkImport.importAndActivateButton")
+                    }
+                }
+            }
+            .navigationTitle("deepLinkImport.nav.title")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("common.cancel") {
+                        onAction(.cancel)
+                        dismiss()
+                    }
+                    .accessibilityIdentifier("deepLinkImport.cancelButton")
+                    .accessibilityLabel(String(localized: "a11y.deepLinkImport.cancel"))
+                }
+            }
+            .onAppear {
+                AccessibilityNotification.ScreenChanged().post()
+            }
+        }
+    }
+}

--- a/App/Sources/Views/RulesEditorView.swift
+++ b/App/Sources/Views/RulesEditorView.swift
@@ -260,9 +260,7 @@ struct RulesEditorView: View {
         do {
             let newYAML = try RulesYAMLEditor.apply(rules, to: profile.yamlContent)
             try MeowConfigValidator.validate(newYAML)
-            profile.yamlBackup = profile.yamlContent
-            profile.yamlContent = newYAML
-            try service.writeActiveConfig(profile)
+            try service.updateContent(profile, yaml: newYAML)
             hasUnsavedChanges = false
             dismiss()
         } catch {

--- a/App/Sources/Views/YamlEditorView.swift
+++ b/App/Sources/Views/YamlEditorView.swift
@@ -70,9 +70,7 @@ struct YamlEditorView: View {
         }
         do {
             try MeowConfigValidator.validate(text)
-            profile.yamlBackup = profile.yamlContent
-            profile.yamlContent = text
-            try service.writeActiveConfig(profile)
+            try service.updateContent(profile, yaml: text)
             dismiss()
         } catch {
             self.error = error.localizedDescription

--- a/MeowShared/Sources/MeowIPC/SharedStore.swift
+++ b/MeowShared/Sources/MeowIPC/SharedStore.swift
@@ -37,6 +37,16 @@ public enum SharedStore {
         return try? decoder.decode(TrafficSnapshot.self, from: data)
     }
 
+    public static func writeTrafficBaseline(_ baseline: TrafficBaseline) throws {
+        let data = try encoder.encode(baseline)
+        AppGroup.defaults.set(data, forKey: PreferenceKey.trafficAccumulatorBaseline)
+    }
+
+    public static func readTrafficBaseline() -> TrafficBaseline? {
+        guard let data = AppGroup.defaults.data(forKey: PreferenceKey.trafficAccumulatorBaseline) else { return nil }
+        return try? decoder.decode(TrafficBaseline.self, from: data)
+    }
+
     public static func queueIntent(_ intent: TunnelIntent) throws {
         let data = try encoder.encode(intent)
         AppGroup.defaults.set(data, forKey: PreferenceKey.pendingIntent)

--- a/MeowShared/Sources/MeowModels/Preferences.swift
+++ b/MeowShared/Sources/MeowModels/Preferences.swift
@@ -12,6 +12,11 @@ public enum PreferenceKey {
     public static let ipv6Enabled = "com.meow.ipv6Enabled"
     public static let pendingIntent = "com.meow.pendingIntent"
     public static let selectedProfileID = "com.meow.selectedProfileID"
+    /// App-only bookkeeping for `DailyTrafficAccumulator` — the extension
+    /// never reads or writes this key. Lives in the App Group (rather than
+    /// the app's local `UserDefaults.standard`) purely for durability
+    /// alongside the rest of the shared state; no cross-process meaning.
+    public static let trafficAccumulatorBaseline = "com.meow.trafficAccumulatorBaseline"
 }
 
 public enum PreferenceDefaults {

--- a/MeowShared/Sources/MeowModels/VpnState.swift
+++ b/MeowShared/Sources/MeowModels/VpnState.swift
@@ -86,6 +86,38 @@ public struct TrafficSnapshot: Codable, Sendable, Equatable {
     }
 }
 
+/// Durable reconciliation baseline for `DailyTrafficAccumulator`, persisted
+/// to the App Group so an app relaunch can credit bytes the extension
+/// counted while the app process was suspended or terminated.
+///
+/// `generation` is the engine-session identity to reconcile against — the
+/// extension's `VpnState.startedAt`, which `PacketTunnelProvider` sets fresh
+/// exactly once per successful `startTunnel` (see `writeState:"connected"`)
+/// and never rewrites again while that engine keeps running. Two snapshots
+/// sharing the same `generation` are guaranteed to come from the same
+/// continuously-running engine, so their cumulative counters are safely
+/// diffable; a different (or missing) `generation` means the engine was
+/// stopped and restarted since the baseline was captured, so counters must
+/// not be diffed (they may have reset to zero).
+public struct TrafficBaseline: Codable, Sendable, Equatable {
+    public var uploadBytes: Int64
+    public var downloadBytes: Int64
+    public var generation: Date?
+    public var capturedAt: Date
+
+    public init(
+        uploadBytes: Int64,
+        downloadBytes: Int64,
+        generation: Date?,
+        capturedAt: Date,
+    ) {
+        self.uploadBytes = uploadBytes
+        self.downloadBytes = downloadBytes
+        self.generation = generation
+        self.capturedAt = capturedAt
+    }
+}
+
 public enum TunnelCommand: String, Codable, Sendable {
     case start
     case stop

--- a/MeowTests/API/MeowAPITests.swift
+++ b/MeowTests/API/MeowAPITests.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import meow_ios
 import Testing
 
 /// Covers the `URLSession`-based client pointed at the engine's loopback REST API.
@@ -47,6 +48,57 @@ struct MeowAPITests {
     @Test(.disabled("blocked on T4.4 + WebSocket stubbing"))
     func `streamLogs yields LogEntry values from WebSocket`() {
         // requires URLSessionWebSocketTask stubbing — follow-up if test infra too heavy
+    }
+
+    /// Regression test for #290: a fresh install starts `streamLogs` against
+    /// port 0 (no API credentials minted yet). The stream's reconnect loop
+    /// used to compute its target URL once before the retry loop, so once
+    /// `updateCredentials` retargeted the client (first tunnel connect), every
+    /// subsequent retry kept hitting the stale `127.0.0.1:0/logs` forever and
+    /// the Logs utility only recovered on relaunch.
+    ///
+    /// Injects a `webSocketTaskFactory` (see `MeowAPI`) that immediately fails
+    /// every connection attempt, so the retry loop cycles quickly. Asserts
+    /// that the request recorded AFTER `updateCredentials` targets the new
+    /// port/secret, proving each retry iteration re-reads current credentials
+    /// instead of a URL captured once up front.
+    @Test
+    func `streamLogs retargets to updated credentials on next retry`() async throws {
+        let recorder = WebSocketRequestRecorder()
+        let api = MeowAPI(
+            port: 0,
+            secret: "",
+            session: .shared,
+            webSocketTaskFactory: { request in
+                recorder.record(request)
+                return ImmediatelyFailingWebSocketTransport()
+            },
+        )
+
+        let stream = api.streamLogs(level: "debug")
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+        defer { consumer.cancel() }
+
+        // First attempt: unconfigured client, still pointed at port 0.
+        while recorder.count < 1 {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let first = try #require(recorder.request(at: 0))
+        #expect(first.url?.absoluteString.contains("127.0.0.1:0/logs") == true)
+
+        // Simulate the engine minting real credentials on first tunnel connect.
+        api.updateCredentials(port: 54321, secret: "s3cr3t-token")
+
+        // Next retry (after the loop's backoff sleep) must target the new
+        // port/secret rather than replaying the pre-update URL.
+        while recorder.count < 2 {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        let second = try #require(recorder.request(at: 1))
+        #expect(second.url?.absoluteString.contains("127.0.0.1:54321/logs") == true)
+        #expect(second.value(forHTTPHeaderField: "Authorization") == "Bearer s3cr3t-token")
     }
 }
 

--- a/MeowTests/Services/DeepLinkImportConfirmationTests.swift
+++ b/MeowTests/Services/DeepLinkImportConfirmationTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+@testable import meow_ios
+import SwiftData
+import Testing
+
+/// Issue #293 — a `meow://connect` deep link must never fetch or activate a
+/// subscription without an explicit in-app decision. `SubscriptionDeepLinkTests`
+/// covers URL parsing; this suite covers what happens next: turning a parsed
+/// link into a `DeepLinkImportConfirmation` (host / name / HTTPS / duplicate
+/// detection — pure, no networking) and reducing the user's choice through
+/// `DeepLinkImportCoordinator` (cancel is a no-op, import-only never
+/// activates, import-and-activate does, replays update in place).
+@Suite("DeepLinkImportConfirmation", .tags(.deepLink))
+struct DeepLinkImportConfirmationTests {
+    // MARK: - make(for:existingProfiles:)
+
+    @Test
+    func `https link with no existing profile is not insecure and not a duplicate`() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml&name=My%20VPN")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(for: link, existingProfiles: [])
+
+        #expect(confirmation.host == "example.com")
+        #expect(confirmation.name == "My VPN")
+        #expect(confirmation.isInsecure == false)
+        #expect(confirmation.isDuplicate == false)
+        #expect(confirmation.existingProfileID == nil)
+    }
+
+    @Test
+    func `http link is flagged insecure`() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=http%3A%2F%2F10.0.0.1%2Fsub.yaml")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(for: link, existingProfiles: [])
+
+        #expect(confirmation.isInsecure)
+    }
+
+    @Test
+    func `select=1 sets requestsActivation but does not itself activate anything`() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs&select=1")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(for: link, existingProfiles: [])
+
+        #expect(confirmation.requestsActivation)
+    }
+
+    @Test
+    func `absent select= means the confirmation never offers Import & Activate`() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fe.com%2Fs")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(for: link, existingProfiles: [])
+
+        #expect(confirmation.requestsActivation == false)
+    }
+
+    @Test
+    func `a profile with the same subscription URL is detected as a duplicate`() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml")!,
+        ))
+        let existingID = UUID()
+        let confirmation = DeepLinkImportConfirmation.make(
+            for: link,
+            existingProfiles: [(id: existingID, url: "https://example.com/sub.yaml")],
+        )
+
+        #expect(confirmation.isDuplicate)
+        #expect(confirmation.existingProfileID == existingID)
+    }
+
+    @Test
+    func `a different subscription URL is not treated as a duplicate`() throws {
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(
+            for: link,
+            existingProfiles: [(id: UUID(), url: "https://example.com/other.yaml")],
+        )
+
+        #expect(confirmation.isDuplicate == false)
+    }
+
+    // MARK: - DeepLinkImportCoordinator
+
+    @MainActor
+    private func makeCoordinator() throws -> (DeepLinkImportCoordinator, ModelContext) {
+        let container = try ModelContainer(
+            for: Profile.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true),
+        )
+        let context = ModelContext(container)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolStub.self]
+        let session = URLSession(configuration: config)
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "DeepLinkImportConfirmationTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        guard let defaults = UserDefaults(suiteName: "DeepLinkImportConfirmationTests-\(UUID().uuidString)") else {
+            throw DeepLinkTestSetupError.defaultsSuiteUnavailable
+        }
+        let service = SubscriptionService(
+            modelContext: context,
+            session: session,
+            activeConfigDirectory: { directory },
+            activeConfigURL: { directory.appending(path: "config.yaml") },
+            preferences: defaults,
+        )
+        return (DeepLinkImportCoordinator(subscriptionService: service), context)
+    }
+
+    @Test
+    @MainActor
+    func `cancel does nothing — no fetch, no persisted profile`() async throws {
+        let (coordinator, context) = try makeCoordinator()
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(for: link, existingProfiles: [])
+
+        let result = try await coordinator.resolve(confirmation, action: .cancel, existingProfile: nil)
+
+        #expect(result == nil)
+        #expect(try context.fetch(FetchDescriptor<Profile>()).isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `import-only fetches and persists a new profile without selecting it`() async throws {
+        let (coordinator, context) = try makeCoordinator()
+        let remote = URL(string: "https://example.com/sub.yaml")!
+        URLProtocolStub.responses[remote] = .init(body: Data("proxies: []\nproxy-groups: []\n".utf8))
+        defer { URLProtocolStub.reset() }
+
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml&select=1")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(for: link, existingProfiles: [])
+
+        let profile = try await coordinator.resolve(confirmation, action: .importOnly, existingProfile: nil)
+
+        let saved = try context.fetch(FetchDescriptor<Profile>())
+        #expect(saved.count == 1)
+        #expect(saved.first?.url == remote.absoluteString)
+        // select=1 was present on the link, but the user chose import-only —
+        // it must not be activated.
+        #expect(profile?.isSelected == false)
+        #expect(saved.first?.isSelected == false)
+    }
+
+    @Test
+    @MainActor
+    func `import-and-activate fetches, persists, and selects the profile`() async throws {
+        let (coordinator, context) = try makeCoordinator()
+        let remote = URL(string: "https://example.com/sub.yaml")!
+        URLProtocolStub.responses[remote] = .init(body: Data("proxies: []\nproxy-groups: []\n".utf8))
+        defer { URLProtocolStub.reset() }
+
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml&select=1")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(for: link, existingProfiles: [])
+
+        let profile = try await coordinator.resolve(confirmation, action: .importAndActivate, existingProfile: nil)
+
+        #expect(profile?.isSelected == true)
+        let saved = try context.fetch(FetchDescriptor<Profile>())
+        #expect(saved.count == 1)
+        #expect(saved.first?.isSelected == true)
+    }
+
+    @Test
+    @MainActor
+    func `importAndActivate without select=1 on the confirmation still does not activate`() async throws {
+        // Defense in depth: even if a caller passes .importAndActivate for a
+        // confirmation that never offered it (no select=1 on the link), the
+        // coordinator refuses to select the profile.
+        let (coordinator, context) = try makeCoordinator()
+        let remote = URL(string: "https://example.com/sub.yaml")!
+        URLProtocolStub.responses[remote] = .init(body: Data("proxies: []\nproxy-groups: []\n".utf8))
+        defer { URLProtocolStub.reset() }
+
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml")!,
+        ))
+        #expect(link.autoSelect == false)
+        let confirmation = DeepLinkImportConfirmation.make(for: link, existingProfiles: [])
+
+        let profile = try await coordinator.resolve(confirmation, action: .importAndActivate, existingProfile: nil)
+
+        #expect(profile?.isSelected == false)
+        let saved = try context.fetch(FetchDescriptor<Profile>())
+        #expect(saved.first?.isSelected == false)
+    }
+
+    @Test
+    @MainActor
+    func `replaying a deep link for an already-imported URL updates in place instead of duplicating`() async throws {
+        let (coordinator, context) = try makeCoordinator()
+        let remote = "https://example.com/sub.yaml"
+        let existing = Profile(name: "Old Name", url: remote, yamlContent: "proxies: []\nproxy-groups: []\n")
+        context.insert(existing)
+        try context.save()
+
+        URLProtocolStub.responses[URL(string: remote)!] = .init(
+            body: Data("proxies: []\nproxy-groups: []\n# refreshed\n".utf8),
+        )
+        defer { URLProtocolStub.reset() }
+
+        let link = try #require(SubscriptionDeepLink.parse(
+            URL(string: "meow://connect?url=https%3A%2F%2Fexample.com%2Fsub.yaml")!,
+        ))
+        let confirmation = DeepLinkImportConfirmation.make(
+            for: link,
+            existingProfiles: [(id: existing.id, url: remote)],
+        )
+        #expect(confirmation.isDuplicate)
+
+        let profile = try await coordinator.resolve(
+            confirmation,
+            action: .importOnly,
+            existingProfile: existing,
+        )
+
+        // Same profile, refreshed content — not a second row.
+        let saved = try context.fetch(FetchDescriptor<Profile>())
+        #expect(saved.count == 1)
+        #expect(profile?.id == existing.id)
+        #expect(saved.first?.name == "Old Name")
+        #expect(saved.first?.yamlContent.contains("# refreshed") == true)
+    }
+}
+
+private enum DeepLinkTestSetupError: Error {
+    case defaultsSuiteUnavailable
+}

--- a/MeowTests/Services/SubscriptionServiceTests.swift
+++ b/MeowTests/Services/SubscriptionServiceTests.swift
@@ -1,27 +1,70 @@
 import Foundation
 @testable import meow_ios
+import MeowModels
 import SwiftData
 import Testing
 
 /// `SubscriptionService` coordinates fetch → detect → convert → persist. Each
 /// step has its own test here; lower-level parsing coverage lives in
 /// `MeowTests/Parsing/`.
+///
+/// The active-config-sync tests (issue #289) cover the invariant that
+/// `config.yaml` always corresponds to the selected profile, or is absent
+/// when no profile is selected: refresh/edit of the selected profile
+/// atomically rewrites the active file, refresh/edit of an inactive profile
+/// never touches it, and deleting the selected profile clears both the
+/// preference and the file. All of them use a temporary directory and an
+/// isolated `UserDefaults` suite instead of the real App Group container.
 @Suite("SubscriptionService", .tags(.service))
 struct SubscriptionServiceTests {
+    /// Everything a test needs to drive `SubscriptionService` against
+    /// isolated storage: an in-memory SwiftData context, a temp-directory
+    /// active-config file, and a private `UserDefaults` suite — never the
+    /// real App Group container.
+    private struct Harness {
+        let service: SubscriptionService
+        let context: ModelContext
+        let configFile: URL
+        let defaults: UserDefaults
+    }
+
     @MainActor
-    private func makeService() throws -> (SubscriptionService, ModelContext) {
+    private func makeService(session: URLSession = .shared) throws -> Harness {
         let container = try ModelContainer(
             for: Profile.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true),
         )
         let context = ModelContext(container)
-        return (SubscriptionService(modelContext: context), context)
+        let dir = FileManager.default.temporaryDirectory
+            .appending(path: "SubscriptionServiceTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        let configFile = dir.appending(path: "config.yaml")
+        let suiteName = "SubscriptionServiceTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw TestSetupError.defaultsSuiteUnavailable
+        }
+        let service = SubscriptionService(
+            modelContext: context,
+            session: session,
+            activeConfigDirectory: { dir },
+            activeConfigURL: { configFile },
+            preferences: defaults,
+        )
+        return Harness(service: service, context: context, configFile: configFile, defaults: defaults)
+    }
+
+    private func stubbedSession(url: String, yaml: String) -> URLSession {
+        URLProtocolStub.responses[URL(string: url)!] = .init(body: Data(yaml.utf8))
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolStub.self]
+        return URLSession(configuration: config)
     }
 
     @Test
     @MainActor
     func `updateInfo overwrites name and url and persists`() throws {
-        let (service, context) = try makeService()
+        let harness = try makeService()
+        let service = harness.service
+        let context = harness.context
         let profile = Profile(name: "Old", url: "https://example.com/a.yaml", yamlContent: "mixed-port: 7890\n")
         context.insert(profile)
         try context.save()
@@ -41,7 +84,9 @@ struct SubscriptionServiceTests {
     @Test
     @MainActor
     func `updateInfo trims whitespace and leaves the YAML body untouched`() throws {
-        let (service, context) = try makeService()
+        let harness = try makeService()
+        let service = harness.service
+        let context = harness.context
         let body = "mixed-port: 7890\nproxies: []\n"
         let profile = Profile(name: "Old", url: "", yamlContent: body)
         context.insert(profile)
@@ -53,6 +98,187 @@ struct SubscriptionServiceTests {
         #expect(profile.name == "Trimmed")
         #expect(profile.url == "https://example.com/c.yaml")
         #expect(profile.yamlContent == body)
+    }
+
+    // MARK: - #289: refresh keeps config.yaml in sync only for the selected profile
+
+    @Test
+    @MainActor
+    func `refresh of the selected profile atomically rewrites the active file`() async throws {
+        let url = "https://example.com/selected.yaml"
+        let refreshed = "proxies:\n  - name: refreshed\n    type: direct\n"
+        defer { URLProtocolStub.reset() }
+        let harness = try makeService(session: stubbedSession(url: url, yaml: refreshed))
+        let service = harness.service
+        let context = harness.context
+        let configFile = harness.configFile
+
+        let profile = Profile(name: "Selected", url: url, yamlContent: "proxies: []\n", isSelected: true)
+        context.insert(profile)
+        try context.save()
+        // Seed the active file so it starts out matching the selection.
+        try service.writeActiveConfig(profile)
+
+        try await service.refresh(profile)
+
+        #expect(profile.yamlContent == refreshed)
+        #expect(profile.yamlBackup == "proxies: []\n")
+        let written = try String(contentsOf: configFile, encoding: .utf8)
+        #expect(written == refreshed)
+    }
+
+    @Test
+    @MainActor
+    func `refresh of an inactive profile updates SwiftData but not the active file`() async throws {
+        let url = "https://example.com/inactive.yaml"
+        let refreshed = "proxies:\n  - name: refreshed\n    type: direct\n"
+        defer { URLProtocolStub.reset() }
+        let harness = try makeService(session: stubbedSession(url: url, yaml: refreshed))
+        let service = harness.service
+        let context = harness.context
+        let configFile = harness.configFile
+
+        let selected = Profile(name: "Selected", url: "", yamlContent: "proxies: []\n", isSelected: true)
+        let inactive = Profile(name: "Other", url: url, yamlContent: "proxies: []\n")
+        context.insert(selected)
+        context.insert(inactive)
+        try context.save()
+        try service.writeActiveConfig(selected)
+
+        try await service.refresh(inactive)
+
+        #expect(inactive.yamlContent == refreshed)
+        let written = try String(contentsOf: configFile, encoding: .utf8)
+        #expect(written == "proxies: []\n")
+    }
+
+    // MARK: - #289: editing YAML/rules only replaces config.yaml for the selected profile
+
+    @Test
+    @MainActor
+    func `updateContent for the selected profile rewrites the active file`() throws {
+        let harness = try makeService()
+        let service = harness.service
+        let context = harness.context
+        let configFile = harness.configFile
+        let selected = Profile(name: "Selected", url: "", yamlContent: "proxies: []\n", isSelected: true)
+        context.insert(selected)
+        try context.save()
+        try service.writeActiveConfig(selected)
+
+        let edited = "proxies:\n  - name: edited\n    type: direct\n"
+        try service.updateContent(selected, yaml: edited)
+
+        #expect(selected.yamlContent == edited)
+        #expect(selected.yamlBackup == "proxies: []\n")
+        let written = try String(contentsOf: configFile, encoding: .utf8)
+        #expect(written == edited)
+    }
+
+    @Test
+    @MainActor
+    func `updateContent for an inactive profile leaves the active file untouched`() throws {
+        let harness = try makeService()
+        let service = harness.service
+        let context = harness.context
+        let configFile = harness.configFile
+        let selected = Profile(name: "Selected", url: "", yamlContent: "proxies: []\n", isSelected: true)
+        let inactive = Profile(name: "Other", url: "", yamlContent: "proxies: []\n")
+        context.insert(selected)
+        context.insert(inactive)
+        try context.save()
+        try service.writeActiveConfig(selected)
+
+        try service.updateContent(inactive, yaml: "proxies:\n  - name: edited\n    type: direct\n")
+
+        #expect(inactive.yamlContent.contains("edited"))
+        let written = try String(contentsOf: configFile, encoding: .utf8)
+        #expect(written == "proxies: []\n")
+    }
+
+    @Test
+    @MainActor
+    func `updateContent rolls back the profile when the active-file write fails`() throws {
+        let container = try ModelContainer(
+            for: Profile.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true),
+        )
+        let context = ModelContext(container)
+        // A regular file sits where the active-config *directory* needs to be
+        // created, so `FileManager.createDirectory` fails and the write never
+        // happens — this exercises the rollback path rather than the happy one.
+        let blockedPath = FileManager.default.temporaryDirectory
+            .appending(path: "SubscriptionServiceTests-blocked-\(UUID().uuidString)")
+        try Data().write(to: blockedPath)
+        defer { try? FileManager.default.removeItem(at: blockedPath) }
+        guard let defaults = UserDefaults(suiteName: "SubscriptionServiceTests-\(UUID().uuidString)") else {
+            throw TestSetupError.defaultsSuiteUnavailable
+        }
+        let service = SubscriptionService(
+            modelContext: context,
+            activeConfigDirectory: { blockedPath },
+            activeConfigURL: { blockedPath.appending(path: "config.yaml") },
+            preferences: defaults,
+        )
+        let original = "proxies: []\n"
+        let profile = Profile(name: "Selected", url: "", yamlContent: original, isSelected: true)
+        context.insert(profile)
+        try context.save()
+
+        #expect(throws: (any Error).self) {
+            try service.updateContent(profile, yaml: "proxies:\n  - name: x\n    type: direct\n")
+        }
+        // SwiftData rolled back to match the untouched (nonexistent) active file.
+        #expect(profile.yamlContent == original)
+        #expect(profile.yamlBackup == original)
+    }
+
+    // MARK: - #289: deleting the selected profile clears both the preference and the active file
+
+    @Test
+    @MainActor
+    func `deleting the selected profile clears the preference and removes the active file`() throws {
+        let harness = try makeService()
+        let service = harness.service
+        let context = harness.context
+        let configFile = harness.configFile
+        let defaults = harness.defaults
+        let profile = Profile(name: "Selected", url: "", yamlContent: "proxies: []\n", isSelected: true)
+        context.insert(profile)
+        try context.save()
+        defaults.set(profile.id.uuidString, forKey: PreferenceKey.selectedProfileID)
+        try service.writeActiveConfig(profile)
+        #expect(FileManager.default.fileExists(atPath: configFile.path))
+
+        try service.delete(profile)
+
+        #expect(defaults.string(forKey: PreferenceKey.selectedProfileID) == nil)
+        #expect(!FileManager.default.fileExists(atPath: configFile.path))
+        #expect(try context.fetch(FetchDescriptor<Profile>()).isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `deleting an inactive profile leaves the preference and active file untouched`() throws {
+        let harness = try makeService()
+        let service = harness.service
+        let context = harness.context
+        let configFile = harness.configFile
+        let defaults = harness.defaults
+        let selected = Profile(name: "Selected", url: "", yamlContent: "proxies: []\n", isSelected: true)
+        let other = Profile(name: "Other", url: "", yamlContent: "proxies: []\n")
+        context.insert(selected)
+        context.insert(other)
+        try context.save()
+        defaults.set(selected.id.uuidString, forKey: PreferenceKey.selectedProfileID)
+        try service.writeActiveConfig(selected)
+
+        try service.delete(other)
+
+        #expect(defaults.string(forKey: PreferenceKey.selectedProfileID) == selected.id.uuidString)
+        let written = try String(contentsOf: configFile, encoding: .utf8)
+        #expect(written == "proxies: []\n")
+        #expect(try context.fetch(FetchDescriptor<Profile>()).count == 1)
     }
 
     @Test(.disabled("blocked on T4.5"))
@@ -78,21 +304,14 @@ struct SubscriptionServiceTests {
     }
 
     @Test(.disabled("blocked on T4.5"))
-    func `refresh preserves yamlBackup on first refresh`() {
-        // before: yamlContent = old, yamlBackup = ""
-        // after refresh: yamlContent = new, yamlBackup = old
-    }
-
-    @Test(.disabled("blocked on T4.5"))
     func `refreshAll: one failure does not poison others`() {
         // profile A stub returns 500, profile B stub returns 200
         // after refreshAll: B updated, A has lastError set, neither throws out of refreshAll
     }
+}
 
-    @Test(.disabled("blocked on T4.5"))
-    func `deleting selected profile auto-selects next`() {
-        // two profiles, delete selected, assert other becomes selected
-    }
+private enum TestSetupError: Error {
+    case defaultsSuiteUnavailable
 }
 
 extension Tag {

--- a/MeowTests/Services/TrafficAccumulatorTests.swift
+++ b/MeowTests/Services/TrafficAccumulatorTests.swift
@@ -1,33 +1,347 @@
 import Foundation
+@testable import meow_ios
+import MeowModels
+import SwiftData
 import Testing
 
-/// `TrafficAccumulator` receives raw counter snapshots from the extension
-/// and converts them to per-day deltas. Delta logic is the tricky part —
-/// engine restarts reset counters to zero, and we must not write negatives.
-@Suite("TrafficAccumulator", .tags(.service))
+/// `DailyTrafficAccumulator` receives cumulative counter snapshots from the
+/// extension and converts them to per-day deltas. The tricky parts:
+///
+/// - Engine restarts reset counters to zero — never write a negative delta.
+/// - The accumulator only lives in the app process, so an app relaunch must
+///   reconcile against a durably-persisted baseline instead of silently
+///   anchoring on the first post-launch snapshot (issue #291), but only when
+///   the persisted baseline is still the *same engine generation* — a
+///   restarted engine must not be back-filled.
+@Suite("DailyTrafficAccumulator", .tags(.service))
 struct TrafficAccumulatorTests {
-    @Test(.disabled("blocked on T4.6"))
-    func `first snapshot emits zero delta`() {
-        // expect recorded delta == 0 on first call
+    // MARK: - Test doubles
+
+    /// Settable clock so tests can control both "now" (bucket keys, baseline
+    /// timestamps) and simulate time passing between ingests.
+    final class FakeClock {
+        var date: Date
+        init(_ date: Date) {
+            self.date = date
+        }
+
+        func now() -> Date {
+            date
+        }
     }
 
-    @Test(.disabled("blocked on T4.6"))
-    func `subsequent snapshots emit (current − previous)`() {
-        // record(tx: 100), record(tx: 250) → delta 150
+    /// Settable snapshot + generation source, standing in for the shared
+    /// container the real `SharedStoreSnapshotProvider` reads.
+    final class FakeSnapshotSource: TrafficSnapshotProviding {
+        var snapshot: TrafficSnapshot?
+        var generation: Date?
+        init(snapshot: TrafficSnapshot? = nil, generation: Date? = nil) {
+            self.snapshot = snapshot
+            self.generation = generation
+        }
+
+        func currentSnapshot() -> TrafficSnapshot? {
+            snapshot
+        }
+
+        func currentGeneration() -> Date? {
+            generation
+        }
     }
 
-    @Test(.disabled("blocked on T4.6"))
-    func `counter reset produces zero delta, never negative`() {
-        // record(tx: 500), then engine restarts and record(tx: 10) → delta 0, baseline rebases to 10
+    /// In-memory baseline store. A single instance shared across two
+    /// `DailyTrafficAccumulator`s simulates the durability the real
+    /// App-Group-backed store provides across an app relaunch: the second
+    /// accumulator instance reads exactly what the first one last persisted.
+    final class InMemoryBaselineStore: TrafficBaselineStoring {
+        private(set) var baseline: TrafficBaseline?
+        func loadBaseline() -> TrafficBaseline? {
+            baseline
+        }
+
+        func saveBaseline(_ baseline: TrafficBaseline) {
+            self.baseline = baseline
+        }
     }
 
-    @Test(.disabled("blocked on T4.6"))
-    func `crossing midnight writes a new DailyTraffic row`() {
-        // seed with date X, advance clock past midnight, record again → two rows
+    private func makeContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: DailyTraffic.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true),
+        )
+        return ModelContext(container)
     }
 
-    @Test(.disabled("blocked on T4.6"))
-    func `30-second batched flush coalesces writes`() {
-        // 10 records within 30s → exactly one SwiftData write
+    private func fetchAll(_ context: ModelContext) throws -> [DailyTraffic] {
+        try context.fetch(FetchDescriptor<DailyTraffic>(sortBy: [SortDescriptor(\.date)]))
+    }
+
+    // MARK: - Live-session behavior (unchanged from pre-#291 semantics)
+
+    @Test
+    @MainActor
+    func `first snapshot emits zero delta`() throws {
+        let context = try makeContext()
+        let source = FakeSnapshotSource(snapshot: .init(uploadBytes: 500, downloadBytes: 900), generation: .init())
+        let accumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: source,
+            baselineStore: InMemoryBaselineStore(),
+        )
+
+        accumulator.start()
+
+        #expect(try fetchAll(context).isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `subsequent snapshots emit (current − previous)`() throws {
+        let context = try makeContext()
+        let generation = Date(timeIntervalSince1970: 1000)
+        let source = FakeSnapshotSource(snapshot: .init(uploadBytes: 100, downloadBytes: 200), generation: generation)
+        let accumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: source,
+            baselineStore: InMemoryBaselineStore(),
+        )
+        accumulator.start()
+
+        source.snapshot = .init(uploadBytes: 250, downloadBytes: 260)
+        accumulator.ingestCurrent()
+
+        let rows = try fetchAll(context)
+        #expect(rows.count == 1)
+        #expect(rows.first?.txBytes == 150)
+        #expect(rows.first?.rxBytes == 60)
+    }
+
+    @Test
+    @MainActor
+    func `counter reset produces zero delta, never negative`() throws {
+        let context = try makeContext()
+        let generation = Date(timeIntervalSince1970: 1000)
+        let source = FakeSnapshotSource(snapshot: .init(uploadBytes: 500, downloadBytes: 500), generation: generation)
+        let accumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: source,
+            baselineStore: InMemoryBaselineStore(),
+        )
+        accumulator.start()
+        source.snapshot = .init(uploadBytes: 700, downloadBytes: 700)
+        accumulator.ingestCurrent()
+
+        // Engine restarts; counters drop back near zero.
+        source.snapshot = .init(uploadBytes: 10, downloadBytes: 5)
+        accumulator.ingestCurrent()
+
+        let rows = try fetchAll(context)
+        #expect(rows.count == 1)
+        #expect(rows.first?.txBytes == 200)
+        #expect(rows.first?.rxBytes == 200)
+
+        // The re-anchored counters are diffable going forward.
+        source.snapshot = .init(uploadBytes: 40, downloadBytes: 35)
+        accumulator.ingestCurrent()
+        let rowsAfter = try fetchAll(context)
+        #expect(rowsAfter.first?.txBytes == 230)
+        #expect(rowsAfter.first?.rxBytes == 230)
+    }
+
+    // MARK: - App-relaunch reconciliation (issue #291)
+
+    @Test
+    @MainActor
+    func `app relaunch with the same engine generation credits the offline delta`() throws {
+        let context = try makeContext()
+        let generation = Date(timeIntervalSince1970: 1000)
+        let baselineStore = InMemoryBaselineStore()
+        let clock = FakeClock(Date(timeIntervalSince1970: 100_000))
+
+        // First app process: connects, ingests once, then is killed.
+        let firstSource = FakeSnapshotSource(
+            snapshot: .init(uploadBytes: 1000, downloadBytes: 2000),
+            generation: generation,
+        )
+        let firstAccumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: firstSource,
+            baselineStore: baselineStore,
+            now: clock.now,
+        )
+        firstAccumulator.start()
+        #expect(baselineStore.baseline?.uploadBytes == 1000)
+        #expect(baselineStore.baseline?.generation == generation)
+
+        // App is dead; the extension keeps running and counters keep
+        // climbing. Time also advances.
+        clock.date = Date(timeIntervalSince1970: 100_500)
+        let secondSource = FakeSnapshotSource(
+            snapshot: .init(uploadBytes: 1600, downloadBytes: 2900),
+            generation: generation,
+        )
+        let secondAccumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: secondSource,
+            baselineStore: baselineStore,
+            now: clock.now,
+        )
+
+        // New process, new accumulator instance, but the *same* baseline
+        // storage — simulates the app relaunching.
+        secondAccumulator.start()
+
+        let rows = try fetchAll(context)
+        #expect(rows.count == 1)
+        #expect(rows.first?.txBytes == 600)
+        #expect(rows.first?.rxBytes == 900)
+    }
+
+    @Test
+    @MainActor
+    func `app relaunch after an engine restart does not credit the gap`() throws {
+        let context = try makeContext()
+        let baselineStore = InMemoryBaselineStore()
+        let clock = FakeClock(Date(timeIntervalSince1970: 100_000))
+
+        let firstSource = FakeSnapshotSource(
+            snapshot: .init(uploadBytes: 1000, downloadBytes: 2000),
+            generation: Date(timeIntervalSince1970: 1000),
+        )
+        let firstAccumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: firstSource,
+            baselineStore: baselineStore,
+            now: clock.now,
+        )
+        firstAccumulator.start()
+
+        // The engine (and the tunnel connection) restarted while the app was
+        // dead — a brand-new generation, and the counters reset near zero.
+        clock.date = Date(timeIntervalSince1970: 100_500)
+        let secondSource = FakeSnapshotSource(
+            snapshot: .init(uploadBytes: 50, downloadBytes: 80),
+            generation: Date(timeIntervalSince1970: 2000),
+        )
+        let secondAccumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: secondSource,
+            baselineStore: baselineStore,
+            now: clock.now,
+        )
+        secondAccumulator.start()
+
+        // No delta credited for the gap — only future ingests (against the
+        // new generation's own anchor) should produce history.
+        #expect(try fetchAll(context).isEmpty)
+        #expect(baselineStore.baseline?.generation == Date(timeIntervalSince1970: 2000))
+
+        secondSource.snapshot = .init(uploadBytes: 90, downloadBytes: 130)
+        secondAccumulator.ingestCurrent()
+        let rows = try fetchAll(context)
+        #expect(rows.count == 1)
+        #expect(rows.first?.txBytes == 40)
+        #expect(rows.first?.rxBytes == 50)
+    }
+
+    @Test
+    @MainActor
+    func `first launch ever with no persisted baseline just anchors`() throws {
+        let context = try makeContext()
+        let source = FakeSnapshotSource(
+            snapshot: .init(uploadBytes: 12345, downloadBytes: 6789),
+            generation: Date(timeIntervalSince1970: 1000),
+        )
+        let accumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: source,
+            baselineStore: InMemoryBaselineStore(),
+        )
+
+        accumulator.start()
+
+        #expect(try fetchAll(context).isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `relaunch reconciliation crossing midnight splits the credit across both days`() throws {
+        let context = try makeContext()
+        let baselineStore = InMemoryBaselineStore()
+        let generation = Date(timeIntervalSince1970: 1000)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+
+        // Baseline captured at 22:00 on day 1.
+        let day1 = calendar.date(from: DateComponents(year: 2026, month: 3, day: 1, hour: 22))!
+        let clock = FakeClock(day1)
+        let firstSource = FakeSnapshotSource(
+            snapshot: .init(uploadBytes: 1000, downloadBytes: 0),
+            generation: generation,
+        )
+        let firstAccumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: firstSource,
+            baselineStore: baselineStore,
+            calendar: calendar,
+            now: clock.now,
+        )
+        firstAccumulator.start()
+
+        // App relaunches at 02:00 on day 2 — a 4-hour offline gap, split
+        // 2 hours before midnight / 2 hours after.
+        let day2 = calendar.date(from: DateComponents(year: 2026, month: 3, day: 2, hour: 2))!
+        clock.date = day2
+        let secondSource = FakeSnapshotSource(
+            snapshot: .init(uploadBytes: 2000, downloadBytes: 0),
+            generation: generation,
+        )
+        let secondAccumulator = DailyTrafficAccumulator(
+            modelContext: context,
+            snapshotProvider: secondSource,
+            baselineStore: baselineStore,
+            calendar: calendar,
+            now: clock.now,
+        )
+        secondAccumulator.start()
+
+        let rows = try fetchAll(context)
+        #expect(rows.count == 2)
+        #expect(rows.map(\.txBytes).sorted() == [500, 500])
+        #expect(rows.reduce(0) { $0 + $1.txBytes } == 1000)
+    }
+
+    // MARK: - TrafficDaySplit (midnight-attribution policy)
+
+    @Test
+    func `TrafficDaySplit keeps a same-day interval in a single bucket`() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let start = calendar.date(from: DateComponents(year: 2026, month: 5, day: 10, hour: 9))!
+        let end = calendar.date(from: DateComponents(year: 2026, month: 5, day: 10, hour: 17))!
+
+        let credits = TrafficDaySplit.credits(deltaUp: 1000, deltaDown: 200, from: start, to: end, calendar: calendar)
+
+        #expect(credits.count == 1)
+        #expect(credits.first?.up == 1000)
+        #expect(credits.first?.down == 200)
+    }
+
+    @Test
+    func `TrafficDaySplit divides bytes proportionally and never loses a byte to rounding`() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        // 3-day span: 6h on day 1, 24h on day 2, 6h on day 3 (36h total).
+        let start = calendar.date(from: DateComponents(year: 2026, month: 5, day: 10, hour: 18))!
+        let end = calendar.date(from: DateComponents(year: 2026, month: 5, day: 12, hour: 6))!
+
+        let credits = TrafficDaySplit.credits(deltaUp: 1001, deltaDown: 999, from: start, to: end, calendar: calendar)
+
+        #expect(credits.count == 3)
+        #expect(credits.reduce(0) { $0 + $1.up } == 1001)
+        #expect(credits.reduce(0) { $0 + $1.down } == 999)
+        // Middle day carries the largest share (2/3 of the interval).
+        #expect(credits[1].up > credits[0].up)
+        #expect(credits[1].up > credits[2].up)
     }
 }

--- a/MeowTests/Support/FakeWebSocketTransport.swift
+++ b/MeowTests/Support/FakeWebSocketTransport.swift
@@ -1,0 +1,43 @@
+import Foundation
+@testable import meow_ios
+
+/// Thread-safe capture of every `URLRequest` a `MeowWebSocketTransport`
+/// factory was invoked with, in call order. `streamLogs`'s reconnect loop
+/// runs on a detached `Task`, so recording has to be safe to call
+/// concurrently with the assertions made from the test's task.
+final class WebSocketRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests: [URLRequest] = []
+
+    func record(_ request: URLRequest) {
+        lock.lock()
+        defer { lock.unlock() }
+        requests.append(request)
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests.count
+    }
+
+    func request(at index: Int) -> URLRequest? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard requests.indices.contains(index) else { return nil }
+        return requests[index]
+    }
+}
+
+/// `MeowWebSocketTransport` that fails every `receive()` immediately, so
+/// `streamLogs`'s retry loop cycles through reconnect attempts (recorded by
+/// `WebSocketRequestRecorder`) without ever opening a real socket.
+final class ImmediatelyFailingWebSocketTransport: MeowWebSocketTransport {
+    func resume() {}
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        throw URLError(.networkConnectionLost)
+    }
+
+    func cancel(with _: URLSessionWebSocketTask.CloseCode, reason _: Data?) {}
+}

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		27E34E45FFE9A9D2242373E2 /* ShadowsocksURIParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48800BB67F7CB5E42F942A83 /* ShadowsocksURIParser.swift */; };
 		28CB589E0ACE5C617C7DCD42 /* TrafficAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729BDB9DF0375708DCD8F84E /* TrafficAccumulatorTests.swift */; };
 		2A21E16ED84D0DF4A7C140A4 /* clash_emoji_groups_realworld.yaml in Resources */ = {isa = PBXBuildFile; fileRef = F73DB7377F110302EA3E8B4B /* clash_emoji_groups_realworld.yaml */; };
+		2AAC16E12E0060C437E70415 /* DeepLinkImportConfirmationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C6076C2AFE3F87452DDEF /* DeepLinkImportConfirmationTests.swift */; };
 		2D71AA36DACB626D73AC50A3 /* YamlEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415A45F45F6FA01D8DA04A95 /* YamlEditorView.swift */; };
 		2E27011B1AF98B38B64FCE3E /* MeowIPC in Frameworks */ = {isa = PBXBuildFile; productRef = 9A3E18C33CE07D8DE1D81356 /* MeowIPC */; };
 		2E4C5E6BA16E22D2EAD4EB22 /* MeowAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1746752AC889A678F94A02 /* MeowAPITests.swift */; };
@@ -110,6 +111,7 @@
 		B2761759D155051F32B46F2D /* AppModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40EEE34003CA284E6D9754E0 /* AppModelContainer.swift */; };
 		B4CDE0AC50BC13DB22E90569 /* VpnManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930ED8C12FBC2859BCDC56E4 /* VpnManager.swift */; };
 		B59F7F4EA30A8A841D561C2F /* MeowModels in Frameworks */ = {isa = PBXBuildFile; productRef = DE2BFC92947DFA842E612CB7 /* MeowModels */; };
+		B5E8C76058F68847C10E5EDB /* FakeWebSocketTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF2A63A9C65B92F9DC00AA1 /* FakeWebSocketTransport.swift */; };
 		B85AC5CED1BCB971FB7C16DB /* MWPacketWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C50CF82F4373D42432869C5 /* MWPacketWriter.m */; };
 		B92365F2ACFA408CA226CA7F /* RulesEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8D42838BD27620D7F278DE /* RulesEditorView.swift */; };
 		BA6EC811EDC00657072F8372 /* ClashConfigLinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F582EC213C10F2BB97940B21 /* ClashConfigLinter.swift */; };
@@ -128,6 +130,8 @@
 		D2FF19F899EE357591812068 /* ProxyGroupModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2EC54BA19FA9CC57BDD2AD /* ProxyGroupModelTests.swift */; };
 		D49CAAAAB4878A24C8A7D52B /* ShadowsocksQRScannerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1871555B4BB947666ABD54B /* ShadowsocksQRScannerSheet.swift */; };
 		D5E3B0B2C42A294616BB2263 /* DnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711184DB8878CD1F212CEEA3 /* DnsView.swift */; };
+		D84500AEEA48460A706AC01B /* MeowAPI+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D147EADA278504AB1CDFA6 /* MeowAPI+Mock.swift */; };
+		D94E6C83D6497117D1E7D35C /* DeepLinkConfirmationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B201C0CCEE8F418C1AA9E387 /* DeepLinkConfirmationSheet.swift */; };
 		D95EF7A2FB411B4088E3255C /* URLValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAA1935B322CD5DD66E23F0 /* URLValidationTests.swift */; };
 		DC1D5D2FD5AFDC3D1D3F2602 /* TrafficScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC73D84B5978335B9C07A8A /* TrafficScreenTests.swift */; };
 		DCC6938C0A43984B033BCD68 /* AppIPCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */; };
@@ -143,6 +147,7 @@
 		F789FAB627C81F4087EEE0AF /* PacketTunnelProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 71FF15AE48B5E9FFE60B4051 /* PacketTunnelProvider.m */; };
 		FA6DFC3CA7B13A278CB1D630 /* AddSubscriptionFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA7DC0A8AEAA9185A7B40F0 /* AddSubscriptionFlowTests.swift */; };
 		FC4878B603356FA17059AB46 /* GlassCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2B37B72F11B1B2B1118221 /* GlassCard.swift */; };
+		FC5AB7D2C4E858BF27386FD9 /* DeepLinkImportConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2583E90C66D44FFDC834DAB9 /* DeepLinkImportConfirmation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -211,6 +216,7 @@
 		24AB2D298F7A38F31686BF15 /* VpnManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnManagerTests.swift; sourceTree = "<group>"; };
 		24F2E3A9014A186B34D8A465 /* MWDarwinBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDarwinBridge.m; sourceTree = "<group>"; };
 		25242F15DCC48F0C6C9BAD2C /* RenameSubscriptionFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameSubscriptionFlowTests.swift; sourceTree = "<group>"; };
+		2583E90C66D44FFDC834DAB9 /* DeepLinkImportConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkImportConfirmation.swift; sourceTree = "<group>"; };
 		2646E6E7241DEDBA8C6127C6 /* ShadowsocksConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksConfigBuilder.swift; sourceTree = "<group>"; };
 		2D7D7768D31382CD90DFEBA6 /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		2E2B37B72F11B1B2B1118221 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
@@ -260,6 +266,7 @@
 		819D62E17DBC5BC82869FA81 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
 		86AFFBA5F04A152705EE60CA /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
 		8A1CBAFD55A777C3B13296E2 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
+		8B8C6076C2AFE3F87452DDEF /* DeepLinkImportConfirmationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkImportConfirmationTests.swift; sourceTree = "<group>"; };
 		8BEF2D3A91176265B1C32542 /* .swiftformat */ = {isa = PBXFileReference; path = .swiftformat; sourceTree = "<group>"; };
 		8D0911E3BAFED1B94903FE31 /* MWPacketWriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWPacketWriter.h; sourceTree = "<group>"; };
 		8D5CF6C1DB2C326705BE75B5 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -284,9 +291,11 @@
 		A7002E0BC1FFE0A41FEBE8F6 /* LocalizableParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizableParityTests.swift; sourceTree = "<group>"; };
 		AB83B7A37D165EF0E16A47BA /* MWSharedStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWSharedStore.m; sourceTree = "<group>"; };
 		AC946E90DE239C2BD7D48DC0 /* BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
+		AEF2A63A9C65B92F9DC00AA1 /* FakeWebSocketTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeWebSocketTransport.swift; sourceTree = "<group>"; };
 		AEF41AF44DDC9B81E01AF637 /* GlobalVpnSwitchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalVpnSwitchBar.swift; sourceTree = "<group>"; };
 		AF51AD7DD7946AB70970C9A8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		B0F1B0B431DA0DD132F917FF /* LogsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsTests.swift; sourceTree = "<group>"; };
+		B201C0CCEE8F418C1AA9E387 /* DeepLinkConfirmationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkConfirmationSheet.swift; sourceTree = "<group>"; };
 		B306CE837FA7A17D7D561877 /* SubscriptionDeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionDeepLinkTests.swift; sourceTree = "<group>"; };
 		B3B120EAA4365C4F723B0FED /* DarwinBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarwinBridgeTests.swift; sourceTree = "<group>"; };
 		B4667453BED6A0D9C1CCBF07 /* MWTunnelEngine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWTunnelEngine.h; sourceTree = "<group>"; };
@@ -295,6 +304,7 @@
 		B6F70A8DAF3D01F062A5FC0E /* MWTunnelSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWTunnelSettings.h; sourceTree = "<group>"; };
 		B7193B43D94BD4897FEDF967 /* ProxyGroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyGroupsView.swift; sourceTree = "<group>"; };
 		B807F37D85605FF0AD1427F5 /* MeowCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MeowCore.xcframework; path = MeowCore/Frameworks/MeowCore.xcframework; sourceTree = "<group>"; };
+		B9D147EADA278504AB1CDFA6 /* MeowAPI+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MeowAPI+Mock.swift"; sourceTree = "<group>"; };
 		BC43530025FE948C50C6C78E /* ConnectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionsTests.swift; sourceTree = "<group>"; };
 		BC8D42838BD27620D7F278DE /* RulesEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesEditorView.swift; sourceTree = "<group>"; };
 		BCEC443073450BDC4FC7E1D3 /* MWEngineLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWEngineLog.h; sourceTree = "<group>"; };
@@ -479,6 +489,7 @@
 		546289FB1F7F3C7197D240BC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				8B8C6076C2AFE3F87452DDEF /* DeepLinkImportConfirmationTests.swift */,
 				7D8C1AC6AD4590D6827E6188 /* GeoAssetStagerTests.swift */,
 				F5B378E3EF2591C9CD059E98 /* ShadowsocksAddServiceTests.swift */,
 				B306CE837FA7A17D7D561877 /* SubscriptionDeepLinkTests.swift */,
@@ -530,6 +541,7 @@
 				8E8110225EBDEBDC762A0E20 /* ClashYAMLTextView.swift */,
 				8E6DE9E643D70646873B923B /* ConnectionsView.swift */,
 				AF51AD7DD7946AB70970C9A8 /* ContentView.swift */,
+				B201C0CCEE8F418C1AA9E387 /* DeepLinkConfirmationSheet.swift */,
 				CA20D7D98E7BC4663E289174 /* DiagnosticsViewController.swift */,
 				711184DB8878CD1F212CEEA3 /* DnsView.swift */,
 				2D7D7768D31382CD90DFEBA6 /* ErrorBanner.swift */,
@@ -581,8 +593,10 @@
 				6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */,
 				F582EC213C10F2BB97940B21 /* ClashConfigLinter.swift */,
 				664BEEB7B966973C3D0A5074 /* DailyTrafficAccumulator.swift */,
+				2583E90C66D44FFDC834DAB9 /* DeepLinkImportConfirmation.swift */,
 				20AB821D2884D05E4EA7E831 /* GeoAssetStager.swift */,
 				5E114A82C37433E90AFEAD0E /* MeowAPI.swift */,
+				B9D147EADA278504AB1CDFA6 /* MeowAPI+Mock.swift */,
 				A693FE7115671D717A87F1DB /* MeowAPITypes.swift */,
 				06D2AA0F7CC09650CF8263EF /* RulesYAMLEditor.swift */,
 				2646E6E7241DEDBA8C6127C6 /* ShadowsocksConfigBuilder.swift */,
@@ -624,6 +638,7 @@
 		AA8EEE351370060E6A4D23CA /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				AEF2A63A9C65B92F9DC00AA1 /* FakeWebSocketTransport.swift */,
 				6B7B8DF88EDD0D51301DD316 /* SwiftDataTestContainer.swift */,
 				819D62E17DBC5BC82869FA81 /* URLProtocolStub.swift */,
 			);
@@ -1126,9 +1141,11 @@
 				F3F6C8C58BB119BAA42C632B /* ChinaDirectKeywordsTests.swift in Sources */,
 				A0ACD40A0E0CF4DFABDA8903 /* ConnectionsTests.swift in Sources */,
 				A80A176366D289562219D18D /* DarwinBridgeTests.swift in Sources */,
+				2AAC16E12E0060C437E70415 /* DeepLinkImportConfirmationTests.swift in Sources */,
 				1413B423DEE5A4AE17B4F677 /* DiagnosticsLabelParserTests.swift in Sources */,
 				9D59A8F980E180CECE858F27 /* DnsTests.swift in Sources */,
 				74FE3E67A25CF1CE3E141EE2 /* EmojiGroupSelectNodeTests.swift in Sources */,
+				B5E8C76058F68847C10E5EDB /* FakeWebSocketTransport.swift in Sources */,
 				0D7669C4305C607B8C449A54 /* GeoAssetStagerTests.swift in Sources */,
 				1DEF3FB14FBD667C00541BFF /* IdentifierSlugTests.swift in Sources */,
 				5915355710B88CF6038756E6 /* KeychainStoreTests.swift in Sources */,
@@ -1172,6 +1189,8 @@
 				8743C9ECD8EE078FA44E6545 /* ContentView.swift in Sources */,
 				53CECD909096DFDB00109EC4 /* DailyTraffic.swift in Sources */,
 				AFFFD00A574AA3A9C3D33248 /* DailyTrafficAccumulator.swift in Sources */,
+				D94E6C83D6497117D1E7D35C /* DeepLinkConfirmationSheet.swift in Sources */,
+				FC5AB7D2C4E858BF27386FD9 /* DeepLinkImportConfirmation.swift in Sources */,
 				08501362516FC991AE70B3EF /* DiagnosticsViewController.swift in Sources */,
 				D5E3B0B2C42A294616BB2263 /* DnsView.swift in Sources */,
 				54E371A3BCD0A05882842AC6 /* EditableRule.swift in Sources */,
@@ -1181,6 +1200,7 @@
 				91159B9CB1EDFE43070C3A4E /* GlobalVpnSwitchBar.swift in Sources */,
 				9942BB6B9F5CDAD3CEA4B98E /* HomeView.swift in Sources */,
 				9212E710474142F878EC5ABC /* LogsView.swift in Sources */,
+				D84500AEEA48460A706AC01B /* MeowAPI+Mock.swift in Sources */,
 				C05561AA0530BFF897CDEB8F /* MeowAPI.swift in Sources */,
 				3BAE21D06E5B9935E58FDF1B /* MeowAPITypes.swift in Sources */,
 				1705DA22AD7A785A8E0A5DF5 /* MeowApp.swift in Sources */,


### PR DESCRIPTION
## Summary

Fix four open reliability and security issues:

- keep the selected profile, SwiftData record, and active `config.yaml` synchronized across refresh, edits, selection, and deletion
- persist traffic reconciliation baselines so bytes transferred while the app is terminated are retained and split across calendar days
- synchronize API credentials and rebuild the log WebSocket request on every reconnect
- require explicit deep-link import review, keep import-only as the safe default, separately confirm activation, warn and require acknowledgment for HTTP, and suppress duplicate/replayed imports

## Root causes

The active configuration file was only updated on selection, traffic baselines existed only in process memory, the log stream captured its initial port before entering the reconnect loop, and `meow://connect` fetched and activated profiles directly from URL parameters.

## Validation

Local-CI-green attestation:

- [x] `swiftformat --lint .` — 0 violations
- [x] `swiftlint --strict` — 0 violations
- [x] `scripts/build-rust.sh` — generated the device and iOS Simulator XCFramework successfully
- [x] `xcodebuild test -quiet -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` — passed
- [x] `xcodebuild test -quiet -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowUITests` — passed
- [x] `xcodebuild test -quiet -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowIntegrationTests` — passed
- [x] `git diff origin/main...HEAD --stat` — verified; 21 intended files and no accidental additions

Fixes #289
Fixes #290
Fixes #291
Fixes #293
