### PR TITLE
docs: drop reverted CN-route bypass claims from README + landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ subscription — meow does not provide proxy servers.
 
 Latest version: **v1.4.0** (July 2026) — dark mode across the app, QR-code
 export for `ss://` profiles and subscription URLs, and a refreshed cat
-branding. Since then, `main` also gained automatic CN-route tunnel bypass:
-when your config rules `GEOIP,CN` to `DIRECT`, the CN CIDR set is excluded
-from the tunnel and that traffic stays on the physical interface. See the
+branding. Since then, `main` also picked up a wake-from-idle reliability
+fix — after sleep/wake the tunnel probes its data path and only restarts
+when the probe fails — plus a meow-rs engine bump to 0.18.0 and a leading
+swipe menu for refreshing individual subscriptions. See the
 [release notes](https://github.com/madeye/meow-ios/releases) for earlier
 per-version changelogs.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -528,10 +528,9 @@
             </div>
             <h3>Smart split routing</h3>
             <p>
-              Rule-based routing on domain, IP, GeoIP and GeoSITE. When a
-              config sends GEOIP,CN to DIRECT, those routes are excluded from
-              the tunnel entirely — direct traffic stays on the physical
-              interface.
+              Rule-based routing on domain, IP, GeoIP and GeoSITE — send CN
+              traffic direct and the rest through your proxy, straight from
+              your config, zero rule maintenance.
             </p>
           </div>
           <div class="feature f-cyan">


### PR DESCRIPTION
## Summary

The last docs refresh (0bad5cf) landed right after the CN-route tunnel-exclusion feature and advertised it in both the README and the landing page's "Smart split routing" card. That feature was reverted on main (PR #321), so both claims are now false.

- **README**: replace the CN-route bypass paragraph with what actually shipped on `main` since v1.4.0 — the wake data-path health probe (PR #324), the meow-rs 0.18.0 engine bump, and the subscription swipe-menu refresh.
- **docs/index.html**: reword the split-routing feature card back to a config-driven rule-routing description with no route-exclusion claim.

## Merge path

Path A (docs-only): diff touches only `README.md` and `docs/index.html` — no `App/`, `MeowCore/`, `core/`, `scripts/`, project/workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)