### PR TITLE
Move config-list refresh into the leading swipe menu

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -72,6 +72,7 @@
 "subscriptions.add.button.add" = "Add";
 "subscriptions.add.button.adding" = "Adding…";
 "subscriptions.editInfo.swipe" = "Edit Info";
+"subscriptions.refresh.swipe" = "Refresh";
 "subscriptions.editInfo.nav.title" = "Edit Subscription";
 "subscriptions.editInfo.button.save" = "Save";
 "subscriptions.editInfo.footer" = "Changes to the URL take effect on the next refresh.";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "subscriptions.add.button.add" = "添加";
 "subscriptions.add.button.adding" = "添加中…";
 "subscriptions.editInfo.swipe" = "编辑信息";
+"subscriptions.refresh.swipe" = "刷新";
 "subscriptions.editInfo.nav.title" = "编辑订阅";
 "subscriptions.editInfo.button.save" = "保存";
 "subscriptions.editInfo.footer" = "网址的更改将在下次刷新时生效。";

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -69,18 +69,6 @@ struct SubscriptionsView: View {
                             .accessibilityLabel(Text("subscriptions.row.a11y.edit \(profile.name)"))
                             .accessibilityHint(Text("subscriptions.row.a11y.editHint"))
                             .accessibilityIdentifier("subscriptions.row.editYaml")
-                            if !profile.url.isEmpty {
-                                Button {
-                                    Task { try? await service.refresh(profile) }
-                                } label: {
-                                    Image(systemName: "arrow.clockwise")
-                                        .frame(minWidth: 44, minHeight: 44)
-                                        .contentShape(Rectangle())
-                                }
-                                .buttonStyle(.borderless)
-                                .accessibilityLabel(Text("subscriptions.row.a11y.refresh \(profile.name)"))
-                                .accessibilityHint(Text("subscriptions.row.a11y.refreshHint"))
-                            }
                             if isExportable(profile) {
                                 Button {
                                     exporting = profile
@@ -116,6 +104,17 @@ struct SubscriptionsView: View {
                     .listRowSeparator(.hidden)
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     .swipeActions(edge: .leading) {
+                        if !profile.url.isEmpty {
+                            Button {
+                                Task { try? await service.refresh(profile) }
+                            } label: {
+                                Label("subscriptions.refresh.swipe", systemImage: "arrow.clockwise")
+                            }
+                            .tint(.blue)
+                            .accessibilityLabel(Text("subscriptions.row.a11y.refresh \(profile.name)"))
+                            .accessibilityHint(Text("subscriptions.row.a11y.refreshHint"))
+                            .accessibilityIdentifier("subscriptions.row.refresh")
+                        }
                         Button {
                             editingInfo = profile
                         } label: {


### PR DESCRIPTION
## Summary
- Remove the inline refresh (arrow.clockwise) button from the subscription/config row's trailing action cluster
- Add Refresh as the first action in the leading swipe menu (ahead of Edit Info), still shown only for profiles with a remote URL
- Keep the existing accessibility label/hint, add the `subscriptions.row.refresh` identifier, and add `subscriptions.refresh.swipe` strings (en: "Refresh", zh-Hans: "刷新")

## Test plan
- `swiftformat --lint` and `swiftlint --strict` pass on the changed file
- App builds for the iOS simulator (arm64)
- MeowTests unit bundle: 203 tests in 35 suites pass on iPhone 17 Pro simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)