### PR TITLE
feat(dns): switch meow-dns to redir-host mode with DoT-only upstreams

### DIFF
--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -363,7 +363,7 @@ int meow_tun_tcp_idle_ttl_ms(void);
  * outbound UDP datagrams to destination port 443 (QUIC's transport) and
  * answers SVCB (64) / HTTPS (65) DNS queries NOERROR-empty from the
  * intercept itself (no h3/SvcParams advertisement), forcing clients onto
- * the A / fake-IPv4 + TCP path.
+ * the A + TCP path.
  *
  * At the FFI layer the new value applies immediately to subsequent UDP
  * datagrams and DNS queries (the backing flag is a plain atomic). The

--- a/MeowIntegrationTests/EngineIntegration/EngineBootTests.swift
+++ b/MeowIntegrationTests/EngineIntegration/EngineBootTests.swift
@@ -131,8 +131,7 @@ private struct EngineFixture {
         dns:
           enable: true
           listen: 127.0.0.1:57953
-          enhanced-mode: fake-ip
-          fake-ip-range: 28.0.0.0/8
+          enhanced-mode: redir-host
           nameserver:
             - 119.29.29.29
         mode: rule

--- a/MeowIntegrationTests/EngineIntegration/TunBridgeTests.swift
+++ b/MeowIntegrationTests/EngineIntegration/TunBridgeTests.swift
@@ -164,8 +164,7 @@ private struct EngineFixture {
         dns:
           enable: true
           listen: 127.0.0.1:57954
-          enhanced-mode: fake-ip
-          fake-ip-range: 28.0.0.0/8
+          enhanced-mode: redir-host
           nameserver:
             - 119.29.29.29
         mode: rule

--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -83,10 +83,11 @@ public enum EffectiveConfigWriter {
             "enhanced-mode": "redir-host",
             // DNS-over-TLS only — mirrors meow_patch_config: redir-host makes
             // every resolver answer a real dial target, so plaintext upstreams
-            // would let a poisoned answer become the connect address.
+            // would let a poisoned answer become the connect address. 1.1.1.1
+            // only; 1.0.0.1:853 is unreachable from the networks this app
+            // targets.
             "nameserver": [
                 "tls://1.1.1.1",
-                "tls://1.0.0.1",
             ],
         ]
         root["external-controller"] = "127.0.0.1:\(apiCredentials.port)"

--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -5,7 +5,8 @@ import Yams
 /// actually loads. Mirrors the Android `MeowInstance.start` pipeline:
 ///
 ///   1. Remove user-managed `dns:` and `subscriptions:` blocks — the extension
-///      owns DNS (fake-ip + local listener) and the app owns subscription fetching.
+///      owns DNS (redir-host + local listener) and the app owns subscription
+///      fetching.
 ///   2. Override `secret:` with the random bearer token minted for this install.
 ///   3. Pin `mixed-port` (defaults to 7890), `allow-lan`, `bind-address`, and
 ///      a DNS listener so tun2socks and LAN clients can use meow's listeners.
@@ -79,11 +80,13 @@ public enum EffectiveConfigWriter {
         root["dns"] = [
             "enable": true,
             "listen": "\(bindAddress):\(defaultDNSPort)",
-            "enhanced-mode": "fake-ip",
-            "fake-ip-range": "28.0.0.0/8",
+            "enhanced-mode": "redir-host",
+            // DNS-over-TLS only — mirrors meow_patch_config: redir-host makes
+            // every resolver answer a real dial target, so plaintext upstreams
+            // would let a poisoned answer become the connect address.
             "nameserver": [
-                "119.29.29.29",
-                "223.5.5.5",
+                "tls://1.1.1.1",
+                "tls://1.0.0.1",
             ],
         ]
         root["external-controller"] = "127.0.0.1:\(apiCredentials.port)"

--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -83,11 +83,12 @@ public enum EffectiveConfigWriter {
             "enhanced-mode": "redir-host",
             // DNS-over-TLS only — mirrors meow_patch_config: redir-host makes
             // every resolver answer a real dial target, so plaintext upstreams
-            // would let a poisoned answer become the connect address. 1.1.1.1
-            // only; 1.0.0.1:853 is unreachable from the networks this app
-            // targets.
+            // would let a poisoned answer become the connect address. Both
+            // halves of Cloudflare's official anycast pair; the pool is
+            // queried in parallel, first success wins.
             "nameserver": [
                 "tls://1.1.1.1",
+                "tls://1.0.0.1",
             ],
         ]
         root["external-controller"] = "127.0.0.1:\(apiCredentials.port)"

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -41,7 +41,7 @@ struct EffectiveConfigWriterTests {
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         let dns = parsed?["dns"] as? [String: Any]
         #expect(dns?["listen"] as? String == "127.0.0.1:1053")
-        #expect((dns?["nameserver"] as? [String]) == ["tls://1.1.1.1", "tls://1.0.0.1"])
+        #expect((dns?["nameserver"] as? [String]) == ["tls://1.1.1.1"])
     }
 
     @Test

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -41,7 +41,7 @@ struct EffectiveConfigWriterTests {
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         let dns = parsed?["dns"] as? [String: Any]
         #expect(dns?["listen"] as? String == "127.0.0.1:1053")
-        #expect((dns?["nameserver"] as? [String]) == ["tls://1.1.1.1"])
+        #expect((dns?["nameserver"] as? [String]) == ["tls://1.1.1.1", "tls://1.0.0.1"])
     }
 
     @Test

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -41,7 +41,7 @@ struct EffectiveConfigWriterTests {
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         let dns = parsed?["dns"] as? [String: Any]
         #expect(dns?["listen"] as? String == "127.0.0.1:1053")
-        #expect((dns?["nameserver"] as? [String]) == ["119.29.29.29", "223.5.5.5"])
+        #expect((dns?["nameserver"] as? [String]) == ["tls://1.1.1.1", "tls://1.0.0.1"])
     }
 
     @Test

--- a/PacketTunnel/Sources/MWTunnelSettings.m
+++ b/PacketTunnel/Sources/MWTunnelSettings.m
@@ -21,10 +21,10 @@
     // CN bypass (when the app's pre-connect probe verified the config routes
     // GEOIP,CN → DIRECT): keep mainland-China destinations on the physical
     // interface instead of relaying them through the netstack just for the
-    // engine to DIRECT-dial them again. With meow-dns in fake-IP mode this
-    // covers literal-IP flows (apps dialing real IPs, app-side DoH results,
-    // IP-based CDNs/gaming); domain flows enter via fake IPs and keep the
-    // engine's full rule treatment either way.
+    // engine to DIRECT-dial them again. With meow-dns in redir-host mode
+    // every destination is a real IP, so this covers domain flows (resolved
+    // through the in-TUN resolver) as well as literal-IP flows (apps dialing
+    // real IPs, app-side DoH results, IP-based CDNs/gaming).
     NSArray<NEIPv4Route *> *v4Excluded = [self ipv4LanExcludedRoutes];
     if (cnBypass) {
         v4Excluded = [v4Excluded arrayByAddingObjectsFromArray:cnBypass.ipv4Routes];

--- a/core/rust/macos-utun-harness/src/main.rs
+++ b/core/rust/macos-utun-harness/src/main.rs
@@ -3,7 +3,7 @@
 //!
 //! Bridges the same C-ABI surface the iOS PacketTunnelProvider drives
 //! (`meow_core_*`, `meow_engine_*`, `meow_tun_*`) into a real macOS `utun`
-//! interface, so the engine + fake-IP DNS + CN-bypass + tun2socks
+//! interface, so the engine + redir-host DNS + CN-bypass + tun2socks
 //! dispatch paths can be exercised with actual packets without an iPhone
 //! and without going through the iOS Simulator (which has no TUN host).
 //!
@@ -129,9 +129,10 @@ struct Args {
     /// into its NAT table per packet. Use a REAL, reachable dst that won't
     /// answer the chosen UDP port (e.g. `8.8.8.8:4433`): DIRECT dial succeeds
     /// (so the session is created), no reply ever arrives (so it goes idle),
-    /// and the egress goes out the default route — no fake-IP, no DNS loop,
-    /// no routing loop. This is the deterministic way to drive the UDP NAT
-    /// leak path; `--udp-stress-target` (socket-based) needs fake-IP routing.
+    /// and the egress goes out the default route — no DNS loop, no routing
+    /// loop. This is the deterministic way to drive the UDP NAT leak path;
+    /// `--udp-stress-target` (socket-based) needs the target routed into
+    /// the tun.
     /// dst port MUST NOT be 53 (that hits the DNS intercept, not the NAT).
     #[arg(long)]
     udp_inject_target: Option<String>,
@@ -597,7 +598,7 @@ fn udp_stress_loop(
         workers.push(thread::spawn(move || {
             // Folded into the payload so a DNS/echo responder sees varying
             // content (and, aimed at the engine DNS with distinct qnames,
-            // churns the fake-IP pool too).
+            // churns the resolver cache too).
             let mut seq = 0u64;
             while !SHUTDOWN.load(Ordering::Relaxed) {
                 if let Some(limit) = duration {
@@ -691,7 +692,7 @@ fn udp_stress_loop(
 /// bypassing the OS route table, system DNS, and the utun device. Each fresh
 /// source is a new NAT 5-tuple the engine inserts into `nat_table`; with a
 /// non-answering dst the session goes idle and the NAT sweeper must reap it.
-/// Deterministic, no network setup, no fake-IP, no routing/DNS loop.
+/// Deterministic, no network setup, no routing/DNS loop.
 fn udp_inject_loop(dst: std::net::SocketAddr, rate: u64, duration: Option<std::time::Duration>) {
     let dst_ip = match dst.ip() {
         std::net::IpAddr::V4(v4) => v4.octets(),

--- a/core/rust/meow-ios-ffi/src/cn_bypass.rs
+++ b/core/rust/meow-ios-ffi/src/cn_bypass.rs
@@ -172,41 +172,17 @@ fn terminal_is_direct(cfg: &Config, name: &str, metadata: &Metadata) -> bool {
     false
 }
 
-/// The fake-IP pool `meow_patch_config` pins (`dns.fake-ip-range`). Every
-/// fake-IP destination must keep routing INTO the tunnel, so a CN CIDR that
-/// overlaps this pool (possible after a Country.mmdb update — 28/8 is
-/// unallocated today) must never reach the excluded-route set: excluding it
-/// would black-hole all fake-IP'd traffic for those addresses.
-const FAKE_IP_POOL_START: u32 = 28 << 24; // 28.0.0.0
-const FAKE_IP_POOL_END: u32 = (29 << 24) - 1; // 28.255.255.255
-
 /// Enumerate the CN v4/v6 CIDRs from the MMDB, merged/simplified by
-/// `CountryIndex` — the exact set a `GEOIP,CN` rule matches against — minus
-/// anything overlapping the fake-IP pool.
+/// `CountryIndex` — the exact set a `GEOIP,CN` rule matches against. With
+/// meow-dns in redir-host mode every destination is a real IP, so the full
+/// set is safe to exclude from the TUN (no fake-IP pool to protect).
 fn cn_ranges(mmdb_path: &Path) -> Result<(Vec<String>, Vec<String>)> {
     let reader = maxminddb::Reader::open_readfile(mmdb_path)
         .with_context(|| format!("opening GeoIP MMDB at {}", mmdb_path.display()))?;
     let allowed: HashSet<String> = std::iter::once("CN".to_string()).collect();
     let index = CountryIndex::build(&reader, &allowed).map_err(|e| anyhow!(e))?;
     let ranges = index.ranges_for("CN");
-    let mut skipped = 0usize;
-    let v4 = ranges
-        .v4
-        .iter()
-        .filter(|net| {
-            let start = u32::from(net.network());
-            let end = u32::from(net.broadcast());
-            let overlaps_pool = start <= FAKE_IP_POOL_END && end >= FAKE_IP_POOL_START;
-            skipped += usize::from(overlaps_pool);
-            !overlaps_pool
-        })
-        .map(|net| net.to_string())
-        .collect();
-    if skipped > 0 {
-        tracing::warn!(
-            "cn-bypass: dropped {skipped} CN range(s) overlapping the fake-IP pool 28.0.0.0/8"
-        );
-    }
+    let v4 = ranges.v4.iter().map(|net| net.to_string()).collect();
     let v6 = ranges.v6.iter().map(|net| net.to_string()).collect();
     Ok((v4, v6))
 }

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -2,10 +2,10 @@
 //! DNS listeners that `tun2socks` dials through loopback.
 //!
 //! DNS is delegated end-to-end to meow's resolver. The pinned `dns:` block from
-//! `meow_patch_config` puts the resolver in fake-IP mode with the FFI's chosen
-//! CIDR (`28.0.0.0/8`) and a local DNS listen socket. The tun2socks UDP/53
-//! path sends non-blocked DNS queries to that listener, so synthesis and
-//! fake-IP reverse mapping stay owned by meow-dns.
+//! `meow_patch_config` puts the resolver in redir-host (Mapping) mode with a
+//! local DNS listen socket. The tun2socks UDP/53 path sends non-blocked DNS
+//! queries to that listener, so upstream resolution and the IP → host reverse
+//! cache stay owned by meow-dns.
 //!
 //! Lifecycle: `start(config_path)` spawns the REST API on the meow-engine
 //! tokio runtime and keeps its `JoinHandle` in `EngineState`. `stop()` aborts
@@ -83,14 +83,14 @@ fn prepare_ios_config(yaml: &str) -> Result<String> {
             "tproxy-port",
             "listeners",
             // Drop the entire `sniffer:` block. meow's
-            // `pre_handle_metadata` reverses each fake-IP destination back
-            // to the qname recorded by the resolver before rule matching,
-            // so SNI/ALPN sniffing is redundant — and when enabled it would
-            // overwrite the resolver-derived hostname based on whatever the
-            // sniffer parses out of the first TLS / HTTP record, which is a
-            // regression versus the authoritative qname captured at DNS
-            // resolution time. Strip at the FFI boundary so user
-            // subscriptions can't re-enable it.
+            // `pre_handle_metadata` folds the qname recorded by the
+            // resolver's reverse cache into each destination before rule
+            // matching, so SNI/ALPN sniffing is redundant — and when enabled
+            // it would overwrite the resolver-derived hostname based on
+            // whatever the sniffer parses out of the first TLS / HTTP
+            // record, which is a regression versus the authoritative qname
+            // captured at DNS resolution time. Strip at the FFI boundary so
+            // user subscriptions can't re-enable it.
             "sniffer",
         ] {
             m.remove(serde_yaml::Value::String(key.to_string()));
@@ -248,9 +248,9 @@ pub fn start(config_path: &str) -> Result<()> {
     // 2-worker engine runtime (data path + REST API both freeze). The meow-dns
     // resolver resolves async, coalesces concurrent lookups, and caches —
     // collapsing the burst to one lookup. `resolve_ip` returns real addresses
-    // (fake-IP synthesis lives only in the DNS-server `lookup_ipv4/6` path), so
-    // the upstream never resolves to a 28.x fake IP. Android installs the same
-    // hook plus a `SocketProtector` via its JNI bridge; iOS needs only the hook
+    // (redir-host mode never synthesises fake IPs anywhere). Android installs
+    // the same hook plus a `SocketProtector` via its JNI bridge; iOS needs only
+    // the hook
     // (the NE process's own sockets already bypass its tunnel).
     meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(resolver.clone())));
 
@@ -351,9 +351,9 @@ pub fn start(config_path: &str) -> Result<()> {
     let listeners = cfg.listeners.named.clone();
     let log_tx = log_broadcast_tx().clone();
 
-    // No FFI-side fake-IP pool, no FFI-side CN-IP table, no resolver hand-off:
-    // meow's own fake-IP pool owns synthesis + reverse mapping behind the DNS
-    // listener that tun2socks dials.
+    // No FFI-side DNS cache, no FFI-side CN-IP table, no resolver hand-off:
+    // meow's own resolver owns upstream resolution + the IP → host reverse
+    // cache behind the DNS listener that tun2socks dials.
 
     let api_task = cfg.api.external_controller.map(|addr| {
         let api_server = ApiServer::new(
@@ -534,8 +534,7 @@ bind-address: 0.0.0.0
 dns:
   enable: true
   listen: 0.0.0.0:1053
-  enhanced-mode: fake-ip
-  fake-ip-range: 28.0.0.0/8
+  enhanced-mode: redir-host
   nameserver:
     - 119.29.29.29
 rules:

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -746,13 +746,17 @@ pub unsafe extern "C" fn meow_patch_config(
     // target, so a poisoned plaintext answer would become the address we
     // actually connect (or CN-bypass around the TUN) to — encrypt the
     // upstream instead. IP-literal entries need no bootstrap nameserver, and
-    // rustls validates Cloudflare's IP-SAN certificate directly. 1.1.1.1
-    // only: its anycast twin 1.0.0.1 is unreachable on :853 from the
-    // networks this app targets (verified 2026-07-17), and a dead pool
-    // entry just adds a doomed dial per query.
+    // rustls validates Cloudflare's IP-SAN certificate directly. Both halves
+    // of Cloudflare's official anycast pair: the resolver queries the pool
+    // in parallel and takes the first success, so a twin that's unreachable
+    // on some networks (1.0.0.1:853 times out on some CN paths) costs only
+    // a doomed dial there while providing redundancy elsewhere.
     dns.insert(
         serde_yaml::Value::String("nameserver".into()),
-        serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("tls://1.1.1.1".into())]),
+        serde_yaml::Value::Sequence(vec![
+            serde_yaml::Value::String("tls://1.1.1.1".into()),
+            serde_yaml::Value::String("tls://1.0.0.1".into()),
+        ]),
     );
     root.insert(
         serde_yaml::Value::String("dns".into()),
@@ -1185,7 +1189,7 @@ rules:
         assert!(patched.contains("enhanced-mode: redir-host"));
         assert!(!patched.contains("fake-ip-range"));
         assert!(patched.contains("tls://1.1.1.1"));
-        assert!(!patched.contains("tls://1.0.0.1"));
+        assert!(patched.contains("tls://1.0.0.1"));
         assert!(!patched.contains("119.29.29.29"));
         assert!(!patched.contains("subscriptions:"));
     }

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -13,11 +13,11 @@
 //! The staticlib owns separate tokio runtimes for the packet/netstack driver
 //! and for meow engine work so lwIP backpressure cannot starve the
 //! REST/API/proxy workers. DNS is delegated to a local meow-dns UDP listener
-//! running in fake-IP mode: the tun2socks UDP/53 path still answers
-//! IPv6-disabled AAAA and HTTP/3-blocked HTTPS/SVCB queries NOERROR-empty
-//! itself, then sends other DNS queries to the listener. The FFI no longer
-//! carries its own fake-IP pool, china-DNS split-horizon, CN-IP table, DoH
-//! cache, or in-FFI TCP-DNS client.
+//! running in redir-host (Mapping) mode: the tun2socks UDP/53 path still
+//! answers IPv6-disabled AAAA and HTTP/3-blocked HTTPS/SVCB queries
+//! NOERROR-empty itself, then sends other DNS queries to the listener. The FFI
+//! no longer carries its own DNS cache, china-DNS split-horizon, CN-IP table,
+//! DoH cache, or in-FFI TCP-DNS client.
 
 mod cn_bypass;
 mod diagnostics;
@@ -693,10 +693,11 @@ pub unsafe extern "C" fn meow_patch_config(
         return -1;
     };
 
-    // Strip `dns` (iOS pins its own resolver block — see below: fake-IP mode
-    // with the FFI's chosen `28.0.0.0/8` range, so meow-dns owns synthesis and
-    // fake-IP reverse mapping for domain-rule matching) and `subscriptions`
-    // (handled app-side). `secret` is intentionally NOT stripped here — we
+    // Strip `dns` (iOS pins its own resolver block — see below: redir-host
+    // mode, so meow-dns returns real upstream IPs and keeps the IP → host
+    // reverse cache that `pre_handle_metadata` uses for domain-rule matching)
+    // and `subscriptions` (handled app-side). `secret` is intentionally NOT
+    // stripped here — we
     // overwrite it below with a per-install random token so the REST API on
     // loopback is authenticated rather than open.
     for key in ["dns", "subscriptions"] {
@@ -734,19 +735,24 @@ pub unsafe extern "C" fn meow_patch_config(
             "listen",
             serde_yaml::Value::String(format!("{bind_addr}:{dns_port}")),
         ),
-        ("enhanced-mode", serde_yaml::Value::String("fake-ip".into())),
         (
-            "fake-ip-range",
-            serde_yaml::Value::String("28.0.0.0/8".into()),
+            "enhanced-mode",
+            serde_yaml::Value::String("redir-host".into()),
         ),
     ] {
         dns.insert(serde_yaml::Value::String(k.into()), v);
     }
+    // DNS-over-TLS only. redir-host makes every resolver answer a real dial
+    // target, so a poisoned plaintext answer would become the address we
+    // actually connect (or CN-bypass around the TUN) to — encrypt the
+    // upstream instead. IP-literal entries need no bootstrap nameserver, and
+    // rustls validates Cloudflare's IP-SAN certificate directly. 1.0.0.1 is
+    // the same anycast service, kept for redundancy.
     dns.insert(
         serde_yaml::Value::String("nameserver".into()),
         serde_yaml::Value::Sequence(vec![
-            serde_yaml::Value::String("119.29.29.29".into()),
-            serde_yaml::Value::String("223.5.5.5".into()),
+            serde_yaml::Value::String("tls://1.1.1.1".into()),
+            serde_yaml::Value::String("tls://1.0.0.1".into()),
         ]),
     );
     root.insert(
@@ -1059,7 +1065,7 @@ pub extern "C" fn meow_tun_tcp_idle_ttl_ms() -> c_int {
 /// outbound UDP datagrams to destination port 443 (QUIC's transport) and
 /// answers SVCB (64) / HTTPS (65) DNS queries NOERROR-empty from the
 /// intercept itself (no h3/SvcParams advertisement), forcing clients onto
-/// the A / fake-IPv4 + TCP path.
+/// the A + TCP path.
 ///
 /// At the FFI layer the new value applies immediately to subsequent UDP
 /// datagrams and DNS queries (the backing flag is a plain atomic). The
@@ -1177,8 +1183,11 @@ rules:
         assert!(patched.contains("allow-lan: true"));
         assert!(patched.contains("bind-address: 0.0.0.0"));
         assert!(patched.contains("listen: 0.0.0.0:1054"));
-        assert!(patched.contains("enhanced-mode: fake-ip"));
-        assert!(patched.contains("fake-ip-range: 28.0.0.0/8"));
+        assert!(patched.contains("enhanced-mode: redir-host"));
+        assert!(!patched.contains("fake-ip-range"));
+        assert!(patched.contains("tls://1.1.1.1"));
+        assert!(patched.contains("tls://1.0.0.1"));
+        assert!(!patched.contains("119.29.29.29"));
         assert!(!patched.contains("subscriptions:"));
     }
 

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -746,14 +746,13 @@ pub unsafe extern "C" fn meow_patch_config(
     // target, so a poisoned plaintext answer would become the address we
     // actually connect (or CN-bypass around the TUN) to — encrypt the
     // upstream instead. IP-literal entries need no bootstrap nameserver, and
-    // rustls validates Cloudflare's IP-SAN certificate directly. 1.0.0.1 is
-    // the same anycast service, kept for redundancy.
+    // rustls validates Cloudflare's IP-SAN certificate directly. 1.1.1.1
+    // only: its anycast twin 1.0.0.1 is unreachable on :853 from the
+    // networks this app targets (verified 2026-07-17), and a dead pool
+    // entry just adds a doomed dial per query.
     dns.insert(
         serde_yaml::Value::String("nameserver".into()),
-        serde_yaml::Value::Sequence(vec![
-            serde_yaml::Value::String("tls://1.1.1.1".into()),
-            serde_yaml::Value::String("tls://1.0.0.1".into()),
-        ]),
+        serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("tls://1.1.1.1".into())]),
     );
     root.insert(
         serde_yaml::Value::String("dns".into()),
@@ -1186,7 +1185,7 @@ rules:
         assert!(patched.contains("enhanced-mode: redir-host"));
         assert!(!patched.contains("fake-ip-range"));
         assert!(patched.contains("tls://1.1.1.1"));
-        assert!(patched.contains("tls://1.0.0.1"));
+        assert!(!patched.contains("tls://1.0.0.1"));
         assert!(!patched.contains("119.29.29.29"));
         assert!(!patched.contains("subscriptions:"));
     }

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -7,31 +7,30 @@
 //! callback registered in [`start`]. No file descriptors cross the FFI.
 //!
 //! DNS: A (1), TXT (16), MX (15), PTR (12), and other non-blocked queries are
-//! sent as raw UDP packets to the local meow-dns listener. A gets fake-IP
-//! synthesis there; generic qtypes get meow-dns's upstream-forward behavior.
-//! AAAA (28) queries are answered NOERROR-empty by the FFI itself when IPv6 is
-//! disabled in app settings (the default) — the fake-IP pool is v4-only, so
-//! stripping AAAA forces every client onto it instead of leaking (or
-//! black-holing) connections over v6. When IPv6 is enabled, AAAA queries are
-//! forwarded to meow-dns like A queries — with a v4-only fake-IP pool the
-//! resolver itself suppresses AAAA for fake-IP'd domains, so clients still land
-//! on the v4 fake path; the Swift TUN advertises an IPv6 address + default
-//! route so v6-literal destinations enter the netstack. When "block HTTP/3" is
-//! enabled, HTTPS/SVCB (65/64) queries also get NOERROR-empty so clients cannot
-//! discover QUIC hints.
+//! sent as raw UDP packets to the local meow-dns listener, which resolves
+//! upstream and answers with real IPs (redir-host mode). AAAA (28) queries are
+//! answered NOERROR-empty by the FFI itself when IPv6 is disabled in app
+//! settings (the default) — the tunnel is v4-only then, so stripping AAAA
+//! forces every client onto the v4 path instead of leaking (or black-holing)
+//! connections over v6. When IPv6 is enabled, AAAA queries are forwarded to
+//! meow-dns like A queries (the resolver returns real upstream IPv6
+//! addresses); the Swift TUN advertises an IPv6 address + default route so v6
+//! destinations enter the netstack. When "block HTTP/3" is enabled, HTTPS/SVCB
+//! (65/64) queries also get NOERROR-empty so clients cannot discover QUIC
+//! hints.
 //!
 //! NEDNSSettings advertises a TUN-subnet address as the system resolver, so
 //! every UDP DNS query arrives as an in-TUN IP packet. netstack turns that into
 //! a UDP payload, the FFI branches on qtype, and non-blocked queries go to the
 //! local DNS listener with the reply injected back through netstack. The
-//! resolver owns fake-IP synthesis, reverse mapping, hosts / NXDOMAIN
-//! semantics, and TTL handling; the FFI owns only the qtype peek plus the
-//! blocked-query short-circuit.
+//! resolver owns upstream resolution, the IP → host reverse cache, hosts /
+//! NXDOMAIN semantics, and TTL handling; the FFI owns only the qtype peek plus
+//! the blocked-query short-circuit.
 //!
-//! TCP/UDP destination IPs come back as fake-IPs from meow's resolver pool.
-//! `dispatch_tcp` and `dispatch_udp` pass the literal destination to the
-//! mixed listener via SOCKS5; meow's normal inbound path reverses fake-IPs back
-//! to the original qname before rule matching.
+//! TCP/UDP destination IPs are the real addresses meow's resolver answered
+//! with. `dispatch_tcp` and `dispatch_udp` pass the literal destination to the
+//! mixed listener via SOCKS5; meow's normal inbound path folds the original
+//! qname back in from the resolver's reverse cache before rule matching.
 
 use crate::logging;
 use futures::{SinkExt, StreamExt};
@@ -185,8 +184,7 @@ pub fn udp_first_reply_deadline_ms() -> u64 {
 //      handshake that still attempts a connection.
 //   2. SVCB (64) / HTTPS (65) DNS queries are answered NOERROR-empty by the
 //      intercept itself instead of being forwarded to meow-dns, so the client
-//      never learns the HTTP/3 `alpn`/SvcParams and falls back to A / fake-IPv4
-//      over TCP.
+//      never learns the HTTP/3 `alpn`/SvcParams and falls back to A over TCP.
 //
 // Both prongs are wired to this single flag. Stored Relaxed — the toggle has no
 // ordering relationship with other state; a stale read for one datagram is
@@ -710,11 +708,12 @@ async fn run_tun2socks(
     let engine_handle_for_tcp = crate::get_engine_runtime().handle().clone();
     let tcp_accept_handle = tokio::spawn(async move {
         while let Some((stream, local_addr, remote_addr)) = tcp_listener.next().await {
-            // Fake-IP mode: TCP DNS (rare, but RFC 1035 § 4.2.2 allows it
-            // when a UDP reply was truncated) inside the TUN is
-            // intentionally unsupported — iOS's stub resolver only falls
-            // back to TCP/53 for very large replies, and our fake-IP A/AAAA
-            // responses are tiny. Drop the stream so the kernel sees the
+            // TCP DNS (rare, but RFC 1035 § 4.2.2 allows it when a UDP
+            // reply was truncated) inside the TUN is intentionally
+            // unsupported — iOS's stub resolver only falls back to TCP/53
+            // for very large replies, and the A/AAAA answers meow-dns
+            // returns stay well under the UDP limit. Drop the stream so
+            // the kernel sees the
             // TCP session close; the client retries on UDP, which the
             // ingress loop intercepts.
             if remote_addr.port() == 53 {

--- a/core/rust/meow-ios-ffi/tests/stress_rss.rs
+++ b/core/rust/meow-ios-ffi/tests/stress_rss.rs
@@ -53,7 +53,7 @@ fn test_lock() -> &'static Mutex<()> {
 }
 
 /// Hand-built minimal IPv4 + UDP packet bound for 172.19.0.2:53 (the
-/// fake-IP pool's DNS server address). The intercept path in `tun2socks.rs`
+/// TUN-subnet DNS server address). The intercept path in `tun2socks.rs`
 /// matches on `dst_port == 53` regardless of dst_ip, so this is enough to
 /// exercise the spawn-per-DNS-query branch without a real engine: the
 /// spawned task short-circuits on `engine::tunnel() == None` and unwinds.


### PR DESCRIPTION
## Summary
- `meow_patch_config` now pins `enhanced-mode: redir-host` (no `fake-ip-range`): meow-dns returns real upstream IPs and keeps the IP → host reverse cache (`REVERSE_TTL_FLOOR` 600 s) that `pre_handle_metadata` folds into each connection for domain-rule matching.
- Upstream resolution is forced to DNS-over-TLS: `tls://1.1.1.1` + `tls://1.0.0.1`. In redir-host mode every resolver answer is a real dial target, so a poisoned plaintext answer would become the connect address — or worse, CN-bypass **around** the TUN. IP-literal DoT entries need no bootstrap nameserver; rustls validates Cloudflare's IP-SAN cert.
- CN-bypass: with real IPs on the wire the route exclusion now covers domain-resolved flows too, so the 28.0.0.0/8 fake-pool overlap guard in `cn_bypass.rs` is removed (there is no pool to protect).
- `EffectiveConfigWriter` (Swift mirror) and the EngineBoot/TunBridge fixtures switch to the same dns block; stale fake-IP comments updated across the FFI, harness, and `MWTunnelSettings.m`.

Note: this re-does a69fcc8 (reverted in d399129, which stated no reason); the DoT-only upstream is the new ingredient. AAAA stripping when IPv6 is off happens in the FFI intercept itself (qtype 28 → NOERROR-empty) and is mode-independent — no v6 leak from real AAAA answers.

## Local CI attestation (Path B)
1. `swiftformat --lint .` → 0 violations (0/129 files require formatting)
2. `swiftlint --strict --quiet` → exit 0
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → **TEST SUCCEEDED**; `swift test` in MeowShared → 27/27 passed; Rust: `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test` in `core/rust/meow-ios-ffi` → 58 + 2 stress tests passed; `scripts/build-rust.sh` → xcframework built; `cargo check --locked` in `core/rust/macos-utun-harness` → clean (no dep changes, lockfile untouched)
4. `git diff origin/main...HEAD --stat` verified — 12 files, all intended (FFI dns block + comments, cn_bypass guard removal, Swift mirror + fixtures, ObjC comment, regenerated `meow_core.h`)

Installed on-device (Release, devicectl) for live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)