### PR TITLE
chore(rust): bump meow-rs pin to 0.18.0 (74e8083a)

### DIFF
--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -109,15 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +148,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -256,7 +253,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
@@ -279,7 +276,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -300,7 +297,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -324,6 +321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -497,7 +503,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -563,6 +569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +595,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -675,6 +693,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +721,40 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -733,7 +796,17 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -752,9 +825,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -818,7 +901,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -841,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -849,6 +932,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1212,7 +1301,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1274,6 +1363,16 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "ctutils",
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1502,15 +1601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1675,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1750,7 +1860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1770,13 +1880,14 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "axum",
  "base64",
  "dashmap 6.2.1",
  "futures",
+ "hickory-proto",
  "libc",
  "meow-common",
  "meow-config",
@@ -1802,8 +1913,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1821,16 +1932,18 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "meow-config"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "futures-util",
  "hickory-proto",
  "httparse",
  "ipnet",
@@ -1858,8 +1971,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1920,8 +2033,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "base64",
  "libc",
@@ -1935,8 +2048,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1944,9 +2057,11 @@ dependencies = [
  "async-trait",
  "base64",
  "blake2",
+ "blake3",
  "bytes",
  "chacha20poly1305",
  "crc32fast",
+ "ctr",
  "futures",
  "h3",
  "h3-quinn",
@@ -1958,6 +2073,7 @@ dependencies = [
  "meow-common",
  "meow-dns",
  "meow-transport",
+ "ml-kem",
  "parking_lot",
  "quinn",
  "rand 0.9.4",
@@ -1973,12 +2089,13 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "webpki-roots 0.26.11",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "meow-rules"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1994,8 +2111,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2023,18 +2140,18 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
- "arc-swap",
  "async-trait",
  "dashmap 6.2.1",
  "ipnet",
+ "iprange",
  "itoa",
  "meow-common",
  "meow-dns",
@@ -2046,6 +2163,7 @@ dependencies = [
  "serde",
  "smallvec",
  "smol_str",
+ "time",
  "tokio",
  "tracing",
  "uuid",
@@ -2085,6 +2203,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,7 +2264,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2129,6 +2272,15 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "objc2"
@@ -2261,8 +2413,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2419,7 +2581,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2565,6 +2727,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2584,12 +2747,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -2617,7 +2782,7 @@ dependencies = [
  "aead",
  "ed25519",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "ring",
 ]
 
@@ -2665,7 +2830,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2856,7 +3021,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2867,7 +3032,17 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -3036,7 +3211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -3118,7 +3303,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3565,7 +3750,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -3756,6 +3941,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3848,7 +4046,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4189,6 +4387,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "yoke"

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -109,15 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +148,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -300,7 +297,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -324,6 +321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -488,7 +494,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -541,6 +547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +573,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -653,12 +671,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -700,7 +763,17 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -716,9 +789,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -770,7 +853,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -793,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -801,6 +884,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1164,7 +1253,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1226,6 +1315,16 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "ctutils",
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1530,6 +1629,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,7 +1797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1698,13 +1817,14 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "axum",
  "base64",
  "dashmap 6.2.1",
  "futures",
+ "hickory-proto",
  "libc",
  "meow-common",
  "meow-config",
@@ -1730,8 +1850,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1749,16 +1869,18 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "meow-config"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "futures-util",
  "hickory-proto",
  "httparse",
  "ipnet",
@@ -1786,8 +1908,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1850,8 +1972,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "base64",
  "libc",
@@ -1865,8 +1987,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1874,9 +1996,11 @@ dependencies = [
  "async-trait",
  "base64",
  "blake2",
+ "blake3",
  "bytes",
  "chacha20poly1305",
  "crc32fast",
+ "ctr",
  "futures",
  "h3",
  "h3-quinn",
@@ -1888,6 +2012,7 @@ dependencies = [
  "meow-common",
  "meow-dns",
  "meow-transport",
+ "ml-kem",
  "parking_lot",
  "quinn",
  "rand 0.9.4",
@@ -1903,12 +2028,13 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "webpki-roots 0.26.11",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "meow-rules"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "ipnet",
  "iprange",
@@ -1924,8 +2050,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1953,18 +2079,18 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.16.0"
-source = "git+https://github.com/madeye/meow-rs?rev=498967eed346477cf1d70760aa0b696c8b026291#498967eed346477cf1d70760aa0b696c8b026291"
+version = "0.18.0"
+source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
 dependencies = [
- "arc-swap",
  "async-trait",
  "dashmap 6.2.1",
  "ipnet",
+ "iprange",
  "itoa",
  "meow-common",
  "meow-dns",
@@ -1976,6 +2102,7 @@ dependencies = [
  "serde",
  "smallvec",
  "smol_str",
+ "time",
  "tokio",
  "tracing",
  "uuid",
@@ -2015,6 +2142,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,7 +2191,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2047,6 +2199,15 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -2164,8 +2325,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2322,7 +2493,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2468,6 +2639,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2487,12 +2659,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -2520,7 +2694,7 @@ dependencies = [
  "aead",
  "ed25519",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "ring",
 ]
 
@@ -2568,7 +2742,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2759,7 +2933,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2770,7 +2944,17 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -2945,7 +3129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -3027,7 +3221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3473,7 +3667,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -3664,6 +3858,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3756,7 +3963,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4097,6 +4304,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "yoke"

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,20 +68,19 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 498967e (meow-rs 0.16.0) — DelayHistory `time` now serializes as an
-# RFC 3339 string (meow-rs#290): the previous serde-default SystemTime object
-# made GET /proxies undecodable for the app once any probe recorded history
-# (issue #255, no latency shown in proxy groups). Also picks up tproxy fixes
-# meow-rs#267–#269 (Linux/macOS CLI only). Previous pin 6f080ec added
-# GET /dns/results (meow-rs#253), consumed by the app's DNS panel, the
-# vendored meow-anytls fork (#265) and quinn-proto/memmap2 RUSTSEC bumps
-# (#263). meow-dns still
-# runs in normal/Mapping (redir-host) mode: the resolver returns real
-# upstream IPs and keeps an IP → host reverse cache (decoupled from the DNS
-# TTL via REVERSE_TTL_FLOOR, meow-rs#240) so `pre_handle_metadata` recovers
-# the hostname for domain-rule matching. The FFI config parser pins
-# `enhanced-mode: redir-host` (no fake-ip-range); fake-IP is no longer used.
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
+# HEAD: 74e8083a (meow-rs 0.18.0) — picks up the rule-IR compilation series
+# (meow-rs#285/#291/#295–#297), lazy metadata enrichment (#292), the VMess
+# AEAD wire-format interop fix (#320), VLESS/Snell UDP-over-TCP read/write
+# fairness (#319), relay-direction fairness per buffer cycle (#347), atomic
+# traffic-snapshot publishing (#339/#341), RouteTable behind RwLock instead
+# of arc-swap (#335), DNS LRU tables no longer preallocated at capacity
+# (#337), and mihomo compat improvements (#313/#333). Windows/OpenWrt/CLI
+# work in 0.17–0.18 doesn't affect this crate. Previous pin 498967e
+# (0.16.0) made DelayHistory `time` serialize as RFC 3339 (meow-rs#290,
+# issue #255). meow-dns runs in fake-ip mode: the FFI config parser pins
+# `enhanced-mode: fake-ip` with `fake-ip-range: 28.0.0.0/8` (the 2026-07-17
+# redir-host/DoT switch was reverted in PR #321).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -89,12 +88,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "498967eed34647
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "498967eed346477cf1d70760aa0b696c8b026291" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -722,6 +722,9 @@ mod config_parse_tests {
         // Fixture has 141 ss proxies + 22 groups. Expected runtime totals:
         //   leaves = 141 ss + 3 built-ins (DIRECT, REJECT, REJECT-DROP) = 144
         //   groups = 22 user-defined (Proxies, 20 categories, Direct, Final)
+        //            + the injected mihomo-compat GLOBAL selector (meow-rs
+        //            0.18, #313) = 23. The app hides GLOBAL in
+        //            ProxyGroupModel, so it never reaches the UI.
         assert_eq!(
             leaves.len(),
             144,
@@ -729,6 +732,10 @@ mod config_parse_tests {
              meow-config was built without the `ss` feature — see commit \
              enabling default features on the meow-config dep",
         );
-        assert_eq!(groups.len(), 22, "all 22 user-defined groups must resolve");
+        assert_eq!(
+            groups.len(),
+            23,
+            "all 22 user-defined groups plus injected GLOBAL must resolve",
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Bumps the meow-rs pin from `498967e` (0.16.0) to `74e8083a` (0.18.0) across all 7 `meow-*` git deps in `core/rust/meow-ios-ffi/Cargo.toml` — 40 upstream commits, including:
  - rule-IR compilation series (meow-rs#285/#291/#295–#297) + lazy metadata enrichment (#292)
  - VMess AEAD wire-format interop fix (#320), VLESS/Snell UDP-over-TCP read/write fairness (#319)
  - relay-direction fairness per buffer cycle (#347), atomic traffic-snapshot publishing (#339/#341)
  - RouteTable arc-swap → RwLock (#335), DNS LRU tables no longer preallocated at capacity (#337)
  - mihomo compat improvements (#313/#333)
- Regenerates **both** lockfiles (`meow-ios-ffi` and `macos-utun-harness` — the harness runs `cargo test --locked` in CI; see PR #317/#318 lesson).
- Updates the config-parse fixture test: meow-rs 0.18 now injects the mihomo-compat `GLOBAL` selector group, so 23 groups resolve instead of 22. The app already hides `GLOBAL` in `ProxyGroupModel.swift`, so nothing new reaches the UI.
- Refreshes the stale pin comment in Cargo.toml (it still described the reverted redir-host DNS mode; the code pins fake-ip).

## Local verification
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-targets -- -D warnings` (meow-ios-ffi) → clean
- `cargo test` (meow-ios-ffi) → 52 passed, 0 failed
- `cargo test --locked` (macos-utun-harness) → builds + passes with the regenerated lockfile
- `scripts/build-rust.sh` → xcframework built
- Release ad-hoc IPA built and side-loaded on device via devicectl
- No Swift / YAML changes in this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)