### PR TITLE
Persist fake IP mappings and enable SNI sniffing

### DIFF
--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -77,22 +77,7 @@ fn install_tls_provider() {
 fn prepare_ios_config(yaml: &str) -> Result<String> {
     let mut doc: serde_yaml::Value = serde_yaml::from_str(yaml).context("parsing config YAML")?;
     if let serde_yaml::Value::Mapping(m) = &mut doc {
-        for key in [
-            "port",
-            "socks-port",
-            "tproxy-port",
-            "listeners",
-            // Drop the entire `sniffer:` block. meow's
-            // `pre_handle_metadata` reverses each fake-IP destination back
-            // to the qname recorded by the resolver before rule matching,
-            // so SNI/ALPN sniffing is redundant — and when enabled it would
-            // overwrite the resolver-derived hostname based on whatever the
-            // sniffer parses out of the first TLS / HTTP record, which is a
-            // regression versus the authoritative qname captured at DNS
-            // resolution time. Strip at the FFI boundary so user
-            // subscriptions can't re-enable it.
-            "sniffer",
-        ] {
+        for key in ["port", "socks-port", "tproxy-port", "listeners"] {
             m.remove(serde_yaml::Value::String(key.to_string()));
         }
     }
@@ -482,12 +467,17 @@ log-level: info
         let out = prepare_ios_config(yaml).expect("strip ok");
         let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
         let m = doc.as_mapping().unwrap();
-        for k in ["port", "socks-port", "tproxy-port", "listeners", "sniffer"] {
+        for k in ["port", "socks-port", "tproxy-port", "listeners"] {
             assert!(
                 !m.contains_key(serde_yaml::Value::String(k.into())),
                 "{k} should have been stripped",
             );
         }
+        let sniffer = m
+            .get(serde_yaml::Value::String("sniffer".into()))
+            .and_then(|v| v.as_mapping())
+            .expect("sniffer should survive runtime preparation");
+        assert_eq!(sniffer.get("enable").and_then(|v| v.as_bool()), Some(true));
         assert_eq!(m.get("mixed-port").and_then(|v| v.as_i64()), Some(7892));
         assert_eq!(m.get("mode").and_then(|v| v.as_str()), Some("rule"));
         assert_eq!(m.get("log-level").and_then(|v| v.as_str()), Some("info"));
@@ -536,8 +526,16 @@ dns:
   listen: 0.0.0.0:1053
   enhanced-mode: fake-ip
   fake-ip-range: 28.0.0.0/8
+  store-fake-ip: true
   nameserver:
     - 119.29.29.29
+sniffer:
+  enable: true
+  parse-pure-ip: true
+  override-destination: false
+  sniff:
+    TLS:
+      ports: [443, 8443]
 rules:
   - MATCH,DIRECT
 "#;
@@ -555,6 +553,11 @@ rules:
             cfg.dns.listen_addr,
             Some("0.0.0.0:1053".parse::<SocketAddr>().unwrap())
         );
+        assert!(cfg.sniffer.enable);
+        assert!(cfg.sniffer.parse_pure_ip);
+        assert!(!cfg.sniffer.override_destination);
+        assert_eq!(cfg.sniffer.tls_ports, vec![443, 8443]);
+        assert!(cfg.sniffer.http_ports.is_empty());
     }
 
     #[test]

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -692,13 +692,12 @@ pub unsafe extern "C" fn meow_patch_config(
         return -1;
     };
 
-    // Strip `dns` (iOS pins its own resolver block — see below: fake-IP mode
-    // with the FFI's chosen `28.0.0.0/8` range, so meow-dns owns synthesis and
-    // fake-IP reverse mapping for domain-rule matching) and `subscriptions`
-    // (handled app-side). `secret` is intentionally NOT stripped here — we
-    // overwrite it below with a per-install random token so the REST API on
-    // loopback is authenticated rather than open.
-    for key in ["dns", "subscriptions"] {
+    // Strip `dns` and `sniffer` because iOS pins both blocks below: persistent
+    // fake-IP mapping plus TLS SNI inspection on the mixed listener. Strip
+    // `subscriptions` as well (handled app-side). `secret` is intentionally NOT
+    // stripped here — we overwrite it below with a per-install random token so
+    // the REST API on loopback is authenticated rather than open.
+    for key in ["dns", "sniffer", "subscriptions"] {
         root.remove(serde_yaml::Value::String(key.to_string()));
     }
 
@@ -734,6 +733,7 @@ pub unsafe extern "C" fn meow_patch_config(
             serde_yaml::Value::String(format!("{bind_addr}:{dns_port}")),
         ),
         ("enhanced-mode", serde_yaml::Value::String("fake-ip".into())),
+        ("store-fake-ip", serde_yaml::Value::Bool(true)),
         (
             "fake-ip-range",
             serde_yaml::Value::String("28.0.0.0/8".into()),
@@ -751,6 +751,37 @@ pub unsafe extern "C" fn meow_patch_config(
     root.insert(
         serde_yaml::Value::String("dns".into()),
         serde_yaml::Value::Mapping(dns),
+    );
+
+    // Always inspect TLS ClientHello SNI on the ports used by HTTPS. The
+    // sniffer writes `metadata.sniff_host`, which domain rules prefer, while
+    // `override-destination: false` deliberately preserves the hostname that
+    // fake-IP reverse mapping recovered as the actual dial target.
+    let mut tls = serde_yaml::Mapping::new();
+    tls.insert(
+        serde_yaml::Value::String("ports".into()),
+        serde_yaml::Value::Sequence(vec![
+            serde_yaml::Value::Number(443.into()),
+            serde_yaml::Value::Number(8443.into()),
+        ]),
+    );
+    let mut sniff = serde_yaml::Mapping::new();
+    sniff.insert(
+        serde_yaml::Value::String("TLS".into()),
+        serde_yaml::Value::Mapping(tls),
+    );
+    let mut sniffer = serde_yaml::Mapping::new();
+    for (key, value) in [
+        ("enable", serde_yaml::Value::Bool(true)),
+        ("parse-pure-ip", serde_yaml::Value::Bool(true)),
+        ("override-destination", serde_yaml::Value::Bool(false)),
+        ("sniff", serde_yaml::Value::Mapping(sniff)),
+    ] {
+        sniffer.insert(serde_yaml::Value::String(key.into()), value);
+    }
+    root.insert(
+        serde_yaml::Value::String("sniffer".into()),
+        serde_yaml::Value::Mapping(sniffer),
     );
 
     // Harden the meow external-controller. It binds on loopback, but iOS
@@ -1157,6 +1188,11 @@ allow-lan: false
 bind-address: 127.0.0.1
 dns:
   enable: false
+sniffer:
+  enable: false
+  sniff:
+    HTTP:
+      ports: [80]
 subscriptions:
   old: {}
 rules:
@@ -1173,6 +1209,104 @@ rules:
         assert!(patched.contains("enhanced-mode: fake-ip"));
         assert!(patched.contains("fake-ip-range: 28.0.0.0/8"));
         assert!(!patched.contains("subscriptions:"));
+
+        let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
+        let root = doc.as_mapping().expect("mapping root");
+        let dns = root
+            .get("dns")
+            .and_then(serde_yaml::Value::as_mapping)
+            .expect("forced dns mapping");
+        assert_eq!(
+            dns.get("store-fake-ip")
+                .and_then(serde_yaml::Value::as_bool),
+            Some(true)
+        );
+        let sniffer = root
+            .get("sniffer")
+            .and_then(serde_yaml::Value::as_mapping)
+            .expect("forced sniffer mapping");
+        assert_eq!(
+            sniffer.get("enable").and_then(serde_yaml::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            sniffer
+                .get("parse-pure-ip")
+                .and_then(serde_yaml::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            sniffer
+                .get("override-destination")
+                .and_then(serde_yaml::Value::as_bool),
+            Some(false)
+        );
+        let sniff = sniffer
+            .get("sniff")
+            .and_then(serde_yaml::Value::as_mapping)
+            .expect("forced protocol map");
+        let ports: Vec<u64> = sniff
+            .get("TLS")
+            .and_then(serde_yaml::Value::as_mapping)
+            .and_then(|tls| tls.get("ports"))
+            .and_then(serde_yaml::Value::as_sequence)
+            .expect("forced TLS ports")
+            .iter()
+            .map(|value| value.as_u64().expect("numeric TLS port"))
+            .collect();
+        assert_eq!(ports, vec![443, 8443]);
+        assert!(
+            sniff.get("HTTP").is_none(),
+            "user HTTP sniffer was replaced"
+        );
+    }
+
+    #[test]
+    fn patched_fake_ip_mapping_survives_config_reload() {
+        let tmp = tempfile::tempdir().expect("temp config dir");
+        let config_path = tmp.path().join("effective-config.yaml");
+        let patched = patch_config(
+            r#"
+proxies:
+  - name: DIRECT
+    type: direct
+rules:
+  - MATCH,DIRECT
+"#,
+            7890,
+            0,
+            1053,
+        );
+        std::fs::write(&config_path, patched).expect("write effective config");
+        let config_path = config_path.to_str().expect("utf-8 config path");
+
+        let first = crate::get_engine_runtime()
+            .block_on(meow_config::load_config(config_path))
+            .expect("load first config generation");
+        assert!(first.sniffer.enable);
+        assert_eq!(first.sniffer.tls_ports, vec![443, 8443]);
+        let fake_ip = crate::get_engine_runtime()
+            .block_on(first.dns.resolver.lookup_ipv4("wake.example"))
+            .expect("fake IP allocation");
+        assert_eq!(
+            first.dns.resolver.reverse_lookup(fake_ip).as_deref(),
+            Some("wake.example")
+        );
+        drop(first);
+
+        let second = crate::get_engine_runtime()
+            .block_on(meow_config::load_config(config_path))
+            .expect("reload config after engine restart");
+        assert!(second.dns.resolver.is_fake_ip(fake_ip));
+        assert_eq!(
+            second.dns.resolver.reverse_lookup(fake_ip).as_deref(),
+            Some("wake.example"),
+            "the reverse map used by stale post-wake destinations must survive restart"
+        );
+        let same_ip = crate::get_engine_runtime()
+            .block_on(second.dns.resolver.lookup_ipv4("wake.example"))
+            .expect("reloaded fake IP allocation");
+        assert_eq!(same_ip, fake_ip);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- persist the fake-IP reverse mapping so stale post-wake destinations remain resolvable after an engine restart
- force-enable TLS SNI sniffing on ports 443 and 8443 in the effective iOS config
- preserve the fake-IP reverse-mapped hostname as the dial target while allowing sniffed SNI to drive domain rules
- cover config pinning and fake-IP persistence across a full config reload

## Root cause

Wake recovery can restart the meow engine. The forced iOS DNS block previously omitted `store-fake-ip`, so a restart discarded the reverse map for already-issued 28.0.0.0/8 destinations. Those stale destinations could no longer be recovered to their original hostnames. Runtime config preparation also stripped the sniffer block.

## Local CI attestation

- [x] `swiftformat --lint .` — 0 files require formatting
- [x] `swiftlint --strict` — 0 violations
- [x] `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test --lib` in `core/rust/meow-ios-ffi/` — 55 tests passed
- [x] `scripts/build-rust.sh` — device and simulator Release libraries plus `MeowCore.xcframework` built successfully
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination "platform=iOS Simulator,name=iPhone 17"` — full scheme passed, including MeowTests, MeowIntegrationTests, and MeowUITests
- [x] `git diff origin/main...HEAD --stat` — verified exactly two intended files: `core/rust/meow-ios-ffi/src/engine.rs` and `core/rust/meow-ios-ffi/src/lib.rs`

The latest `main` `ci.yml` run was green before opening this PR.