### PR TITLE
feat(dns): re-apply redir-host mode with DoT upstream, keep SNI sniffer pinned

### DIFF
--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -241,9 +241,10 @@ void meow_tun_stop_blocking(void);
  * callback, so Swift never sees probe traffic.
  *
  * Pass the TUN's own IPv4 address as `src_ip` and the advertised in-TUN DNS
- * server as `dns_ip` (the `NEPacketTunnelNetworkSettings` values). In
- * fake-IP mode the answer is synthesised locally, so a healthy verdict does
- * not depend on upstream reachability — safe to run while the physical
+ * server as `dns_ip` (the `NEPacketTunnelNetworkSettings` values). The probe
+ * qname is pinned in the effective config's `hosts:` block, so meow-dns
+ * answers it locally even in redir-host mode and a healthy verdict does not
+ * depend on upstream reachability — safe to run while the physical
  * interface is still coming up after a wake.
  *
  * Returns 0 when a reply came back (path is live), -1 when tun2socks is not
@@ -359,7 +360,7 @@ int meow_tun_tcp_idle_ttl_ms(void);
  * outbound UDP datagrams to destination port 443 (QUIC's transport) and
  * answers SVCB (64) / HTTPS (65) DNS queries NOERROR-empty from the
  * intercept itself (no h3/SvcParams advertisement), forcing clients onto
- * the A / fake-IPv4 + TCP path.
+ * the A + TCP path.
  *
  * At the FFI layer the new value applies immediately to subsequent UDP
  * datagrams and DNS queries (the backing flag is a plain atomic). The

--- a/MeowIntegrationTests/EngineIntegration/EngineBootTests.swift
+++ b/MeowIntegrationTests/EngineIntegration/EngineBootTests.swift
@@ -131,8 +131,7 @@ private struct EngineFixture {
         dns:
           enable: true
           listen: 127.0.0.1:57953
-          enhanced-mode: fake-ip
-          fake-ip-range: 28.0.0.0/8
+          enhanced-mode: redir-host
           nameserver:
             - 119.29.29.29
         mode: rule

--- a/MeowIntegrationTests/EngineIntegration/TunBridgeTests.swift
+++ b/MeowIntegrationTests/EngineIntegration/TunBridgeTests.swift
@@ -164,8 +164,7 @@ private struct EngineFixture {
         dns:
           enable: true
           listen: 127.0.0.1:57954
-          enhanced-mode: fake-ip
-          fake-ip-range: 28.0.0.0/8
+          enhanced-mode: redir-host
           nameserver:
             - 119.29.29.29
         mode: rule

--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -5,7 +5,8 @@ import Yams
 /// actually loads. Mirrors the Android `MeowInstance.start` pipeline:
 ///
 ///   1. Remove user-managed `dns:` and `subscriptions:` blocks — the extension
-///      owns DNS (fake-ip + local listener) and the app owns subscription fetching.
+///      owns DNS (redir-host + local listener) and the app owns subscription
+///      fetching.
 ///   2. Override `secret:` with the random bearer token minted for this install.
 ///   3. Pin `mixed-port` (defaults to 7890), `allow-lan`, `bind-address`, and
 ///      a DNS listener so tun2socks and LAN clients can use meow's listeners.
@@ -79,13 +80,21 @@ public enum EffectiveConfigWriter {
         root["dns"] = [
             "enable": true,
             "listen": "\(bindAddress):\(defaultDNSPort)",
-            "enhanced-mode": "fake-ip",
-            "fake-ip-range": "28.0.0.0/8",
+            "enhanced-mode": "redir-host",
+            // DNS-over-TLS only — mirrors meow_patch_config: redir-host makes
+            // every resolver answer a real dial target, so plaintext upstreams
+            // would let a poisoned answer become the connect address. 1.1.1.1
+            // only; 1.0.0.1:853 is unreachable from the networks this app
+            // targets.
             "nameserver": [
-                "119.29.29.29",
-                "223.5.5.5",
+                "tls://1.1.1.1",
             ],
         ]
+        // Mirror of meow_patch_config's probe pin: keeps the wake-path health
+        // probe answerable without upstream network in redir-host mode.
+        var hosts = root["hosts"] as? [String: Any] ?? [:]
+        hosts["probe.meow-ios.internal"] = "203.0.113.53"
+        root["hosts"] = hosts
         root["external-controller"] = "127.0.0.1:\(apiCredentials.port)"
         root["secret"] = apiCredentials.secret
 

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -41,7 +41,10 @@ struct EffectiveConfigWriterTests {
         let parsed = try Yams.load(yaml: out) as? [String: Any]
         let dns = parsed?["dns"] as? [String: Any]
         #expect(dns?["listen"] as? String == "127.0.0.1:1053")
-        #expect((dns?["nameserver"] as? [String]) == ["119.29.29.29", "223.5.5.5"])
+        #expect(dns?["enhanced-mode"] as? String == "redir-host")
+        #expect((dns?["nameserver"] as? [String]) == ["tls://1.1.1.1"])
+        let hosts = parsed?["hosts"] as? [String: Any]
+        #expect(hosts?["probe.meow-ios.internal"] as? String == "203.0.113.53")
     }
 
     @Test

--- a/core/rust/macos-utun-harness/src/main.rs
+++ b/core/rust/macos-utun-harness/src/main.rs
@@ -3,7 +3,7 @@
 //!
 //! Bridges the same C-ABI surface the iOS PacketTunnelProvider drives
 //! (`meow_core_*`, `meow_engine_*`, `meow_tun_*`) into a real macOS `utun`
-//! interface, so the engine + fake-IP DNS + CN-bypass + tun2socks
+//! interface, so the engine + redir-host DNS + tun2socks
 //! dispatch paths can be exercised with actual packets without an iPhone
 //! and without going through the iOS Simulator (which has no TUN host).
 //!
@@ -129,9 +129,10 @@ struct Args {
     /// into its NAT table per packet. Use a REAL, reachable dst that won't
     /// answer the chosen UDP port (e.g. `8.8.8.8:4433`): DIRECT dial succeeds
     /// (so the session is created), no reply ever arrives (so it goes idle),
-    /// and the egress goes out the default route — no fake-IP, no DNS loop,
-    /// no routing loop. This is the deterministic way to drive the UDP NAT
-    /// leak path; `--udp-stress-target` (socket-based) needs fake-IP routing.
+    /// and the egress goes out the default route — no DNS loop, no routing
+    /// loop. This is the deterministic way to drive the UDP NAT leak path;
+    /// `--udp-stress-target` (socket-based) needs the target routed into
+    /// the tun.
     /// dst port MUST NOT be 53 (that hits the DNS intercept, not the NAT).
     #[arg(long)]
     udp_inject_target: Option<String>,
@@ -597,7 +598,7 @@ fn udp_stress_loop(
         workers.push(thread::spawn(move || {
             // Folded into the payload so a DNS/echo responder sees varying
             // content (and, aimed at the engine DNS with distinct qnames,
-            // churns the fake-IP pool too).
+            // churns the resolver cache too).
             let mut seq = 0u64;
             while !SHUTDOWN.load(Ordering::Relaxed) {
                 if let Some(limit) = duration {
@@ -691,7 +692,7 @@ fn udp_stress_loop(
 /// bypassing the OS route table, system DNS, and the utun device. Each fresh
 /// source is a new NAT 5-tuple the engine inserts into `nat_table`; with a
 /// non-answering dst the session goes idle and the NAT sweeper must reap it.
-/// Deterministic, no network setup, no fake-IP, no routing/DNS loop.
+/// Deterministic, no network setup, no routing/DNS loop.
 fn udp_inject_loop(dst: std::net::SocketAddr, rate: u64, duration: Option<std::time::Duration>) {
     let dst_ip = match dst.ip() {
         std::net::IpAddr::V4(v4) => v4.octets(),

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -77,9 +77,10 @@ lwip = "0.3"
 # (#337), and mihomo compat improvements (#313/#333). Windows/OpenWrt/CLI
 # work in 0.17–0.18 doesn't affect this crate. Previous pin 498967e
 # (0.16.0) made DelayHistory `time` serialize as RFC 3339 (meow-rs#290,
-# issue #255). meow-dns runs in fake-ip mode: the FFI config parser pins
-# `enhanced-mode: fake-ip` with `fake-ip-range: 28.0.0.0/8` (the 2026-07-17
-# redir-host/DoT switch was reverted in PR #321).
+# issue #255). meow-dns runs in redir-host (Mapping) mode: the FFI config
+# parser pins `enhanced-mode: redir-host` with a DoT-only upstream
+# (`tls://1.1.1.1`) — re-applied 2026-07-20 after the PR #321 revert, now
+# with the TLS SNI sniffer kept enabled as the reverse-cache backstop.
 meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -2,10 +2,10 @@
 //! DNS listeners that `tun2socks` dials through loopback.
 //!
 //! DNS is delegated end-to-end to meow's resolver. The pinned `dns:` block from
-//! `meow_patch_config` puts the resolver in fake-IP mode with the FFI's chosen
-//! CIDR (`28.0.0.0/8`) and a local DNS listen socket. The tun2socks UDP/53
-//! path sends non-blocked DNS queries to that listener, so synthesis and
-//! fake-IP reverse mapping stay owned by meow-dns.
+//! `meow_patch_config` puts the resolver in redir-host (Mapping) mode with a
+//! local DNS listen socket. The tun2socks UDP/53 path sends non-blocked DNS
+//! queries to that listener, so upstream resolution and the IP → host reverse
+//! cache stay owned by meow-dns.
 //!
 //! Lifecycle: `start(config_path)` spawns the REST API on the meow-engine
 //! tokio runtime and keeps its `JoinHandle` in `EngineState`. `stop()` aborts
@@ -233,10 +233,9 @@ pub fn start(config_path: &str) -> Result<()> {
     // 2-worker engine runtime (data path + REST API both freeze). The meow-dns
     // resolver resolves async, coalesces concurrent lookups, and caches —
     // collapsing the burst to one lookup. `resolve_ip` returns real addresses
-    // (fake-IP synthesis lives only in the DNS-server `lookup_ipv4/6` path), so
-    // the upstream never resolves to a 28.x fake IP. Android installs the same
-    // hook plus a `SocketProtector` via its JNI bridge; iOS needs only the hook
-    // (the NE process's own sockets already bypass its tunnel).
+    // (redir-host mode never synthesises fake IPs anywhere). Android installs
+    // the same hook plus a `SocketProtector` via its JNI bridge; iOS needs
+    // only the hook (the NE process's own sockets already bypass its tunnel).
     meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(resolver.clone())));
 
     let tunnel = Tunnel::new(resolver.clone());
@@ -336,9 +335,9 @@ pub fn start(config_path: &str) -> Result<()> {
     let listeners = cfg.listeners.named.clone();
     let log_tx = log_broadcast_tx().clone();
 
-    // No FFI-side fake-IP pool, no FFI-side CN-IP table, no resolver hand-off:
-    // meow's own fake-IP pool owns synthesis + reverse mapping behind the DNS
-    // listener that tun2socks dials.
+    // No FFI-side DNS cache, no FFI-side CN-IP table, no resolver hand-off:
+    // meow's own resolver owns upstream resolution + the IP → host reverse
+    // cache behind the DNS listener that tun2socks dials.
 
     let api_task = cfg.api.external_controller.map(|addr| {
         let api_server = ApiServer::new(
@@ -524,9 +523,7 @@ bind-address: 0.0.0.0
 dns:
   enable: true
   listen: 0.0.0.0:1053
-  enhanced-mode: fake-ip
-  fake-ip-range: 28.0.0.0/8
-  store-fake-ip: true
+  enhanced-mode: redir-host
   nameserver:
     - 119.29.29.29
 sniffer:

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -13,11 +13,11 @@
 //! The staticlib owns separate tokio runtimes for the packet/netstack driver
 //! and for meow engine work so lwIP backpressure cannot starve the
 //! REST/API/proxy workers. DNS is delegated to a local meow-dns UDP listener
-//! running in fake-IP mode: the tun2socks UDP/53 path still answers
-//! IPv6-disabled AAAA and HTTP/3-blocked HTTPS/SVCB queries NOERROR-empty
-//! itself, then sends other DNS queries to the listener. The FFI no longer
-//! carries its own fake-IP pool, china-DNS split-horizon, CN-IP table, DoH
-//! cache, or in-FFI TCP-DNS client.
+//! running in redir-host (Mapping) mode: the tun2socks UDP/53 path still
+//! answers IPv6-disabled AAAA and HTTP/3-blocked HTTPS/SVCB queries
+//! NOERROR-empty itself, then sends other DNS queries to the listener. The FFI
+//! no longer carries its own DNS cache, china-DNS split-horizon, CN-IP table,
+//! DoH cache, or in-FFI TCP-DNS client.
 
 mod diagnostics;
 mod engine;
@@ -692,8 +692,10 @@ pub unsafe extern "C" fn meow_patch_config(
         return -1;
     };
 
-    // Strip `dns` and `sniffer` because iOS pins both blocks below: persistent
-    // fake-IP mapping plus TLS SNI inspection on the mixed listener. Strip
+    // Strip `dns` and `sniffer` because iOS pins both blocks below: redir-host
+    // resolution over DoT (meow-dns returns real upstream IPs and keeps the
+    // IP → host reverse cache that `pre_handle_metadata` uses for domain-rule
+    // matching) plus TLS SNI inspection on the mixed listener. Strip
     // `subscriptions` as well (handled app-side). `secret` is intentionally NOT
     // stripped here — we overwrite it below with a per-install random token so
     // the REST API on loopback is authenticated rather than open.
@@ -732,31 +734,57 @@ pub unsafe extern "C" fn meow_patch_config(
             "listen",
             serde_yaml::Value::String(format!("{bind_addr}:{dns_port}")),
         ),
-        ("enhanced-mode", serde_yaml::Value::String("fake-ip".into())),
-        ("store-fake-ip", serde_yaml::Value::Bool(true)),
         (
-            "fake-ip-range",
-            serde_yaml::Value::String("28.0.0.0/8".into()),
+            "enhanced-mode",
+            serde_yaml::Value::String("redir-host".into()),
         ),
     ] {
         dns.insert(serde_yaml::Value::String(k.into()), v);
     }
+    // DNS-over-TLS only. redir-host makes every resolver answer a real dial
+    // target, so a poisoned plaintext answer would become the address we
+    // actually connect to — encrypt the upstream instead. IP-literal entries
+    // need no bootstrap nameserver, and rustls validates Cloudflare's IP-SAN
+    // certificate directly. 1.1.1.1 only: its anycast twin 1.0.0.1 is
+    // unreachable on :853 from the networks this app targets (verified
+    // 2026-07-17), and a dead pool entry just adds a doomed dial per query.
     dns.insert(
         serde_yaml::Value::String("nameserver".into()),
-        serde_yaml::Value::Sequence(vec![
-            serde_yaml::Value::String("119.29.29.29".into()),
-            serde_yaml::Value::String("223.5.5.5".into()),
-        ]),
+        serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("tls://1.1.1.1".into())]),
     );
     root.insert(
         serde_yaml::Value::String("dns".into()),
         serde_yaml::Value::Mapping(dns),
     );
 
+    // Keep the wake-path health probe (`meow_tun_health_probe`) answerable
+    // without upstream network: in redir-host mode meow-dns forwards unknown
+    // names to the DoT upstream, so a post-wake probe would stall while the
+    // physical interface is still reassociating and misread a live packet
+    // path as wedged. A `hosts:` entry is answered locally by the resolver
+    // before any upstream dial. The address is TEST-NET-3 documentation
+    // space — the probe reply is intercepted at the FFI egress and nothing
+    // ever dials it. Merged into (not replacing) the user's own `hosts:`.
+    let hosts_key = serde_yaml::Value::String("hosts".into());
+    if !matches!(root.get(&hosts_key), Some(serde_yaml::Value::Mapping(_))) {
+        root.insert(
+            hosts_key.clone(),
+            serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+        );
+    }
+    if let Some(serde_yaml::Value::Mapping(hosts)) = root.get_mut(&hosts_key) {
+        hosts.insert(
+            serde_yaml::Value::String(tun2socks::PROBE_QNAME.into()),
+            serde_yaml::Value::String(tun2socks::PROBE_HOSTS_IP.into()),
+        );
+    }
+
     // Always inspect TLS ClientHello SNI on the ports used by HTTPS. The
-    // sniffer writes `metadata.sniff_host`, which domain rules prefer, while
-    // `override-destination: false` deliberately preserves the hostname that
-    // fake-IP reverse mapping recovered as the actual dial target.
+    // sniffer writes `metadata.sniff_host`, which domain rules prefer — in
+    // redir-host mode that recovers the hostname for flows whose IP → host
+    // reverse-cache entry expired or is shared across names — while
+    // `override-destination: false` deliberately keeps the resolver-answered
+    // real IP as the dial target.
     let mut tls = serde_yaml::Mapping::new();
     tls.insert(
         serde_yaml::Value::String("ports".into()),
@@ -923,9 +951,10 @@ pub extern "C" fn meow_tun_stop_blocking() {
 /// callback, so Swift never sees probe traffic.
 ///
 /// Pass the TUN's own IPv4 address as `src_ip` and the advertised in-TUN DNS
-/// server as `dns_ip` (the `NEPacketTunnelNetworkSettings` values). In
-/// fake-IP mode the answer is synthesised locally, so a healthy verdict does
-/// not depend on upstream reachability — safe to run while the physical
+/// server as `dns_ip` (the `NEPacketTunnelNetworkSettings` values). The probe
+/// qname is pinned in the effective config's `hosts:` block, so meow-dns
+/// answers it locally even in redir-host mode and a healthy verdict does not
+/// depend on upstream reachability — safe to run while the physical
 /// interface is still coming up after a wake.
 ///
 /// Returns 0 when a reply came back (path is live), -1 when tun2socks is not
@@ -1083,7 +1112,7 @@ pub extern "C" fn meow_tun_tcp_idle_ttl_ms() -> c_int {
 /// outbound UDP datagrams to destination port 443 (QUIC's transport) and
 /// answers SVCB (64) / HTTPS (65) DNS queries NOERROR-empty from the
 /// intercept itself (no h3/SvcParams advertisement), forcing clients onto
-/// the A / fake-IPv4 + TCP path.
+/// the A + TCP path.
 ///
 /// At the FFI layer the new value applies immediately to subsequent UDP
 /// datagrams and DNS queries (the backing flag is a plain atomic). The
@@ -1144,6 +1173,7 @@ pub extern "C" fn meow_resident_bytes() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::meow_patch_config;
+    use crate::tun2socks;
     use std::ffi::CString;
 
     fn patch_config(yaml: &str, mixed_port: i32, allow_lan: i32, dns_port: i32) -> String {
@@ -1193,6 +1223,8 @@ sniffer:
   sniff:
     HTTP:
       ports: [80]
+hosts:
+  keep.example: 10.0.0.7
 subscriptions:
   old: {}
 rules:
@@ -1206,20 +1238,33 @@ rules:
         assert!(patched.contains("allow-lan: true"));
         assert!(patched.contains("bind-address: 0.0.0.0"));
         assert!(patched.contains("listen: 0.0.0.0:1054"));
-        assert!(patched.contains("enhanced-mode: fake-ip"));
-        assert!(patched.contains("fake-ip-range: 28.0.0.0/8"));
+        assert!(patched.contains("enhanced-mode: redir-host"));
+        assert!(!patched.contains("fake-ip-range"));
+        assert!(!patched.contains("store-fake-ip"));
+        assert!(patched.contains("tls://1.1.1.1"));
+        assert!(!patched.contains("tls://1.0.0.1"));
+        assert!(!patched.contains("119.29.29.29"));
         assert!(!patched.contains("subscriptions:"));
 
         let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
         let root = doc.as_mapping().expect("mapping root");
-        let dns = root
-            .get("dns")
+        let hosts = root
+            .get("hosts")
             .and_then(serde_yaml::Value::as_mapping)
-            .expect("forced dns mapping");
+            .expect("forced hosts mapping");
         assert_eq!(
-            dns.get("store-fake-ip")
-                .and_then(serde_yaml::Value::as_bool),
-            Some(true)
+            hosts
+                .get(tun2socks::PROBE_QNAME)
+                .and_then(serde_yaml::Value::as_str),
+            Some(tun2socks::PROBE_HOSTS_IP),
+            "probe qname must stay locally answerable in redir-host mode"
+        );
+        assert_eq!(
+            hosts
+                .get("keep.example")
+                .and_then(serde_yaml::Value::as_str),
+            Some("10.0.0.7"),
+            "user hosts entries survive the probe merge"
         );
         let sniffer = root
             .get("sniffer")
@@ -1262,7 +1307,7 @@ rules:
     }
 
     #[test]
-    fn patched_fake_ip_mapping_survives_config_reload() {
+    fn patched_config_answers_probe_qname_locally_in_redir_host() {
         let tmp = tempfile::tempdir().expect("temp config dir");
         let config_path = tmp.path().join("effective-config.yaml");
         let patched = patch_config(
@@ -1280,33 +1325,25 @@ rules:
         std::fs::write(&config_path, patched).expect("write effective config");
         let config_path = config_path.to_str().expect("utf-8 config path");
 
-        let first = crate::get_engine_runtime()
+        let cfg = crate::get_engine_runtime()
             .block_on(meow_config::load_config(config_path))
-            .expect("load first config generation");
-        assert!(first.sniffer.enable);
-        assert_eq!(first.sniffer.tls_ports, vec![443, 8443]);
-        let fake_ip = crate::get_engine_runtime()
-            .block_on(first.dns.resolver.lookup_ipv4("wake.example"))
-            .expect("fake IP allocation");
-        assert_eq!(
-            first.dns.resolver.reverse_lookup(fake_ip).as_deref(),
-            Some("wake.example")
-        );
-        drop(first);
+            .expect("load patched config");
+        assert!(cfg.sniffer.enable);
+        assert_eq!(cfg.sniffer.tls_ports, vec![443, 8443]);
 
-        let second = crate::get_engine_runtime()
-            .block_on(meow_config::load_config(config_path))
-            .expect("reload config after engine restart");
-        assert!(second.dns.resolver.is_fake_ip(fake_ip));
+        // The hosts pin must answer the wake-probe qname without any upstream
+        // dial — this runs offline — and redir-host must never hand back a
+        // synthesised fake IP.
+        let probe_ip = crate::get_engine_runtime()
+            .block_on(cfg.dns.resolver.lookup_ipv4(tun2socks::PROBE_QNAME))
+            .expect("hosts-pinned probe answer");
         assert_eq!(
-            second.dns.resolver.reverse_lookup(fake_ip).as_deref(),
-            Some("wake.example"),
-            "the reverse map used by stale post-wake destinations must survive restart"
+            probe_ip,
+            tun2socks::PROBE_HOSTS_IP
+                .parse::<std::net::IpAddr>()
+                .expect("probe hosts ip")
         );
-        let same_ip = crate::get_engine_runtime()
-            .block_on(second.dns.resolver.lookup_ipv4("wake.example"))
-            .expect("reloaded fake IP allocation");
-        assert_eq!(same_ip, fake_ip);
+        assert!(!cfg.dns.resolver.is_fake_ip(probe_ip));
     }
 
     #[test]

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -7,31 +7,31 @@
 //! callback registered in [`start`]. No file descriptors cross the FFI.
 //!
 //! DNS: A (1), TXT (16), MX (15), PTR (12), and other non-blocked queries are
-//! sent as raw UDP packets to the local meow-dns listener. A gets fake-IP
-//! synthesis there; generic qtypes get meow-dns's upstream-forward behavior.
-//! AAAA (28) queries are answered NOERROR-empty by the FFI itself when IPv6 is
-//! disabled in app settings (the default) — the fake-IP pool is v4-only, so
-//! stripping AAAA forces every client onto it instead of leaking (or
-//! black-holing) connections over v6. When IPv6 is enabled, AAAA queries are
-//! forwarded to meow-dns like A queries — with a v4-only fake-IP pool the
-//! resolver itself suppresses AAAA for fake-IP'd domains, so clients still land
-//! on the v4 fake path; the Swift TUN advertises an IPv6 address + default
-//! route so v6-literal destinations enter the netstack. When "block HTTP/3" is
-//! enabled, HTTPS/SVCB (65/64) queries also get NOERROR-empty so clients cannot
-//! discover QUIC hints.
+//! sent as raw UDP packets to the local meow-dns listener, which resolves
+//! upstream and answers with real IPs (redir-host mode). AAAA (28) queries are
+//! answered NOERROR-empty by the FFI itself when IPv6 is disabled in app
+//! settings (the default) — the tunnel is v4-only then, so stripping AAAA
+//! forces every client onto the v4 path instead of leaking (or black-holing)
+//! connections over v6. When IPv6 is enabled, AAAA queries are forwarded to
+//! meow-dns like A queries (the resolver returns real upstream IPv6
+//! addresses); the Swift TUN advertises an IPv6 address + default route so v6
+//! destinations enter the netstack. When "block HTTP/3" is enabled, HTTPS/SVCB
+//! (65/64) queries also get NOERROR-empty so clients cannot discover QUIC
+//! hints.
 //!
 //! NEDNSSettings advertises a TUN-subnet address as the system resolver, so
 //! every UDP DNS query arrives as an in-TUN IP packet. netstack turns that into
 //! a UDP payload, the FFI branches on qtype, and non-blocked queries go to the
 //! local DNS listener with the reply injected back through netstack. The
-//! resolver owns fake-IP synthesis, reverse mapping, hosts / NXDOMAIN
-//! semantics, and TTL handling; the FFI owns only the qtype peek plus the
-//! blocked-query short-circuit.
+//! resolver owns upstream resolution, the IP → host reverse cache, hosts /
+//! NXDOMAIN semantics, and TTL handling; the FFI owns only the qtype peek plus
+//! the blocked-query short-circuit.
 //!
-//! TCP/UDP destination IPs come back as fake-IPs from meow's resolver pool.
-//! `dispatch_tcp` and `dispatch_udp` pass the literal destination to the
-//! mixed listener via SOCKS5; meow's normal inbound path reverses fake-IPs back
-//! to the original qname before rule matching.
+//! TCP/UDP destination IPs are the real addresses meow's resolver answered
+//! with. `dispatch_tcp` and `dispatch_udp` pass the literal destination to the
+//! mixed listener via SOCKS5; meow's normal inbound path folds the original
+//! qname back in from the resolver's reverse cache (with the TLS SNI sniffer
+//! as backstop) before rule matching.
 
 use crate::logging;
 use futures::{SinkExt, StreamExt};
@@ -185,8 +185,7 @@ pub fn udp_first_reply_deadline_ms() -> u64 {
 //      handshake that still attempts a connection.
 //   2. SVCB (64) / HTTPS (65) DNS queries are answered NOERROR-empty by the
 //      intercept itself instead of being forwarded to meow-dns, so the client
-//      never learns the HTTP/3 `alpn`/SvcParams and falls back to A / fake-IPv4
-//      over TCP.
+//      never learns the HTTP/3 `alpn`/SvcParams and falls back to A over TCP.
 //
 // Both prongs are wired to this single flag. Stored Relaxed — the toggle has no
 // ordering relationship with other state; a stale read for one datagram is
@@ -667,9 +666,10 @@ pub fn ingest(packet: &[u8]) -> i32 {
 // egress — and wait for the reply frame to come back out. A reply proves every
 // stage is live; silence within the deadline means the path is wedged (or the
 // engine is down), which is exactly the condition the wake-path restart
-// exists to clear. In fake-IP mode the answer is synthesised locally, so the
-// probe needs no upstream network and is safe to run while the physical
-// interface is still reassociating after a wake.
+// exists to clear. The probe qname is pinned in the effective config's
+// `hosts:` block (see `meow_patch_config`), so meow-dns answers it locally
+// even in redir-host mode — the probe needs no upstream network and is safe
+// to run while the physical interface is still reassociating after a wake.
 // ---------------------------------------------------------------------------
 
 /// Fixed client port for probe queries. Replies are matched on (dst port,
@@ -678,12 +678,18 @@ pub fn ingest(packet: &[u8]) -> i32 {
 /// client would simply retry that one reply.
 const PROBE_SRC_PORT: u16 = 53535;
 
-/// Probe qname. Any name works — fake-IP synthesises an answer for every
-/// non-filtered name — but a reserved-TLD name keeps the probe out of real
-/// caches if the resolver is ever switched to redir-host mode (where this
-/// query goes to the configured upstreams and the probe additionally checks
-/// upstream reachability).
-const PROBE_QNAME: &str = "probe.meow-ios.internal";
+/// Probe qname. `meow_patch_config` pins this name to [`PROBE_HOSTS_IP`] in
+/// the effective config's `hosts:` block, so the resolver answers it locally
+/// (hosts entries short-circuit before any upstream dial) and the probe never
+/// depends on upstream reachability — redir-host mode would otherwise forward
+/// an unknown name to the DoT upstream. The reserved TLD keeps it out of real
+/// caches.
+pub(crate) const PROBE_QNAME: &str = "probe.meow-ios.internal";
+
+/// The address [`PROBE_QNAME`] resolves to via the pinned `hosts:` entry.
+/// TEST-NET-3 documentation space: probe replies are intercepted at the
+/// egress by [`probe_reply_intercept`], so nothing ever dials it.
+pub(crate) const PROBE_HOSTS_IP: &str = "203.0.113.53";
 
 /// Interval between probe re-sends while waiting for a reply. Ingest is
 /// drop-on-full, so a probe frame can be lost to a saturated ingress queue
@@ -928,13 +934,13 @@ async fn run_tun2socks(
     let engine_handle_for_tcp = crate::get_engine_runtime().handle().clone();
     let tcp_accept_handle = tokio::spawn(async move {
         while let Some((stream, local_addr, remote_addr)) = tcp_listener.next().await {
-            // Fake-IP mode: TCP DNS (rare, but RFC 1035 § 4.2.2 allows it
-            // when a UDP reply was truncated) inside the TUN is
-            // intentionally unsupported — iOS's stub resolver only falls
-            // back to TCP/53 for very large replies, and our fake-IP A/AAAA
-            // responses are tiny. Drop the stream so the kernel sees the
-            // TCP session close; the client retries on UDP, which the
-            // ingress loop intercepts.
+            // TCP DNS (rare, but RFC 1035 § 4.2.2 allows it when a UDP
+            // reply was truncated) inside the TUN is intentionally
+            // unsupported — iOS's stub resolver only falls back to TCP/53
+            // for very large replies, and the A/AAAA answers meow-dns
+            // returns stay well under the UDP limit. Drop the stream so the
+            // kernel sees the TCP session close; the client retries on UDP,
+            // which the ingress loop intercepts.
             if remote_addr.port() == 53 {
                 trace!(
                     "tun2socks: dropping in-TUN TCP/53 flow {} -> {} (UDP/53 intercept handles DNS)",

--- a/core/rust/meow-ios-ffi/tests/stress_rss.rs
+++ b/core/rust/meow-ios-ffi/tests/stress_rss.rs
@@ -53,7 +53,7 @@ fn test_lock() -> &'static Mutex<()> {
 }
 
 /// Hand-built minimal IPv4 + UDP packet bound for 172.19.0.2:53 (the
-/// fake-IP pool's DNS server address). The intercept path in `tun2socks.rs`
+/// TUN-subnet DNS server address). The intercept path in `tun2socks.rs`
 /// matches on `dst_port == 53` regardless of dst_ip, so this is enough to
 /// exercise the spawn-per-DNS-query branch without a real engine: the
 /// spawned task short-circuits on `engine::tunnel() == None` and unwinds.


### PR DESCRIPTION
## Summary
- Re-applies the redir-host DNS switch (bf9e5e8, reverted in PR #321) on top of the fake-IP-persistence/sniffer commit 1958739: `meow_patch_config` pins `enhanced-mode: redir-host` with a DoT-only upstream (`tls://1.1.1.1`; `1.0.0.1:853` stays excluded — verified unreachable from target networks 2026-07-17).
- The pinned SNI sniffer block stays **enabled** (TLS 443/8443, `override-destination: false`) — in redir-host mode it is the backstop for flows whose IP → host reverse-cache entry expired or is shared across names.
- Drops the now-moot `store-fake-ip` / `fake-ip-range` keys; the fake-IP-persistence test is replaced by a redir-host load test.
- **New:** pins the wake-path health-probe qname (`probe.meow-ios.internal → 203.0.113.53`, TEST-NET-3) in the effective config's `hosts:` block, merged into (not replacing) user `hosts:`. hosts entries short-circuit before any upstream dial, so the PR #324 probe keeps its no-upstream-needed semantics in redir-host mode instead of stalling on a DoT dial while the interface reassociates after wake (which would misread a live path as wedged and bring back spurious restarts). New offline regression test covers this.
- Swift mirror (`EffectiveConfigWriter`), `meow_core.h`, engine/tun2socks/harness comments, and engine-boot/tun-bridge fixtures updated to match.

## Local CI attestation (Path B)
1. `swiftformat --lint .` at repo root → 0 violations (0/126 files require formatting).
2. `swiftlint --strict --quiet` at repo root → 0 violations.
3. Tests on iOS 26 simulator (iPhone 17) + Rust:
   - `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → **TEST SUCCEEDED**
   - `cd MeowShared && swift test` → 27 tests passed
   - `scripts/build-rust.sh` → xcframework written OK
   - `cargo test` in `core/rust/meow-ios-ffi` → 57 passed, 0 failed (incl. new `patched_config_answers_probe_qname_locally_in_redir_host`)
   - `cargo clippy --all-targets -- -D warnings` in `core/rust/meow-ios-ffi` → clean
   - `cargo test --locked` in `core/rust/macos-utun-harness` → ok (no dep changes, lockfile untouched)
4. `git diff origin/main...HEAD --stat` verified — 11 files, exactly the DNS/sniffer/probe/comment scope above, no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)