### PR TITLE
feat(subscriptions): export ss:// URIs and subscription URLs as QR codes

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -81,6 +81,20 @@
 "subscriptions.row.a11y.refresh %@" = "Refresh %@";
 "subscriptions.row.a11y.editInfo %@" = "Rename or edit info for %@";
 "subscriptions.row.a11y.editInfoHint" = "Opens the name and URL editor";
+"subscriptions.row.a11y.exportQR %@" = "Export QR code for %@";
+"subscriptions.row.a11y.exportQRHint" = "Shows a scannable QR code of the share link";
+
+/* QR export sheet */
+"qrExport.nav.title" = "Export QR Code";
+"qrExport.picker.server" = "Server";
+"qrExport.button.copy" = "Copy Link";
+"qrExport.button.copied" = "Copied";
+"qrExport.button.share" = "Share";
+"qrExport.empty" = "Nothing to export — this profile has no Shadowsocks servers.";
+"qrExport.error.tooLong" = "This link is too long to fit in a QR code. Use Copy or Share instead.";
+"qrExport.caption.subscription" = "Scan to import this subscription URL into another client.";
+"qrExport.caption.shadowsocks" = "Scan to import this server into any Shadowsocks-compatible client.";
+"qrExport.a11y.qrImage %@" = "QR code for %@";
 "subscriptions.toolbar.a11y.add" = "Add subscription";
 "subscriptions.toolbar.addFromURL" = "Add from URL";
 "subscriptions.toolbar.importFromFile" = "Import from iCloud Drive…";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -87,6 +87,20 @@
 "subscriptions.row.a11y.refresh %@" = "刷新 %@";
 "subscriptions.row.a11y.editInfo %@" = "重命名或编辑 %@ 的信息";
 "subscriptions.row.a11y.editInfoHint" = "打开名称与 URL 编辑器";
+"subscriptions.row.a11y.exportQR %@" = "导出 %@ 的二维码";
+"subscriptions.row.a11y.exportQRHint" = "显示可扫描的分享链接二维码";
+
+/* QR export sheet */
+"qrExport.nav.title" = "导出二维码";
+"qrExport.picker.server" = "服务器";
+"qrExport.button.copy" = "复制链接";
+"qrExport.button.copied" = "已复制";
+"qrExport.button.share" = "分享";
+"qrExport.empty" = "没有可导出的内容 — 此配置不包含 Shadowsocks 服务器。";
+"qrExport.error.tooLong" = "链接过长，无法生成二维码。请使用复制或分享。";
+"qrExport.caption.subscription" = "扫描即可将此订阅地址导入其他客户端。";
+"qrExport.caption.shadowsocks" = "扫描即可将此服务器导入任意兼容 Shadowsocks 的客户端。";
+"qrExport.a11y.qrImage %@" = "%@ 的二维码";
 "subscriptions.toolbar.a11y.add" = "添加订阅";
 "subscriptions.toolbar.addFromURL" = "从 URL 添加";
 "subscriptions.toolbar.importFromFile" = "从 iCloud 云盘导入…";

--- a/App/Sources/AppModelContainer.swift
+++ b/App/Sources/AppModelContainer.swift
@@ -20,6 +20,7 @@ enum AppModelContainer {
             )
             let container = try ModelContainer(for: schema, configurations: config)
             seedProfileForUITestsIfRequested(container)
+            seedShadowsocksProfileForUITestsIfRequested(container)
             seedScreenshotDemoIfRequested(container)
             return Holder(container: container)
         } catch {
@@ -61,6 +62,27 @@ enum AppModelContainer {
             yamlBackup: "proxies:\n  - name: seed\n    type: direct\n",
         )
         context.insert(profile)
+        try? context.save()
+    }
+
+    /// `-SeedShadowsocksProfile <name>` seeds the locally generated
+    /// Shadowsocks profile (template render, marker line included) with one
+    /// server, so QR-export tests act on an existing exportable row instead
+    /// of driving the add flow — same "Save Password?" rationale as above.
+    private static func seedShadowsocksProfileForUITestsIfRequested(_ container: ModelContainer) {
+        let args = ProcessInfo.processInfo.arguments
+        guard args.contains("-UITests"), let idx = args.firstIndex(of: "-SeedShadowsocksProfile"),
+              idx + 1 < args.count,
+              let yaml = try? ShadowsocksConfigBuilder.render(servers: [ShadowsocksServer(
+                  name: "seed-ss",
+                  server: "qr-export.example.com",
+                  port: 8388,
+                  cipher: "aes-128-gcm",
+                  password: "seed-password",
+              )])
+        else { return }
+        let context = ModelContext(container)
+        context.insert(Profile(name: args[idx + 1], url: "", yamlContent: yaml, yamlBackup: yaml))
         try? context.save()
     }
 

--- a/App/Sources/Services/ShadowsocksURIEncoder.swift
+++ b/App/Sources/Services/ShadowsocksURIEncoder.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Renders a ``ShadowsocksServer`` back into a SIP002 `ss://` share link —
+/// the inverse of ``ShadowsocksURIParser`` — so locally added servers can be
+/// exported as QR codes.
+///
+/// Output shapes:
+/// - SS-2022 ciphers (`2022-…`): plain percent-encoded `method:password`
+///   userinfo, per SIP002's AEAD-2022 recommendation.
+/// - Everything else: unpadded base64url `method:password` userinfo.
+/// - Plugins are re-spelled in SIP003 form (`name;key=value;flag`), with the
+///   engine's canonical names mapped back to the share-link spellings the
+///   parser canonicalizes from (`obfs` → `obfs-local`).
+///
+/// The `udp` field has no SIP002 representation and is not exported.
+enum ShadowsocksURIEncoder {
+    static func encode(_ server: ShadowsocksServer) -> String {
+        var uri = "ss://\(userinfo(server))@\(hostText(server.server)):\(server.port)"
+        if let plugin = server.plugin, !plugin.isEmpty {
+            let value = sip003Value(plugin, server.pluginOpts)
+            uri += "/?plugin=\(percentEncode(value))"
+        }
+        if !server.name.isEmpty {
+            uri += "#\(percentEncode(server.name))"
+        }
+        return uri
+    }
+
+    // MARK: - Components
+
+    private static func userinfo(_ server: ShadowsocksServer) -> String {
+        if server.cipher.hasPrefix("2022-") {
+            return "\(percentEncode(server.cipher)):\(percentEncode(server.password))"
+        }
+        return base64URLNoPad("\(server.cipher):\(server.password)")
+    }
+
+    /// Clash YAML stores IPv6 literals bare; the URI authority needs brackets.
+    private static func hostText(_ host: String) -> String {
+        host.contains(":") ? "[\(host)]" : host
+    }
+
+    /// Joins plugin name and options into a SIP003 option string. Boolean
+    /// `true` options are emitted as bare flags (`fast_open`), matching how
+    /// the parser decodes them, so the pair round-trips.
+    private static func sip003Value(
+        _ plugin: String,
+        _ opts: [ShadowsocksServer.PluginOption],
+    ) -> String {
+        let (name, mapped) = shareLinkPlugin(plugin, opts)
+        var parts = [name]
+        for opt in mapped {
+            parts.append(opt.value == "true" ? opt.key : "\(opt.key)=\(opt.value)")
+        }
+        return parts.joined(separator: ";")
+    }
+
+    /// Inverse of the parser's `canonicalizePlugin`: the engine's `obfs`
+    /// plugin is spelled `obfs-local` in share links, with `mode`/`host`
+    /// spelled `obfs`/`obfs-host`.
+    private static func shareLinkPlugin(
+        _ plugin: String,
+        _ opts: [ShadowsocksServer.PluginOption],
+    ) -> (String, [ShadowsocksServer.PluginOption]) {
+        guard plugin == ShadowsocksServer.obfsPlugin else { return (plugin, opts) }
+        let mapped = opts.map { opt in
+            switch opt.key {
+            case "mode": ShadowsocksServer.PluginOption("obfs", opt.value)
+            case "host": ShadowsocksServer.PluginOption("obfs-host", opt.value)
+            default: opt
+            }
+        }
+        return ("obfs-local", mapped)
+    }
+
+    // MARK: - Encoding helpers
+
+    /// RFC 3986 unreserved characters — everything else is percent-encoded.
+    /// Deliberately stricter than `urlQueryAllowed` so SIP003 separators
+    /// (`;`, `=`) inside the plugin value can't be confused with URI syntax,
+    /// matching the fully-encoded examples in the SIP002 spec.
+    private static let unreserved: CharacterSet = {
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "-._~")
+        return set
+    }()
+
+    private static func percentEncode(_ text: String) -> String {
+        text.addingPercentEncoding(withAllowedCharacters: unreserved) ?? text
+    }
+
+    private static func base64URLNoPad(_ text: String) -> String {
+        Data(text.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/App/Sources/Views/QRExportSheet.swift
+++ b/App/Sources/Views/QRExportSheet.swift
@@ -1,0 +1,191 @@
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+
+/// Renders a share-link payload as a QR code image. CoreImage emits a
+/// 1pt-per-module bitmap; callers scale it up with interpolation disabled so
+/// the modules stay crisp.
+enum QRCodeRenderer {
+    static func image(for payload: String, scale: CGFloat = 12) -> UIImage? {
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(payload.utf8)
+        filter.correctionLevel = "M"
+        guard let output = filter.outputImage else { return nil }
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        guard let cgImage = CIContext().createCGImage(scaled, from: scaled.extent) else {
+            return nil
+        }
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+/// Shows one or more share-link payloads as scannable QR codes — a profile's
+/// Clash subscription URL, or the `ss://` URIs of the locally added
+/// Shadowsocks servers. Multiple payloads (one per server) get a picker.
+struct QRExportSheet: View {
+    struct Payload: Identifiable, Equatable, Hashable {
+        var title: String
+        var text: String
+
+        var id: String {
+            title + "\n" + text
+        }
+    }
+
+    enum Kind {
+        case subscriptionURL
+        case shadowsocksURI
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    let kind: Kind
+    let payloads: [Payload]
+    @State private var selection: Payload?
+    @State private var copied = false
+
+    init(kind: Kind, payloads: [Payload]) {
+        self.kind = kind
+        self.payloads = payloads
+        _selection = State(initialValue: payloads.first)
+    }
+
+    private var current: Payload? {
+        selection ?? payloads.first
+    }
+
+    private var captionKey: LocalizedStringKey {
+        switch kind {
+        case .subscriptionURL: "qrExport.caption.subscription"
+        case .shadowsocksURI: "qrExport.caption.shadowsocks"
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let payload = current {
+                    payloadView(payload)
+                } else {
+                    // Only reachable if the generated profile's YAML was
+                    // hand-edited down to zero ss proxies.
+                    Text("qrExport.empty")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .padding()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AppTheme.screenBackground)
+            .navigationTitle("qrExport.nav.title")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("common.close") { dismiss() }
+                        .accessibilityIdentifier("qrExport.closeButton")
+                }
+            }
+        }
+    }
+
+    private func payloadView(_ payload: Payload) -> some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                if payloads.count > 1 {
+                    serverPicker
+                }
+                qrImage(payload)
+                payloadText(payload)
+                actionButtons(payload)
+                Text(captionKey)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(20)
+        }
+    }
+
+    private var serverPicker: some View {
+        Picker("qrExport.picker.server", selection: $selection) {
+            ForEach(payloads) { item in
+                Text(item.title).tag(Optional(item))
+            }
+        }
+        .pickerStyle(.menu)
+        .tint(AppTheme.accent)
+        .accessibilityIdentifier("qrExport.serverPicker")
+    }
+
+    @ViewBuilder
+    private func qrImage(_ payload: Payload) -> some View {
+        if let image = QRCodeRenderer.image(for: payload.text) {
+            Image(uiImage: image)
+                .resizable()
+                .interpolation(.none)
+                .scaledToFit()
+                .frame(maxWidth: 280)
+                // QR quiet zone: always white behind dark modules so
+                // scanners keep contrast in dark mode too.
+                .padding(16)
+                .background(Color.white, in: RoundedRectangle(cornerRadius: 16))
+                .accessibilityLabel(Text("qrExport.a11y.qrImage \(payload.title)"))
+                .accessibilityIdentifier("qrExport.qrImage")
+        } else {
+            // A payload can exceed QR capacity (~2.9 KB at level M) —
+            // e.g. a very long subscription URL. Copying still works.
+            Text("qrExport.error.tooLong")
+                .font(.callout)
+                .foregroundStyle(.red)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private func payloadText(_ payload: Payload) -> some View {
+        Text(payload.text)
+            .font(.caption.monospaced())
+            .foregroundStyle(.secondary)
+            .textSelection(.enabled)
+            .lineLimit(6)
+            .truncationMode(.middle)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(
+                AppTheme.panel,
+                in: RoundedRectangle(cornerRadius: 12),
+            )
+            .accessibilityIdentifier("qrExport.payloadText")
+    }
+
+    private func actionButtons(_ payload: Payload) -> some View {
+        HStack(spacing: 10) {
+            Button {
+                UIPasteboard.general.string = payload.text
+                copied = true
+                Task {
+                    try? await Task.sleep(for: .seconds(1.5))
+                    copied = false
+                }
+            } label: {
+                Label(
+                    copied ? "qrExport.button.copied" : "qrExport.button.copy",
+                    systemImage: copied ? "checkmark" : "doc.on.doc",
+                )
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.roundedRectangle(radius: 8))
+            .tint(AppTheme.accent)
+            .accessibilityIdentifier("qrExport.copyButton")
+
+            ShareLink(item: payload.text) {
+                Label("qrExport.button.share", systemImage: "square.and.arrow.up")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.roundedRectangle(radius: 8))
+            .tint(AppTheme.accent)
+            .accessibilityIdentifier("qrExport.shareButton")
+        }
+    }
+}

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -10,6 +10,7 @@ struct SubscriptionsView: View {
     @State private var showingImporter = false
     @State private var editing: Profile?
     @State private var editingInfo: Profile?
+    @State private var exporting: Profile?
     @State private var error: String?
 
     var body: some View {
@@ -79,6 +80,19 @@ struct SubscriptionsView: View {
                                 .buttonStyle(.borderless)
                                 .accessibilityLabel(Text("subscriptions.row.a11y.refresh \(profile.name)"))
                                 .accessibilityHint(Text("subscriptions.row.a11y.refreshHint"))
+                            }
+                            if isExportable(profile) {
+                                Button {
+                                    exporting = profile
+                                } label: {
+                                    Image(systemName: "qrcode")
+                                        .frame(minWidth: 44, minHeight: 44)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.borderless)
+                                .accessibilityLabel(Text("subscriptions.row.a11y.exportQR \(profile.name)"))
+                                .accessibilityHint(Text("subscriptions.row.a11y.exportQRHint"))
+                                .accessibilityIdentifier("subscriptions.row.exportQR")
                             }
                             Button {
                                 editingInfo = profile
@@ -162,6 +176,9 @@ struct SubscriptionsView: View {
         }
         .sheet(item: $editingInfo) { profile in
             EditSubscriptionInfoSheet(profile: profile, error: $error)
+        }
+        .sheet(item: $exporting) { profile in
+            QRExportSheet(kind: exportKind(profile), payloads: exportPayloads(profile))
         }
         .alert("common.error", isPresented: .constant(error != nil)) {
             Button("common.ok") { error = nil }
@@ -304,6 +321,32 @@ struct SubscriptionsView: View {
             )
         }
         return yaml
+    }
+}
+
+// MARK: - QR export
+
+extension SubscriptionsView {
+    /// A profile is QR-exportable when there's a share link to encode: the
+    /// locally generated Shadowsocks profile exports per-server `ss://` URIs,
+    /// URL subscriptions export the subscription URL itself. Local YAML
+    /// imports (empty URL, not generated) have nothing link-shaped to share.
+    private func isExportable(_ profile: Profile) -> Bool {
+        ShadowsocksConfigBuilder.isGenerated(profile.yamlContent) || !profile.url.isEmpty
+    }
+
+    private func exportKind(_ profile: Profile) -> QRExportSheet.Kind {
+        ShadowsocksConfigBuilder.isGenerated(profile.yamlContent) ? .shadowsocksURI : .subscriptionURL
+    }
+
+    private func exportPayloads(_ profile: Profile) -> [QRExportSheet.Payload] {
+        if ShadowsocksConfigBuilder.isGenerated(profile.yamlContent) {
+            return ShadowsocksConfigBuilder.extractServers(from: profile.yamlContent).map {
+                QRExportSheet.Payload(title: $0.name, text: ShadowsocksURIEncoder.encode($0))
+            }
+        }
+        guard !profile.url.isEmpty else { return [] }
+        return [QRExportSheet.Payload(title: profile.name, text: profile.url)]
     }
 }
 

--- a/MeowTests/Parsing/ShadowsocksURIEncoderTests.swift
+++ b/MeowTests/Parsing/ShadowsocksURIEncoderTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+@testable import meow_ios
+import Testing
+
+/// `ss://` share-link generation for QR export: SIP002 output shapes and,
+/// critically, round-tripping through ``ShadowsocksURIParser`` so an exported
+/// QR code re-imports as the identical server (`udp` excepted — SIP002 has no
+/// representation for it).
+@Suite("Shadowsocks URI encoder", .tags(.parsing))
+struct ShadowsocksURIEncoderTests {
+    /// Round-trip equality modulo `udp`, which the URI format can't carry.
+    private func expectRoundTrips(_ server: ShadowsocksServer) throws {
+        var reparsed = try ShadowsocksURIParser.parse(ShadowsocksURIEncoder.encode(server))
+        reparsed.udp = server.udp
+        #expect(reparsed == server)
+    }
+
+    @Test
+    func `encodes AEAD cipher as base64url userinfo with fragment name`() throws {
+        let server = ShadowsocksServer(
+            name: "My Node",
+            server: "example.com",
+            port: 8443,
+            cipher: "aes-128-gcm",
+            password: "secret!pw",
+        )
+        let uri = ShadowsocksURIEncoder.encode(server)
+        #expect(uri.hasPrefix("ss://"))
+        #expect(uri.hasSuffix("#My%20Node"))
+        // Userinfo is unpadded base64url, not plain method:password.
+        #expect(!uri.contains("aes-128-gcm:"))
+        #expect(!uri.contains("="))
+        try expectRoundTrips(server)
+    }
+
+    @Test
+    func `encodes SS-2022 cipher as plain percent-encoded userinfo`() throws {
+        let server = ShadowsocksServer(
+            name: "n1",
+            server: "host.example.net",
+            port: 443,
+            cipher: "2022-blake3-aes-256-gcm",
+            password: "MTIzNDU2Nzg5MDEyMzQ1Ng==",
+        )
+        let uri = ShadowsocksURIEncoder.encode(server)
+        #expect(uri.contains("2022-blake3-aes-256-gcm:MTIzNDU2Nzg5MDEyMzQ1Ng%3D%3D@"))
+        try expectRoundTrips(server)
+    }
+
+    @Test
+    func `brackets IPv6 hosts`() throws {
+        let server = ShadowsocksServer(
+            name: "v6",
+            server: "2001:db8::1",
+            port: 443,
+            cipher: "aes-128-gcm",
+            password: "pw",
+        )
+        #expect(ShadowsocksURIEncoder.encode(server).contains("@[2001:db8::1]:443"))
+        try expectRoundTrips(server)
+    }
+
+    @Test
+    func `round-trips password containing @ and colon`() throws {
+        try expectRoundTrips(ShadowsocksServer(
+            name: "tricky",
+            server: "1.2.3.4",
+            port: 8388,
+            cipher: "aes-256-gcm",
+            password: "p@ss:word",
+        ))
+    }
+
+    @Test
+    func `encodes ech-tls-tunnel plugin options in order with bare flags`() throws {
+        let server = ShadowsocksServer(
+            name: "ech-sgp",
+            server: "sgp.example.com",
+            port: 443,
+            cipher: "aes-128-gcm",
+            password: "pw",
+            plugin: ShadowsocksServer.echTLSPlugin,
+            pluginOpts: [
+                .init("mode", "client"),
+                .init("sni", "sgp.example.com"),
+                .init("path", "/ws-abc"),
+                .init("ech_config", "QUJDRA=="),
+                .init("fingerprint", "chrome"),
+                .init("fast_open", "true"),
+            ],
+        )
+        let uri = ShadowsocksURIEncoder.encode(server)
+        // Fully percent-encoded SIP003 value: `;` → %3B, `=` → %3D.
+        #expect(uri.contains("plugin=ech-tls-tunnel%3Bmode%3Dclient%3Bsni%3D"))
+        // Boolean true is a bare flag, so no `fast_open=true`.
+        #expect(uri.contains("%3Bfast_open#"))
+        try expectRoundTrips(server)
+    }
+
+    @Test
+    func `spells the engine's obfs plugin as obfs-local in share links`() throws {
+        let server = ShadowsocksServer(
+            name: "obfs",
+            server: "obfs.example.com",
+            port: 8388,
+            cipher: "aes-256-gcm",
+            password: "pw",
+            plugin: ShadowsocksServer.obfsPlugin,
+            pluginOpts: [
+                .init("mode", "http"),
+                .init("host", "www.bing.com"),
+            ],
+        )
+        let uri = ShadowsocksURIEncoder.encode(server)
+        #expect(uri.contains("obfs-local%3Bobfs%3Dhttp%3Bobfs-host%3Dwww.bing.com"))
+        // The parser canonicalizes obfs-local back to the engine spelling.
+        try expectRoundTrips(server)
+    }
+
+    @Test
+    func `round-trips v2ray-plugin with boolean flags`() throws {
+        try expectRoundTrips(ShadowsocksServer(
+            name: "ws",
+            server: "ws.example.com",
+            port: 443,
+            cipher: "chacha20-ietf-poly1305",
+            password: "pw",
+            plugin: ShadowsocksServer.v2rayPlugin,
+            pluginOpts: [
+                .init("mode", "websocket"),
+                .init("tls", "true"),
+                .init("host", "cdn.example.com"),
+                .init("path", "/ws"),
+                .init("mux", "true"),
+            ],
+        ))
+    }
+
+    @Test
+    func `percent-encodes non-ASCII names`() throws {
+        let server = ShadowsocksServer(
+            name: "香港 01",
+            server: "hk.example.com",
+            port: 443,
+            cipher: "aes-128-gcm",
+            password: "pw",
+        )
+        let uri = ShadowsocksURIEncoder.encode(server)
+        #expect(!uri.contains("香港"))
+        try expectRoundTrips(server)
+    }
+
+    @Test
+    func `omits the fragment for empty names`() {
+        let server = ShadowsocksServer(
+            name: "",
+            server: "example.com",
+            port: 443,
+            cipher: "aes-128-gcm",
+            password: "pw",
+        )
+        #expect(!ShadowsocksURIEncoder.encode(server).contains("#"))
+    }
+}

--- a/MeowTests/Services/QRCodeRendererTests.swift
+++ b/MeowTests/Services/QRCodeRendererTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+@testable import meow_ios
+import Testing
+import UIKit
+
+/// QR bitmap generation for the export sheet: real share-link payloads render,
+/// module edges stay crisp under integer scaling, and over-capacity payloads
+/// fail soft (nil → the sheet shows its too-long notice instead of a QR).
+@Suite("QR code renderer", .tags(.service))
+struct QRCodeRendererTests {
+    @Test
+    func `renders a scannable-size image for a share link`() throws {
+        let uri = "ss://YWVzLTEyOC1nY206c2VjcmV0@example.com:8443#Node"
+        let image = try #require(QRCodeRenderer.image(for: uri))
+        // 12pt per module and a Version-lucky payload still lands well above
+        // the ~200px floor scanners want.
+        #expect(image.size.width >= 200)
+        #expect(image.size.width == image.size.height)
+    }
+
+    @Test
+    func `renders subscription URLs with query parameters`() {
+        let url = "https://sub.example.com/api/v1/client/subscribe?token=abc123&flag=clash"
+        #expect(QRCodeRenderer.image(for: url) != nil)
+    }
+
+    @Test
+    func `returns nil when the payload exceeds QR capacity`() {
+        // Level-M byte capacity tops out at 2331 bytes (Version 40).
+        let oversized = String(repeating: "x", count: 3000)
+        #expect(QRCodeRenderer.image(for: oversized) == nil)
+    }
+}

--- a/MeowUITests/Flows/ExportQRFlowTests.swift
+++ b/MeowUITests/Flows/ExportQRFlowTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+/// Flow: add a Shadowsocks server, then export it back out as a QR code from
+/// the subscriptions list. Asserts the sheet renders a QR image whose payload
+/// is the server's `ss://` share link.
+final class ExportQRFlowTests: XCTestCase {
+    override func setUp() {
+        continueAfterFailure = false
+    }
+
+    func testExportShadowsocksServerAsQRCode() {
+        let meow = MeowApp()
+        meow.launch()
+        let app = meow.app
+
+        // Add a server manually so the generated local profile exists.
+        meow.subscriptionsTab.tap()
+        let addMenu = app.buttons["subscriptions.toolbar.add"]
+        XCTAssertTrue(addMenu.waitForExistence(timeout: 5))
+        addMenu.tap()
+        let item = app.buttons["subscriptions.toolbar.addShadowsocks"]
+        XCTAssertTrue(item.waitForExistence(timeout: 5))
+        item.tap()
+
+        let server = app.textFields["ssAdd.serverField"]
+        XCTAssertTrue(server.waitForExistence(timeout: 5))
+        server.tap()
+        server.typeText("qr-export.example.com")
+        let port = app.textFields["ssAdd.portField"]
+        port.tap()
+        port.typeText("8388")
+        let password = app.secureTextFields["ssAdd.passwordField"]
+        password.tap()
+        password.typeText("hunter22")
+        app.buttons["ssAdd.addButton"].tap()
+        XCTAssertTrue(app.staticTexts["My Servers"].waitForExistence(timeout: 10))
+
+        // The generated profile row offers QR export.
+        let export = app.buttons["subscriptions.row.exportQR"].firstMatch
+        XCTAssertTrue(export.waitForExistence(timeout: 5))
+        export.tap()
+
+        // Sheet shows a QR image plus the ss:// share link it encodes.
+        XCTAssertTrue(app.images["qrExport.qrImage"].waitForExistence(timeout: 5))
+        let payload = app.staticTexts["qrExport.payloadText"]
+        XCTAssertTrue(payload.exists)
+        XCTAssertTrue((payload.label).hasPrefix("ss://"))
+
+        app.buttons["qrExport.closeButton"].tap()
+        XCTAssertFalse(app.images["qrExport.qrImage"].waitForExistence(timeout: 2))
+    }
+}

--- a/MeowUITests/Flows/ExportQRFlowTests.swift
+++ b/MeowUITests/Flows/ExportQRFlowTests.swift
@@ -1,42 +1,25 @@
 import XCTest
 
-/// Flow: add a Shadowsocks server, then export it back out as a QR code from
-/// the subscriptions list. Asserts the sheet renders a QR image whose payload
-/// is the server's `ss://` share link.
+/// Flow: export a Shadowsocks server as a QR code from the subscriptions
+/// list. The generated local profile is seeded via `-SeedShadowsocksProfile`
+/// rather than driving the add flow — its password SecureField triggers an
+/// iOS "Save Password?" dialog that covers the list (same reason the rename
+/// flow seeds via `-SeedProfile`).
 final class ExportQRFlowTests: XCTestCase {
     override func setUp() {
         continueAfterFailure = false
     }
 
     func testExportShadowsocksServerAsQRCode() {
-        let meow = MeowApp()
-        meow.launch()
-        let app = meow.app
+        let app = XCUIApplication()
+        app.launchArguments += ["-UITests", "-ResetState", "-SeedShadowsocksProfile", "My Servers"]
+        app.launch()
 
-        // Add a server manually so the generated local profile exists.
-        meow.subscriptionsTab.tap()
-        let addMenu = app.buttons["subscriptions.toolbar.add"]
-        XCTAssertTrue(addMenu.waitForExistence(timeout: 5))
-        addMenu.tap()
-        let item = app.buttons["subscriptions.toolbar.addShadowsocks"]
-        XCTAssertTrue(item.waitForExistence(timeout: 5))
-        item.tap()
-
-        let server = app.textFields["ssAdd.serverField"]
-        XCTAssertTrue(server.waitForExistence(timeout: 5))
-        server.tap()
-        server.typeText("qr-export.example.com")
-        let port = app.textFields["ssAdd.portField"]
-        port.tap()
-        port.typeText("8388")
-        let password = app.secureTextFields["ssAdd.passwordField"]
-        password.tap()
-        password.typeText("hunter22")
-        app.buttons["ssAdd.addButton"].tap()
-        XCTAssertTrue(app.staticTexts["My Servers"].waitForExistence(timeout: 10))
+        app.tabBars.buttons["Subscriptions"].tap()
+        XCTAssertTrue(app.staticTexts["My Servers"].waitForExistence(timeout: 5))
 
         // The generated profile row offers QR export.
-        let export = app.buttons["subscriptions.row.exportQR"].firstMatch
+        let export = app.buttons["subscriptions.row.exportQR"]
         XCTAssertTrue(export.waitForExistence(timeout: 5))
         export.tap()
 
@@ -44,7 +27,7 @@ final class ExportQRFlowTests: XCTestCase {
         XCTAssertTrue(app.images["qrExport.qrImage"].waitForExistence(timeout: 5))
         let payload = app.staticTexts["qrExport.payloadText"]
         XCTAssertTrue(payload.exists)
-        XCTAssertTrue((payload.label).hasPrefix("ss://"))
+        XCTAssertTrue(payload.label.hasPrefix("ss://"))
 
         app.buttons["qrExport.closeButton"].tap()
         XCTAssertFalse(app.images["qrExport.qrImage"].waitForExistence(timeout: 2))

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0784F0245333B91BE515A7F1 /* EngineOverviewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3521886886FB3552D3753B1B /* EngineOverviewSection.swift */; };
 		07BE855FF6DC83A07129C654 /* SubscriptionDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */; };
 		08501362516FC991AE70B3EF /* DiagnosticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA20D7D98E7BC4663E289174 /* DiagnosticsViewController.swift */; };
+		08E3A9B66D5881AF7F22A799 /* ShadowsocksURIEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03081064CD4E37ACB92EA355 /* ShadowsocksURIEncoderTests.swift */; };
 		0AAE287B7127912BEE7EFC15 /* HomeScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59B5D27EF37B635FC5B38AA /* HomeScreenTests.swift */; };
 		0B13BCBE3F3A575D7E213399 /* TunnelLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB11E2BC5612E27CCE83B0DC /* TunnelLifecycleTests.swift */; };
 		0BDA436570A2C655E8210F0C /* TunnelSettingsLANExclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703008DEDF15E37B8C951A9A /* TunnelSettingsLANExclusionTests.swift */; };
@@ -39,6 +40,7 @@
 		2E4C5E6BA16E22D2EAD4EB22 /* MeowAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1746752AC889A678F94A02 /* MeowAPITests.swift */; };
 		2E70DD05E62B166087AA7207 /* TunnelSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41537EBB7380469E247A65 /* TunnelSettings.swift */; };
 		3211232F74DEF5C2141AAB3F /* MeowModels in Frameworks */ = {isa = PBXBuildFile; productRef = A4C4C3CB93C1D3A437D659F8 /* MeowModels */; };
+		33E77D1331C9AA6795569373 /* ExportQRFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00F6BDADF0FACF2ED3B0447 /* ExportQRFlowTests.swift */; };
 		34358821D3A262F7D08C62D9 /* MeowIPC in Frameworks */ = {isa = PBXBuildFile; productRef = 0CA41BA11AE3954D104A7AB8 /* MeowIPC */; };
 		34B4F8F808C424CBAF8E7EA9 /* MWSharedStore.m in Sources */ = {isa = PBXBuildFile; fileRef = AB83B7A37D165EF0E16A47BA /* MWSharedStore.m */; };
 		3BAE21D06E5B9935E58FDF1B /* MeowAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A693FE7115671D717A87F1DB /* MeowAPITypes.swift */; };
@@ -52,6 +54,7 @@
 		4A6D4B20B4094E334F26892F /* TunBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC654683AAE620AA9C1DCEBF /* TunBridgeTests.swift */; };
 		4AFF0859870D8941AC3CE716 /* MeowIPC in Frameworks */ = {isa = PBXBuildFile; productRef = BE92B6925662A398B4A18E9C /* MeowIPC */; };
 		4C1FB9714B9308B7577B9622 /* MeowModels in Frameworks */ = {isa = PBXBuildFile; productRef = 564BE37A8BC742522CCABC5E /* MeowModels */; };
+		4E0EE8ED5787010E844F6F87 /* ShadowsocksURIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF63D9219A475F002F2734 /* ShadowsocksURIEncoder.swift */; };
 		4E366621A02CAF97E4AA2EF2 /* RulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE160D91FCAFCD07383E8CB5 /* RulesTests.swift */; };
 		4F29B935B393F48182AC7CE4 /* MWIPCListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 329B260F122D91D5DDB24C44 /* MWIPCListener.m */; };
 		4F396A44EF40DD59F1A79D3B /* ShadowsocksConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2286E52FC6D973728DE5D1A8 /* ShadowsocksConfigBuilderTests.swift */; };
@@ -104,6 +107,7 @@
 		A247AFB42C2CB73BACCD3CB0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A2F021F1A3C84F902320EB /* SettingsView.swift */; };
 		A582A655A6EA5FF633395AD9 /* ChinaDirectKeywords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3172561A6CE70D61D7666597 /* ChinaDirectKeywords.swift */; };
 		A80A176366D289562219D18D /* DarwinBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B120EAA4365C4F723B0FED /* DarwinBridgeTests.swift */; };
+		A9CC84474AFAAD1C4DCE3CAC /* QRCodeRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF623F1E34B38A27E15C6B36 /* QRCodeRendererTests.swift */; };
 		AB4AFCDA6C326D173F7C6D01 /* SubscriptionDeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B306CE837FA7A17D7D561877 /* SubscriptionDeepLinkTests.swift */; };
 		ACB0FE6DC7CD1D5E824CCB35 /* EngineBootTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1046B4656B3C3717791D82D4 /* EngineBootTests.swift */; };
 		ADBD29F9A34A3AF34057D104 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1880D3F09797DFE2718AFC /* AppModel.swift */; };
@@ -138,6 +142,7 @@
 		DCC6938C0A43984B033BCD68 /* AppIPCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */; };
 		DE9A4BC5630A1A55FD1880C4 /* RenameSubscriptionFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25242F15DCC48F0C6C9BAD2C /* RenameSubscriptionFlowTests.swift */; };
 		DF9A0976E5BE73EF1F9DFC91 /* VpnToggleFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */; };
+		DFC8E7A2F7941A994200FF6C /* QRExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257652A3B2BA6B1E11BA6252 /* QRExportSheet.swift */; };
 		E164E98C5E2EDB5B326E2B98 /* UtilityScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */; };
 		E5EEB30272FBA79B72C45004 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AFFBA5F04A152705EE60CA /* AccessibilityTests.swift */; };
 		E64DA5B39E08AF0DF25BFCBC /* LocalizableParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7002E0BC1FFE0A41FEBE8F6 /* LocalizableParityTests.swift */; };
@@ -199,6 +204,7 @@
 /* Begin PBXFileReference section */
 		00F3DBAD225AF1027B18873A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		01E90E01A4CE68C4F872A40B /* ConnectionsScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionsScreenTests.swift; sourceTree = "<group>"; };
+		03081064CD4E37ACB92EA355 /* ShadowsocksURIEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksURIEncoderTests.swift; sourceTree = "<group>"; };
 		0539F84A7F111BFF4BDD1840 /* MWSharedStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWSharedStore.h; sourceTree = "<group>"; };
 		06D2AA0F7CC09650CF8263EF /* RulesYAMLEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesYAMLEditor.swift; sourceTree = "<group>"; };
 		08020B398C102C110F6A8567 /* SharedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStoreTests.swift; sourceTree = "<group>"; };
@@ -217,6 +223,7 @@
 		24AB2D298F7A38F31686BF15 /* VpnManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VpnManagerTests.swift; sourceTree = "<group>"; };
 		24F2E3A9014A186B34D8A465 /* MWDarwinBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDarwinBridge.m; sourceTree = "<group>"; };
 		25242F15DCC48F0C6C9BAD2C /* RenameSubscriptionFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameSubscriptionFlowTests.swift; sourceTree = "<group>"; };
+		257652A3B2BA6B1E11BA6252 /* QRExportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRExportSheet.swift; sourceTree = "<group>"; };
 		2583E90C66D44FFDC834DAB9 /* DeepLinkImportConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkImportConfirmation.swift; sourceTree = "<group>"; };
 		2646E6E7241DEDBA8C6127C6 /* ShadowsocksConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksConfigBuilder.swift; sourceTree = "<group>"; };
 		2D7D7768D31382CD90DFEBA6 /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
@@ -309,6 +316,7 @@
 		BC43530025FE948C50C6C78E /* ConnectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionsTests.swift; sourceTree = "<group>"; };
 		BC8D42838BD27620D7F278DE /* RulesEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesEditorView.swift; sourceTree = "<group>"; };
 		BCEC443073450BDC4FC7E1D3 /* MWEngineLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWEngineLog.h; sourceTree = "<group>"; };
+		C0FF63D9219A475F002F2734 /* ShadowsocksURIEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksURIEncoder.swift; sourceTree = "<group>"; };
 		C2BB9ECB4E5C46D70B0CE6B2 /* RulesYAMLEditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesYAMLEditorTests.swift; sourceTree = "<group>"; };
 		C2BE1F013E2C0B2B1E591FEA /* MWDiagnosticsRunner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWDiagnosticsRunner.h; sourceTree = "<group>"; };
 		C5D0FAA1804EB1A35F47036A /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
@@ -317,12 +325,14 @@
 		CDFB76E2466D24EF8DF96740 /* BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
 		CF2336C906828FDB560633D6 /* ProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTests.swift; sourceTree = "<group>"; };
 		CFAA1935B322CD5DD66E23F0 /* URLValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLValidationTests.swift; sourceTree = "<group>"; };
+		D00F6BDADF0FACF2ED3B0447 /* ExportQRFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportQRFlowTests.swift; sourceTree = "<group>"; };
 		D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionDeepLink.swift; sourceTree = "<group>"; };
 		D1A7AFDD113E049439EEE4A9 /* MeowShared */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MeowShared; path = MeowShared; sourceTree = SOURCE_ROOT; };
 		D51C2BC68B7800884B68643F /* DiagnosticsLabelParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLabelParserTests.swift; sourceTree = "<group>"; };
 		D5A3FCA37BA819ACC0A9D0EB /* AddShadowsocksFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddShadowsocksFlowTests.swift; sourceTree = "<group>"; };
 		D7A0587577F4B11031F0816D /* ProxiesDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxiesDecodingTests.swift; sourceTree = "<group>"; };
 		DAEF8BEDC4B0E7EF70E37EE1 /* UtilitySessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStoreTests.swift; sourceTree = "<group>"; };
+		DF623F1E34B38A27E15C6B36 /* QRCodeRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeRendererTests.swift; sourceTree = "<group>"; };
 		DFC4AC97B3877B1A566FBFF6 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		E327200BE05E4504B91CAACC /* .swiftformat */ = {isa = PBXFileReference; path = .swiftformat; sourceTree = "<group>"; };
 		E56D18B0FBFA455C9F60134A /* UserDiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDiagnosticsView.swift; sourceTree = "<group>"; };
@@ -471,6 +481,7 @@
 			children = (
 				D5A3FCA37BA819ACC0A9D0EB /* AddShadowsocksFlowTests.swift */,
 				9CA7DC0A8AEAA9185A7B40F0 /* AddSubscriptionFlowTests.swift */,
+				D00F6BDADF0FACF2ED3B0447 /* ExportQRFlowTests.swift */,
 				25242F15DCC48F0C6C9BAD2C /* RenameSubscriptionFlowTests.swift */,
 				8E4FF4D4C7BBBCF3E43AF134 /* VpnToggleFlowTests.swift */,
 				3BA2BC08659A01899A4DB2CC /* YamlEditorFlowTests.swift */,
@@ -493,6 +504,7 @@
 			children = (
 				8B8C6076C2AFE3F87452DDEF /* DeepLinkImportConfirmationTests.swift */,
 				7D8C1AC6AD4590D6827E6188 /* GeoAssetStagerTests.swift */,
+				DF623F1E34B38A27E15C6B36 /* QRCodeRendererTests.swift */,
 				F5B378E3EF2591C9CD059E98 /* ShadowsocksAddServiceTests.swift */,
 				B306CE837FA7A17D7D561877 /* SubscriptionDeepLinkTests.swift */,
 				A43280DA576025F244CD1432 /* SubscriptionServiceTests.swift */,
@@ -554,6 +566,7 @@
 				8E8D0D6120471BD1DBC4ACFB /* NavRow.swift */,
 				3B0CE1B314060B8B82956086 /* ProvidersView.swift */,
 				B7193B43D94BD4897FEDF967 /* ProxyGroupsView.swift */,
+				257652A3B2BA6B1E11BA6252 /* QRExportSheet.swift */,
 				1711243E170547D1DA68FCD6 /* RuleEditorSheet.swift */,
 				BC8D42838BD27620D7F278DE /* RulesEditorView.swift */,
 				8A1CBAFD55A777C3B13296E2 /* RulesView.swift */,
@@ -603,6 +616,7 @@
 				A693FE7115671D717A87F1DB /* MeowAPITypes.swift */,
 				06D2AA0F7CC09650CF8263EF /* RulesYAMLEditor.swift */,
 				2646E6E7241DEDBA8C6127C6 /* ShadowsocksConfigBuilder.swift */,
+				C0FF63D9219A475F002F2734 /* ShadowsocksURIEncoder.swift */,
 				48800BB67F7CB5E42F942A83 /* ShadowsocksURIParser.swift */,
 				601ADF66737508CC359C4936 /* SubscriptionConverter.swift */,
 				D17FF5C7044F3F3FF3153128 /* SubscriptionDeepLink.swift */,
@@ -759,6 +773,7 @@
 			children = (
 				FD9FC97CA0606C12439B0684 /* EmojiGroupSelectNodeTests.swift */,
 				2286E52FC6D973728DE5D1A8 /* ShadowsocksConfigBuilderTests.swift */,
+				03081064CD4E37ACB92EA355 /* ShadowsocksURIEncoderTests.swift */,
 				6052B63FD334E86DC81BAE1E /* ShadowsocksURIParserTests.swift */,
 				4B0AD4D11A4D395987DD843B /* SubscriptionParserTests.swift */,
 			);
@@ -1108,6 +1123,7 @@
 				F29284A5EE821CC192BE2993 /* AddShadowsocksFlowTests.swift in Sources */,
 				FA6DFC3CA7B13A278CB1D630 /* AddSubscriptionFlowTests.swift in Sources */,
 				7770F0EA76C4181C58C020EC /* AppShellTests.swift in Sources */,
+				33E77D1331C9AA6795569373 /* ExportQRFlowTests.swift in Sources */,
 				0AAE287B7127912BEE7EFC15 /* HomeScreenTests.swift in Sources */,
 				528DCD00B7A73F10142E0455 /* MeowApp.swift in Sources */,
 				DE9A4BC5630A1A55FD1880C4 /* RenameSubscriptionFlowTests.swift in Sources */,
@@ -1159,10 +1175,12 @@
 				8C45959FE9EE5CD0D3F06BB7 /* ProfileTests.swift in Sources */,
 				25931B4F38353E7DF1CD7F5E /* ProxiesDecodingTests.swift in Sources */,
 				D2FF19F899EE357591812068 /* ProxyGroupModelTests.swift in Sources */,
+				A9CC84474AFAAD1C4DCE3CAC /* QRCodeRendererTests.swift in Sources */,
 				4E366621A02CAF97E4AA2EF2 /* RulesTests.swift in Sources */,
 				C7B7EACD6297D7AA66065602 /* RulesYAMLEditorTests.swift in Sources */,
 				938E95C0263F042450113B67 /* ShadowsocksAddServiceTests.swift in Sources */,
 				4F396A44EF40DD59F1A79D3B /* ShadowsocksConfigBuilderTests.swift in Sources */,
+				08E3A9B66D5881AF7F22A799 /* ShadowsocksURIEncoderTests.swift in Sources */,
 				648D6C8316865A3DFBD6766D /* ShadowsocksURIParserTests.swift in Sources */,
 				4660565BBEE9CDFD88BD62AF /* SharedStoreTests.swift in Sources */,
 				AB4AFCDA6C326D173F7C6D01 /* SubscriptionDeepLinkTests.swift in Sources */,
@@ -1212,6 +1230,7 @@
 				4702884A9BD243CD419172C4 /* ProvidersView.swift in Sources */,
 				784598C57754825780BD4F2C /* ProxyGroupModel.swift in Sources */,
 				90E26674740B7C7141781B01 /* ProxyGroupsView.swift in Sources */,
+				DFC8E7A2F7941A994200FF6C /* QRExportSheet.swift in Sources */,
 				C0EE6EDCE210308C46DE6856 /* RuleEditorSheet.swift in Sources */,
 				B92365F2ACFA408CA226CA7F /* RulesEditorView.swift in Sources */,
 				8E43F6904E5AAD529AACBA1C /* RulesView.swift in Sources */,
@@ -1221,6 +1240,7 @@
 				43CC40E5E8E7DEEB9E61CEB8 /* ShadowsocksConfigBuilder.swift in Sources */,
 				D49CAAAAB4878A24C8A7D52B /* ShadowsocksQRScannerSheet.swift in Sources */,
 				2534B8CDD2E40D5F2105C9EF /* ShadowsocksServer.swift in Sources */,
+				4E0EE8ED5787010E844F6F87 /* ShadowsocksURIEncoder.swift in Sources */,
 				27E34E45FFE9A9D2242373E2 /* ShadowsocksURIParser.swift in Sources */,
 				9ADDC891C0BCC6053E86E2E2 /* SubscriptionConverter.swift in Sources */,
 				07BE855FF6DC83A07129C654 /* SubscriptionDeepLink.swift in Sources */,


### PR DESCRIPTION
## Summary

Adds QR-code export to the subscriptions list, closing the share-out loop (we could already scan QR codes in, but not produce them):

- **New `ShadowsocksURIEncoder`** — renders a `ShadowsocksServer` back into a SIP002 `ss://` share link, the exact inverse of `ShadowsocksURIParser`: unpadded base64url userinfo (plain percent-encoded userinfo for SS-2022 ciphers), IPv6 bracketing, SIP003 plugin string with bare boolean flags, and reverse plugin canonicalization (`obfs` → `obfs-local`, `mode`/`host` → `obfs`/`obfs-host`) so exported links round-trip through our own parser and import cleanly into other Shadowsocks clients. `udp` has no SIP002 representation and is documented as not exported.
- **New `QRExportSheet` + `QRCodeRenderer`** — CoreImage QR generation on a forced-white quiet zone (scannable in dark mode), a server picker when the generated profile holds several servers, copy + share fallbacks, and a graceful notice when a payload exceeds QR byte capacity.
- **`SubscriptionsView`** — new `qrcode` row button: the locally generated Shadowsocks profile exports per-server `ss://` URIs; URL subscriptions export the subscription URL. Local YAML imports (no URL) have nothing link-shaped to share and show no button.
- **`-SeedShadowsocksProfile` launch arg** — seeds the generated SS profile for UI tests (the add flow's SecureField triggers the iOS "Save Password?" dialog, which covers the list).
- Localized en + zh-Hans.

## Tests

- `ShadowsocksURIEncoderTests` (9 cases): output-shape assertions plus field-for-field round-trip through `ShadowsocksURIParser` for AEAD, SS-2022, IPv6, tricky passwords, ech-tls-tunnel / obfs / v2ray plugins, non-ASCII names.
- `QRCodeRendererTests` (3 cases): scannable size, URL payloads, over-capacity returns nil.
- `ExportQRFlowTests` (UI): seeded profile → export button → QR image + `ss://` payload → close.

## Path B local-CI attestation

- [x] `swiftformat --lint .` at repo root → 0 violations
- [x] `swiftlint --strict` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -testLanguage en` → **TEST SUCCEEDED** (all suites; UI diff so MeowUITests included; no service-layer/engine/IPC changes so MeowIntegrationTests not in scope; no Rust changes)
- [x] `git diff origin/main...HEAD --stat` verified — 10 files, exactly the feature's sources/tests/strings/pbxproj, no accidental additions

Baseline: main CI run 29171916755 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)