### PR TITLE
feat(dns): resolve gfw-listed hostnames through the tunnel (ChinaDNS-style)

### DIFF
--- a/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
+++ b/MeowShared/Sources/MeowModels/EffectiveConfigWriter.swift
@@ -77,7 +77,7 @@ public enum EffectiveConfigWriter {
         root["mixed-port"] = mixedPort
         root["allow-lan"] = prefs.allowLan
         root["bind-address"] = bindAddress
-        root["dns"] = [
+        var dns: [String: Any] = [
             "enable": true,
             "listen": "\(bindAddress):\(defaultDNSPort)",
             "enhanced-mode": "redir-host",
@@ -91,6 +91,18 @@ public enum EffectiveConfigWriter {
                 "223.5.5.5",
             ],
         ]
+        // Mirror of meow_patch_config's ChinaDNS-style pin: gfw-listed names
+        // resolve via TCP/53 tunnelled through the config's own proxy so the
+        // direct-path censor can't poison them.
+        if let proxy = Self.gfwDNSProxy(root) {
+            dns["nameserver-policy"] = [
+                "geosite:gfw": [
+                    "tcp://8.8.8.8#\(proxy)",
+                    "tcp://1.1.1.1#\(proxy)",
+                ],
+            ]
+        }
+        root["dns"] = dns
         // Mirror of meow_patch_config's probe pin: keeps the wake-path health
         // probe answerable without upstream network in redir-host mode.
         var hosts = root["hosts"] as? [String: Any] ?? [:]
@@ -106,5 +118,33 @@ public enum EffectiveConfigWriter {
         // Stable key ordering so the effective file diffs cleanly across
         // restarts, and meow-rs doesn't care about input key order.
         return try Yams.dump(object: root, sortKeys: true)
+    }
+
+    /// Mirror of the Rust `gfw_dns_proxy` derivation: the final `MATCH,`
+    /// rule's target when it names a proxy or group defined in this config,
+    /// else the first proxy-group, else the first proxy. Built-in policies
+    /// (DIRECT/REJECT/…) never qualify.
+    static func gfwDNSProxy(_ root: [String: Any]) -> String? {
+        let builtins: Set = [
+            "DIRECT", "REJECT", "REJECT-DROP", "PASS", "COMPATIBLE", "GLOBAL", "BLOCK",
+        ]
+        func names(_ key: String) -> [String] {
+            ((root[key] as? [Any]) ?? []).compactMap { ($0 as? [String: Any])?["name"] as? String }
+        }
+        let groups = names("proxy-groups")
+        let proxies = names("proxies")
+        func usable(_ name: String) -> Bool {
+            !builtins.contains(name.uppercased()) && (groups.contains(name) || proxies.contains(name))
+        }
+
+        let rules = (root["rules"] as? [Any]) ?? []
+        for rule in rules.reversed() {
+            guard let rule = rule as? String else { continue }
+            let parts = rule.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            guard parts.count >= 2, parts[0].uppercased() == "MATCH" else { continue }
+            if usable(parts[1]) { return parts[1] }
+            break
+        }
+        return groups.first(where: usable) ?? proxies.first(where: usable)
     }
 }

--- a/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
+++ b/MeowShared/Tests/MeowSharedTests/EffectiveConfigWriterTests.swift
@@ -43,8 +43,39 @@ struct EffectiveConfigWriterTests {
         #expect(dns?["listen"] as? String == "127.0.0.1:1053")
         #expect(dns?["enhanced-mode"] as? String == "redir-host")
         #expect((dns?["nameserver"] as? [String]) == ["119.29.29.29", "223.5.5.5"])
+        // No groups and no MATCH rule here — derivation falls back to the
+        // fixture's only proxy (n1) for the gfw policy.
+        let policy = dns?["nameserver-policy"] as? [String: Any]
+        #expect((policy?["geosite:gfw"] as? [String]) == ["tcp://8.8.8.8#n1", "tcp://1.1.1.1#n1"])
         let hosts = parsed?["hosts"] as? [String: Any]
         #expect(hosts?["probe.meow-ios.internal"] as? String == "203.0.113.53")
+    }
+
+    @Test
+    func `pins gfw nameserver-policy through final MATCH target`() throws {
+        let source = """
+        proxies:
+          - name: sg
+            type: ss
+            server: 192.0.2.10
+            port: 8388
+            cipher: aes-256-gcm
+            password: pw
+        proxy-groups:
+          - name: Auto
+            type: select
+            proxies: [sg]
+        rules:
+          - DOMAIN-SUFFIX,example.com,DIRECT
+          - MATCH,Auto
+        """
+        let out = try patch(source)
+        let parsed = try Yams.load(yaml: out) as? [String: Any]
+        let dns = parsed?["dns"] as? [String: Any]
+        let policy = dns?["nameserver-policy"] as? [String: Any]
+        #expect(
+            (policy?["geosite:gfw"] as? [String]) == ["tcp://8.8.8.8#Auto", "tcp://1.1.1.1#Auto"],
+        )
     }
 
     @Test

--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -924,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "axum",
  "base64",
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "base64",
  "libc",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2141,12 +2141,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2264,7 +2264,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3303,7 +3303,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4046,7 +4046,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -876,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "axum",
  "base64",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "base64",
  "libc",
@@ -1988,7 +1988,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2080,12 +2080,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2191,7 +2191,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2493,7 +2493,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2742,7 +2742,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3221,7 +3221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3963,7 +3963,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,7 +68,10 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 74e8083a (meow-rs 0.18.0) — picks up the rule-IR compilation series
+# HEAD: 88553178 (0.18.0 + meow-rs#350) — adds #PROXY-fragment support on
+# nameserver-policy entries, which the pinned ChinaDNS-style geosite:gfw
+# policy below relies on. Previous pin 74e8083a (meow-rs 0.18.0) picked up
+# the rule-IR compilation series
 # (meow-rs#285/#291/#295–#297), lazy metadata enrichment (#292), the VMess
 # AEAD wire-format interop fix (#320), VLESS/Snell UDP-over-TCP read/write
 # fairness (#319), relay-direction fairness per buffer cycle (#347), atomic
@@ -82,7 +85,7 @@ lwip = "0.3"
 # (119.29.29.29 / 223.5.5.5) — re-applied 2026-07-20 after the PR #321
 # revert, TLS SNI sniffer kept enabled as the reverse-cache backstop; the
 # DoT-only pool was dropped same day (unreachable from target networks).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -90,12 +93,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -653,6 +653,64 @@ fn random_port() -> u16 {
 // Config patching (replaces the Swift/Yams EffectiveConfigWriter)
 // ---------------------------------------------------------------------------
 
+/// Choose the proxy adapter that should carry gfw-listed DNS lookups for the
+/// pinned `nameserver-policy`: the target of the final `MATCH,` rule when it
+/// names a proxy or group defined in this config, else the first
+/// proxy-group, else the first proxy. Built-in policies (DIRECT/REJECT/…)
+/// never qualify — tunnelling the trusted resolver through them would be a
+/// no-op or a black hole. `None` → the caller omits the policy.
+fn gfw_dns_proxy(root: &serde_yaml::Mapping) -> Option<String> {
+    fn names_of(root: &serde_yaml::Mapping, key: &str) -> Vec<String> {
+        root.get(key)
+            .and_then(serde_yaml::Value::as_sequence)
+            .map(|seq| {
+                seq.iter()
+                    .filter_map(|item| item.as_mapping()?.get("name")?.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+    const BUILTINS: [&str; 7] = [
+        "DIRECT",
+        "REJECT",
+        "REJECT-DROP",
+        "PASS",
+        "COMPATIBLE",
+        "GLOBAL",
+        "BLOCK",
+    ];
+    let groups = names_of(root, "proxy-groups");
+    let proxies = names_of(root, "proxies");
+    let usable = |name: &str| {
+        !BUILTINS.contains(&name.to_ascii_uppercase().as_str())
+            && (groups.iter().any(|n| n == name) || proxies.iter().any(|n| n == name))
+    };
+
+    let match_target = root
+        .get("rules")
+        .and_then(serde_yaml::Value::as_sequence)
+        .and_then(|rules| {
+            rules.iter().rev().find_map(|rule| {
+                let rule = rule.as_str()?;
+                let mut parts = rule.split(',').map(str::trim);
+                if !parts.next()?.eq_ignore_ascii_case("MATCH") {
+                    return None;
+                }
+                parts.next().map(str::to_string)
+            })
+        });
+    if let Some(target) = match_target {
+        if usable(&target) {
+            return Some(target);
+        }
+    }
+    groups
+        .iter()
+        .find(|n| usable(n))
+        .or_else(|| proxies.iter().find(|n| usable(n)))
+        .cloned()
+}
+
 /// Patch a Clash YAML config for iOS: strips `dns` and `subscriptions`;
 /// pins `mixed-port`, `allow-lan`, listener bind address, and DNS listen
 /// socket; injects a hardened `external-controller` (random loopback port)
@@ -755,6 +813,29 @@ pub unsafe extern "C" fn meow_patch_config(
             serde_yaml::Value::String("223.5.5.5".into()),
         ]),
     );
+    // ChinaDNS-style trusted path for GFW-listed names: resolve any hostname
+    // matching geosite:gfw through TCP/53 upstreams tunnelled over the
+    // config's own proxy (the `#<name>` fragment), so a censor on the direct
+    // path can neither poison nor observe those lookups — closing the main
+    // plaintext-upstream hole for exactly the names it targets. Everything
+    // else keeps the fast plain-UDP pool above. Degrades gracefully: with no
+    // usable proxy/group in the config the policy is omitted, and before
+    // geosite.dat has downloaded meow-rs skips the entry with a warning
+    // (both fall back to the plain pool for gfw names too).
+    if let Some(proxy) = gfw_dns_proxy(root) {
+        let mut policy = serde_yaml::Mapping::new();
+        policy.insert(
+            serde_yaml::Value::String("geosite:gfw".into()),
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String(format!("tcp://8.8.8.8#{proxy}")),
+                serde_yaml::Value::String(format!("tcp://1.1.1.1#{proxy}")),
+            ]),
+        );
+        dns.insert(
+            serde_yaml::Value::String("nameserver-policy".into()),
+            serde_yaml::Value::Mapping(policy),
+        );
+    }
     root.insert(
         serde_yaml::Value::String("dns".into()),
         serde_yaml::Value::Mapping(dns),
@@ -1248,6 +1329,10 @@ rules:
         assert!(patched.contains("223.5.5.5"));
         assert!(!patched.contains("tls://"));
         assert!(!patched.contains("subscriptions:"));
+        // No proxy or group defined (MATCH targets built-in DIRECT), so the
+        // gfw nameserver-policy must be omitted rather than reference a
+        // non-existent adapter.
+        assert!(!patched.contains("nameserver-policy"));
 
         let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
         let root = doc.as_mapping().expect("mapping root");
@@ -1307,6 +1392,114 @@ rules:
             sniff.get("HTTP").is_none(),
             "user HTTP sniffer was replaced"
         );
+    }
+
+    #[test]
+    fn patch_config_pins_gfw_policy_on_final_match_target() {
+        let patched = patch_config(
+            r#"
+proxies:
+  - name: sg
+    type: ss
+    server: 192.0.2.10
+    port: 8388
+    cipher: aes-256-gcm
+    password: pw
+proxy-groups:
+  - name: Auto
+    type: select
+    proxies: [sg]
+rules:
+  - DOMAIN-SUFFIX,example.com,DIRECT
+  - MATCH,Auto
+"#,
+            7890,
+            0,
+            1053,
+        );
+        let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
+        let policy = doc
+            .get("dns")
+            .and_then(|d| d.get("nameserver-policy"))
+            .and_then(serde_yaml::Value::as_mapping)
+            .expect("gfw nameserver-policy pinned");
+        let upstreams: Vec<&str> = policy
+            .get("geosite:gfw")
+            .and_then(serde_yaml::Value::as_sequence)
+            .expect("geosite:gfw entry")
+            .iter()
+            .filter_map(serde_yaml::Value::as_str)
+            .collect();
+        assert_eq!(
+            upstreams,
+            vec!["tcp://8.8.8.8#Auto", "tcp://1.1.1.1#Auto"],
+            "policy upstreams tunnel through the final MATCH target"
+        );
+    }
+
+    #[test]
+    fn patch_config_gfw_policy_falls_back_to_first_group() {
+        // MATCH targets an undefined name — derivation must fall back to the
+        // first defined proxy-group instead of pinning a dangling adapter.
+        let patched = patch_config(
+            r#"
+proxies:
+  - name: sg
+    type: ss
+    server: 192.0.2.10
+    port: 8388
+    cipher: aes-256-gcm
+    password: pw
+proxy-groups:
+  - name: Select
+    type: select
+    proxies: [sg]
+rules:
+  - MATCH,Ghost
+"#,
+            7890,
+            0,
+            1053,
+        );
+        assert!(patched.contains("tcp://8.8.8.8#Select"));
+    }
+
+    #[test]
+    fn patched_config_with_gfw_policy_loads() {
+        // The pinned policy must never break config load (Class A error in
+        // meow-rs when a policy entry ends up with zero valid upstreams —
+        // exactly what happened before meow-rs supported #PROXY fragments on
+        // policy entries). Offline: load builds adapters, dials nothing.
+        let tmp = tempfile::tempdir().expect("temp config dir");
+        let config_path = tmp.path().join("effective-config.yaml");
+        let patched = patch_config(
+            r#"
+proxies:
+  - name: sg
+    type: ss
+    server: 192.0.2.10
+    port: 8388
+    cipher: aes-256-gcm
+    password: pw
+proxy-groups:
+  - name: Auto
+    type: select
+    proxies: [sg]
+rules:
+  - MATCH,Auto
+"#,
+            7890,
+            0,
+            1053,
+        );
+        assert!(patched.contains("tcp://8.8.8.8#Auto"));
+        std::fs::write(&config_path, patched).expect("write effective config");
+        let config_path = config_path.to_str().expect("utf-8 config path");
+
+        let cfg = crate::get_engine_runtime()
+            .block_on(meow_config::load_config(config_path))
+            .expect("config with pinned gfw policy loads");
+        assert!(cfg.sniffer.enable);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Pins `dns.nameserver-policy: {geosite:gfw: [tcp://8.8.8.8#<proxy>, tcp://1.1.1.1#<proxy>]}` in `meow_patch_config`: gfw-listed hostnames resolve over TCP/53 tunnelled through the config's own proxy, immune to on-path poisoning; everything else keeps the plain-UDP pool. Closes the redir-host plaintext exposure for exactly the names the censor targets (poisoned answer = literal dial target; recycled bogus IPs collide in the reverse cache).
- Carrying proxy derived from the config: final `MATCH` target if it names a defined proxy/group (built-ins excluded) → first proxy-group → first proxy → omit policy. Cold-start without geosite.dat degrades to the plain pool via a meow-rs warn-skip.
- Bumps meow-rs pin `74e8083a` → `88553178` (meow-rs#350: `#PROXY` fragments on policy entries; previously these hard-errored config load). **Both** `meow-ios-ffi` and `macos-utun-harness` lockfiles regenerated.
- `EffectiveConfigWriter` mirrors the pin + derivation.

## Local CI attestation (Path B)
1. `swiftformat --lint .` at repo root → 0 violations.
2. `swiftlint --strict --quiet` at repo root → 0 violations.
3. Tests on iOS 26 simulator (iPhone 17) + Rust:
   - `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → **TEST SUCCEEDED** (against the new-pin xcframework)
   - `cd MeowShared && swift test` → 28 tests passed
   - `scripts/build-rust.sh` → xcframework written OK
   - `cargo test` in `core/rust/meow-ios-ffi` → 60 passed total (58 lib + 2 stress), 0 failed — incl. new `patch_config_pins_gfw_policy_on_final_match_target`, `patch_config_gfw_policy_falls_back_to_first_group`, and `patched_config_with_gfw_policy_loads` (offline guard against the Class A policy-load error)
   - `cargo clippy --all-targets -- -D warnings` in `core/rust/meow-ios-ffi` → clean
   - `cargo test --locked` in `core/rust/macos-utun-harness` → green (lockfile regenerated with the pin bump)
4. `git diff origin/main...HEAD --stat` verified — 6 files: lib.rs, Cargo.toml + both lockfiles, EffectiveConfigWriter + tests; no accidental additions.

Depends on madeye/meow-rs#350 (merged, `88553178`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)