### PR TITLE
fix(dns): drop DoT-only upstream pool for plain UDP resolvers

### DIFF
--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -81,13 +81,14 @@ public enum EffectiveConfigWriter {
             "enable": true,
             "listen": "\(bindAddress):\(defaultDNSPort)",
             "enhanced-mode": "redir-host",
-            // DNS-over-TLS only — mirrors meow_patch_config: redir-host makes
-            // every resolver answer a real dial target, so plaintext upstreams
-            // would let a poisoned answer become the connect address. 1.1.1.1
-            // only; 1.0.0.1:853 is unreachable from the networks this app
-            // targets.
+            // Plain UDP upstreams — mirrors meow_patch_config: DoT to
+            // 1.1.1.1:853 proved unusable from the networks this app
+            // targets, so the poisoned-answer exposure of plaintext DNS in
+            // redir-host mode is an accepted trade-off (user decision
+            // 2026-07-20).
             "nameserver": [
-                "tls://1.1.1.1",
+                "119.29.29.29",
+                "223.5.5.5",
             ],
         ]
         // Mirror of meow_patch_config's probe pin: keeps the wake-path health

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -42,7 +42,7 @@ struct EffectiveConfigWriterTests {
         let dns = parsed?["dns"] as? [String: Any]
         #expect(dns?["listen"] as? String == "127.0.0.1:1053")
         #expect(dns?["enhanced-mode"] as? String == "redir-host")
-        #expect((dns?["nameserver"] as? [String]) == ["tls://1.1.1.1"])
+        #expect((dns?["nameserver"] as? [String]) == ["119.29.29.29", "223.5.5.5"])
         let hosts = parsed?["hosts"] as? [String: Any]
         #expect(hosts?["probe.meow-ios.internal"] as? String == "203.0.113.53")
     }

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -78,9 +78,10 @@ lwip = "0.3"
 # work in 0.17–0.18 doesn't affect this crate. Previous pin 498967e
 # (0.16.0) made DelayHistory `time` serialize as RFC 3339 (meow-rs#290,
 # issue #255). meow-dns runs in redir-host (Mapping) mode: the FFI config
-# parser pins `enhanced-mode: redir-host` with a DoT-only upstream
-# (`tls://1.1.1.1`) — re-applied 2026-07-20 after the PR #321 revert, now
-# with the TLS SNI sniffer kept enabled as the reverse-cache backstop.
+# parser pins `enhanced-mode: redir-host` with plain UDP upstreams
+# (119.29.29.29 / 223.5.5.5) — re-applied 2026-07-20 after the PR #321
+# revert, TLS SNI sniffer kept enabled as the reverse-cache backstop; the
+# DoT-only pool was dropped same day (unreachable from target networks).
 meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -693,7 +693,7 @@ pub unsafe extern "C" fn meow_patch_config(
     };
 
     // Strip `dns` and `sniffer` because iOS pins both blocks below: redir-host
-    // resolution over DoT (meow-dns returns real upstream IPs and keeps the
+    // resolution (meow-dns returns real upstream IPs and keeps the
     // IP → host reverse cache that `pre_handle_metadata` uses for domain-rule
     // matching) plus TLS SNI inspection on the mixed listener. Strip
     // `subscriptions` as well (handled app-side). `secret` is intentionally NOT
@@ -741,16 +741,19 @@ pub unsafe extern "C" fn meow_patch_config(
     ] {
         dns.insert(serde_yaml::Value::String(k.into()), v);
     }
-    // DNS-over-TLS only. redir-host makes every resolver answer a real dial
-    // target, so a poisoned plaintext answer would become the address we
-    // actually connect to — encrypt the upstream instead. IP-literal entries
-    // need no bootstrap nameserver, and rustls validates Cloudflare's IP-SAN
-    // certificate directly. 1.1.1.1 only: its anycast twin 1.0.0.1 is
-    // unreachable on :853 from the networks this app targets (verified
-    // 2026-07-17), and a dead pool entry just adds a doomed dial per query.
+    // Plain UDP upstreams (user decision 2026-07-20, replacing the DoT-only
+    // pool): tls://1.1.1.1:853 proved unusable from the networks this app
+    // targets, and a resolver with no reachable upstream is a full DNS
+    // outage. Accepted trade-off: in redir-host mode every resolver answer
+    // is a real dial target, so a poisoned plaintext answer becomes the
+    // connect address — rule matching still has the SNI sniffer as a
+    // hostname backstop, but the dial itself trusts these answers.
     dns.insert(
         serde_yaml::Value::String("nameserver".into()),
-        serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("tls://1.1.1.1".into())]),
+        serde_yaml::Value::Sequence(vec![
+            serde_yaml::Value::String("119.29.29.29".into()),
+            serde_yaml::Value::String("223.5.5.5".into()),
+        ]),
     );
     root.insert(
         serde_yaml::Value::String("dns".into()),
@@ -759,7 +762,7 @@ pub unsafe extern "C" fn meow_patch_config(
 
     // Keep the wake-path health probe (`meow_tun_health_probe`) answerable
     // without upstream network: in redir-host mode meow-dns forwards unknown
-    // names to the DoT upstream, so a post-wake probe would stall while the
+    // names to the upstream pool, so a post-wake probe would stall while the
     // physical interface is still reassociating and misread a live packet
     // path as wedged. A `hosts:` entry is answered locally by the resolver
     // before any upstream dial. The address is TEST-NET-3 documentation
@@ -1241,9 +1244,9 @@ rules:
         assert!(patched.contains("enhanced-mode: redir-host"));
         assert!(!patched.contains("fake-ip-range"));
         assert!(!patched.contains("store-fake-ip"));
-        assert!(patched.contains("tls://1.1.1.1"));
-        assert!(!patched.contains("tls://1.0.0.1"));
-        assert!(!patched.contains("119.29.29.29"));
+        assert!(patched.contains("119.29.29.29"));
+        assert!(patched.contains("223.5.5.5"));
+        assert!(!patched.contains("tls://"));
         assert!(!patched.contains("subscriptions:"));
 
         let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -682,8 +682,8 @@ const PROBE_SRC_PORT: u16 = 53535;
 /// the effective config's `hosts:` block, so the resolver answers it locally
 /// (hosts entries short-circuit before any upstream dial) and the probe never
 /// depends on upstream reachability — redir-host mode would otherwise forward
-/// an unknown name to the DoT upstream. The reserved TLD keeps it out of real
-/// caches.
+/// an unknown name to the configured upstreams. The reserved TLD keeps it out
+/// of real caches.
 pub(crate) const PROBE_QNAME: &str = "probe.meow-ios.internal";
 
 /// The address [`PROBE_QNAME`] resolves to via the pinned `hosts:` entry.


### PR DESCRIPTION
## Summary
- Replaces the DoT-only `nameserver: [tls://1.1.1.1]` pool from PR #329 with the plain UDP pair `119.29.29.29` / `223.5.5.5` — `1.1.1.1:853` proved unusable on-device from the target networks, and an unreachable upstream pool is a full DNS outage.
- redir-host mode, the pinned SNI sniffer, and the hosts-pinned wake-probe qname are unchanged.
- Accepted trade-off (user decision, recorded in the pinned-block comment): in redir-host mode a poisoned plaintext answer becomes the connect address; the SNI sniffer still backstops hostname rule matching.

## Local CI attestation (Path B)
1. `swiftformat --lint .` at repo root → 0 violations (0/126 files require formatting).
2. `swiftlint --strict --quiet` at repo root → 0 violations.
3. Tests on iOS 26 simulator (iPhone 17) + Rust:
   - `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → **TEST SUCCEEDED**
   - `cd MeowShared && swift test` → 27 tests passed
   - `scripts/build-rust.sh` → xcframework written OK
   - `cargo test` in `core/rust/meow-ios-ffi` → 57 passed, 0 failed
   - `cargo clippy --all-targets -- -D warnings` in `core/rust/meow-ios-ffi` → clean
   - No dependency changes → `macos-utun-harness` Cargo.lock untouched
4. `git diff origin/main...HEAD --stat` verified — 5 files (lib.rs, tun2socks.rs comment, Cargo.toml comment, EffectiveConfigWriter + its tests), no accidental additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)