### PR TITLE
Persist redir-host reverse DNS table, real answer TTLs, remove engine restart logic

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.h
+++ b/PacketTunnel/Sources/MWTunnelEngine.h
@@ -10,18 +10,8 @@
 /// Blocking: runs engine + tun2socks start FFI calls. Call on a background queue.
 - (BOOL)startWithError:(NSError **)error;
 
-/// Blocking: restarts engine + tun2socks while preserving the packet read loop.
-- (BOOL)restartWithError:(NSError **)error;
-
 /// Stops engine, tun2socks, ingress loop, traffic pump.
 - (void)stop;
-
-/// Blocking end-to-end data-path probe: injects a synthetic in-TUN DNS query
-/// and waits (≤ timeoutMs) for its reply to traverse the full ingress → lwip
-/// → meow-dns → egress pipeline. YES = the path is demonstrably live; NO =
-/// wedged, not started, or timed out — restart-worthy. Call on the engine
-/// control queue, never on a runtime callback thread.
-- (BOOL)isDataPathHealthyWithTimeoutMs:(int32_t)timeoutMs;
 
 @property (nonatomic, readonly) BOOL isEngineRunning;
 @property (nonatomic, readonly) BOOL tunStarted;

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -5,7 +5,6 @@
 #import "MWSharedStore.h"
 #import "MWDarwinBridge.h"
 #import "MWEngineLog.h"
-#import "MWTunnelSettings.h"
 #import "meow_core.h"
 #import <stdatomic.h>
 #import <os/log.h>
@@ -47,8 +46,7 @@ static const int kLocalDNSPort                 = 1053;
     // Bumped on terminal stop. A readPackets completion handler captures the
     // epoch when it arms and drops itself if the epoch advanced in the meantime,
     // so an in-flight handler from a stopped generation cannot ingest stale
-    // packets or re-arm a second concurrent read chain. In-place wake restarts
-    // intentionally keep this read chain alive.
+    // packets or re-arm a second concurrent read chain.
     _Atomic uint64_t _ingressEpoch;
     _Atomic int64_t _ingressPackets;
     dispatch_source_t _trafficTimer;
@@ -162,40 +160,6 @@ static const int kLocalDNSPort                 = 1053;
     return YES;
 }
 
-// MARK: - Restart
-
-- (BOOL)restartWithError:(NSError **)error {
-    if (!_started) {
-        if (error) *error = [NSError errorWithDomain:@"MWTunnelEngine"
-                                                code:3
-                                            userInfo:@{NSLocalizedDescriptionKey: @"engine not started"}];
-        return NO;
-    }
-
-    os_log_info(gLog, "engine: restart entry");
-
-    [self stopTrafficPump];
-    if (_tunStarted) {
-        meow_tun_stop_blocking();
-        _tunStarted = NO;
-    }
-    meow_engine_stop();
-
-    if (![self startRuntimeWithError:error]) {
-        atomic_store_explicit(&_ingressRunning, NO, memory_order_relaxed);
-        atomic_fetch_add_explicit(&_ingressEpoch, 1, memory_order_relaxed);
-        [self releaseWriterContext];
-        _started = NO;
-        return NO;
-    }
-
-    // Do not call startIngressLoop here. The original readPackets chain remains
-    // armed across the in-place restart; arming another read on the same
-    // NEPacketTunnelFlow can violate the one-read-at-a-time contract.
-    [self startTrafficPump];
-    return YES;
-}
-
 // MARK: - Stop
 
 - (void)stop {
@@ -224,14 +188,6 @@ static const int kLocalDNSPort                 = 1053;
 
 - (BOOL)isEngineRunning {
     return meow_engine_is_running() != 0;
-}
-
-- (BOOL)isDataPathHealthyWithTimeoutMs:(int32_t)timeoutMs {
-    if (!_started || !_tunStarted) return NO;
-    int rc = meow_tun_health_probe(MWTunnelClientIPv4Address.UTF8String,
-                                   MWTunnelDNSServerIPv4Address.UTF8String,
-                                   timeoutMs);
-    return rc == 0;
 }
 
 @synthesize tunStarted = _tunStarted;
@@ -366,7 +322,7 @@ static const int kLocalDNSPort                 = 1053;
     }
     _lastTcpConns = tcpConns;
 
-    [self maybeRestartForFootprint:footprintMB now:now];
+    [self maybeRelieveFootprintPressure:footprintMB now:now];
 
     NSTimeInterval epoch = now + NSTimeIntervalSince1970;
     NSDictionary *snapshot = @{
@@ -394,7 +350,7 @@ static const int kLocalDNSPort                 = 1053;
 
 // MARK: - Soft-cap watchdog
 
-- (void)maybeRestartForFootprint:(NSInteger)footprintMB now:(NSTimeInterval)now {
+- (void)maybeRelieveFootprintPressure:(NSInteger)footprintMB now:(NSTimeInterval)now {
     if (footprintMB < kSoftCapFootprintMB) return;
     if (_lastReliefAttempt > 0 && (now - _lastReliefAttempt) < kReliefCooldownS) {
         return;

--- a/PacketTunnel/Sources/MWTunnelSettings.m
+++ b/PacketTunnel/Sources/MWTunnelSettings.m
@@ -34,8 +34,9 @@ NSString *const MWTunnelDNSServerIPv4Address = @"172.19.0.2";
     // the default route; only the explicitly excluded LAN/link-local ranges
     // bypass the tunnel, mirroring the IPv4 LAN-exclusion policy.
     //
-    // IPv4↔IPv6 path transitions are handled by the path monitor's
-    // address-family restart in PacketTunnelProvider.
+    // IPv4↔IPv6 path transitions need no special handling: the engine dials
+    // per-flow/per-query, so it picks up the current address families lazily
+    // on the next dial (in-place engine restarts were removed).
     if (ipv6Enabled) {
         NEIPv6Settings *ipv6 = [[NEIPv6Settings alloc]
             initWithAddresses:@[@"fd6d:6577::1"]

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -12,8 +12,6 @@
 #import <os/log.h>
 #import <mach/mach.h>
 #import <malloc/malloc.h>
-#import <stdatomic.h>
-@import Network;
 
 // keep in sync with MeowShared/Sources/MeowIPC/DiagnosticsIPC.swift and
 // MeowShared/Sources/MeowIPC/ProxyControlIPC.swift tag values
@@ -27,48 +25,11 @@ static os_log_t gLog;
 @implementation PacketTunnelProvider {
     MWTunnelEngine     *_engine;
     MWIPCListener      *_ipcListener;
-    nw_path_monitor_t   _pathMonitor;
-    dispatch_queue_t    _pathQueue;
-    BOOL                _havePath;
-    BOOL                _lastSatisfied;
-    nw_interface_type_t _lastInterfaceType;
-    BOOL                _lastHasIPv4;
-    BOOL                _lastHasIPv6;
-    // Serializes blocking engine start/stop/restart work. NE lifecycle
-    // callbacks can arrive on different system queues; MWTunnelEngine owns
-    // non-atomic state and must not be driven concurrently.
+    // Serializes blocking engine start/stop work. NE lifecycle callbacks can
+    // arrive on different system queues; MWTunnelEngine owns non-atomic state
+    // and must not be driven concurrently.
     dispatch_queue_t    _engineControlQueue;
-    // Monotonic counter bumped by every restart source/invalidator. A debounced
-    // restart block captures the value at schedule time and only runs if it's
-    // still current when the debounce window elapses, so a burst of path
-    // changes collapses to a single restart after things settle.
-    _Atomic uint64_t    _restartGeneration;
-    // Bumped whenever a path monitor starts or stops. Path callbacks capture it
-    // so a canceled monitor cannot schedule a delayed restart for a later
-    // tunnel generation.
-    _Atomic uint64_t    _pathGeneration;
-    // CLOCK_MONOTONIC nanoseconds of the last successful engine start or
-    // restart (0 = never). Written on _engineControlQueue, read on _pathQueue,
-    // hence atomic. CLOCK_MONOTONIC keeps counting across sleep, so a grace
-    // window that straddles a sleep/wake cycle expires rather than suppressing
-    // a restart the post-wake network state genuinely needs.
-    _Atomic uint64_t    _lastEngineStartNs;
 }
-
-// Quiet window after the last path event before a triggered engine restart
-// actually fires. Long enough to ride out rapid path churn without stacking
-// restarts, short enough that a genuine path change recovers connectivity
-// quickly.
-static const NSTimeInterval kEngineRestartDebounceS = 3.0;
-
-// Grace window after a successful engine (re)start during which an
-// address-family-only path change does NOT trigger another restart. Routers
-// commonly deliver the IPv6 RA / DHCPv6 prefix 5-30s after DHCPv4 completes,
-// so one physical reconnect would otherwise restart the engine twice —
-// dropping every connection again and re-resolving proxy hostnames from a
-// fresh (empty) DNS cache. A family change outside the window still restarts:
-// the network genuinely changed shape mid-session.
-static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
 
 + (void)initialize {
     if (self == [PacketTunnelProvider class]) {
@@ -85,9 +46,6 @@ static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
                                                     0);
         _engineControlQueue = dispatch_queue_create(
             "com.tangzixiang.meow.PacketTunnel.engine-control", attr);
-        atomic_init(&_restartGeneration, 0);
-        atomic_init(&_pathGeneration, 0);
-        atomic_init(&_lastEngineStartNs, 0);
     }
     return self;
 }
@@ -131,9 +89,6 @@ static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
                 return;
             }
             self->_engine = engine;
-            atomic_store_explicit(&self->_lastEngineStartNs,
-                                  clock_gettime_nsec_np(CLOCK_MONOTONIC),
-                                  memory_order_relaxed);
 
             MWIPCListener *listener = [[MWIPCListener alloc]
                 initWithHandler:^(NSDictionary *intent) {
@@ -141,8 +96,6 @@ static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
                 }];
             [listener start];
             self->_ipcListener = listener;
-
-            [self startPathMonitor];
 
             [self writeState:@"connected" profileID:profileID errorMessage:nil];
             completionHandler(nil);
@@ -154,9 +107,7 @@ static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
            completionHandler:(void (^)(void))completionHandler {
     os_log_info(gLog, "stopTunnel reason=%ld", (long)reason);
     MWEngineLogf(MWLogInfo, @"NE: stopTunnel reason=%ld", (long)reason);
-    atomic_fetch_add_explicit(&_restartGeneration, 1, memory_order_relaxed);
     dispatch_async(_engineControlQueue, ^{
-        [self stopPathMonitor];
         MWTunnelEngine *engine = self->_engine;
         self->_engine = nil;
         [engine stop];
@@ -171,10 +122,6 @@ static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
 - (void)sleepWithCompletionHandler:(void (^)(void))completionHandler {
     os_log_info(gLog, "sleep: keeping tun active before device sleep");
     MWEngineLog(MWLogInfo, @"NE: sleep — keeping tun active before device sleep");
-    // Invalidate any pending engine restart: we're heading back to sleep, so a
-    // restart now would just be torn down. Bumping the generation makes the
-    // scheduled block bail when it fires.
-    atomic_fetch_add_explicit(&_restartGeneration, 1, memory_order_relaxed);
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
         malloc_zone_pressure_relief(NULL, 0);
         completionHandler();
@@ -182,110 +129,13 @@ static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
 }
 
 - (void)wake {
+    // No restart, no probe: the engine runs uninterrupted across sleep/wake.
+    // In-place engine restarts (wake-health, path-change, address-family) were
+    // removed — a restart was a guaranteed multi-second DNS blackout, while
+    // everything the engine dials is per-flow/per-query and self-heals on the
+    // current network.
     os_log_info(gLog, "wake: tun remained active");
     MWEngineLog(MWLogInfo, @"NE: wake — tun remained active");
-    // Sleep invalidated any pending engine restart, and the path monitor only
-    // fires on deltas — a delta consumed during a darkwake (whose restart the
-    // re-sleep then canceled) never re-fires at the final wake. So don't trust
-    // path state: verify the data path actually moves packets. The probe is an
-    // in-process DNS round-trip through the whole ingress→lwip→meow-dns→egress
-    // pipeline (~ms when healthy, no upstream network needed in fake-IP mode).
-    // Only a failed probe schedules the (debounced, re-probed) restart, so a
-    // healthy wake no longer pays the restart's DNS blackout.
-    dispatch_async(_engineControlQueue, ^{
-        MWTunnelEngine *engine = self->_engine;
-        if (!engine) return;
-        if ([engine isDataPathHealthyWithTimeoutMs:2000]) {
-            os_log_info(gLog, "wake: data path healthy, no restart needed");
-            return;
-        }
-        os_log_error(gLog, "wake: data path unresponsive, scheduling engine restart");
-        MWEngineLog(MWLogError, @"NE: wake — data path unresponsive, scheduling engine restart");
-        [self scheduleEngineRestartForReason:@"wake-health"];
-    });
-}
-
-- (void)scheduleEngineRestartForReason:(NSString *)reason {
-    uint64_t gen = atomic_fetch_add_explicit(&_restartGeneration, 1, memory_order_relaxed) + 1;
-    __weak __typeof__(self) weak = self;
-    dispatch_after(
-        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kEngineRestartDebounceS * NSEC_PER_SEC)),
-        dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-            __strong __typeof__(weak) self = weak;
-            if (!self) return;
-            if (atomic_load_explicit(&self->_restartGeneration, memory_order_relaxed) != gen) {
-                os_log_info(gLog, "%{public}@ restart: superseded by newer event, skipping",
-                            reason);
-                return;
-            }
-            [self restartEngineForGeneration:gen reason:reason];
-        });
-}
-
-// Restart the running engine in place. No-op if no engine is running (e.g.
-// restart raced a stop). Runs on _engineControlQueue so it cannot interleave with
-// a user/app stop.
-- (void)restartEngineForGeneration:(uint64_t)gen reason:(NSString *)reason {
-    dispatch_async(_engineControlQueue, ^{
-        if (atomic_load_explicit(&self->_restartGeneration, memory_order_relaxed) != gen) {
-            os_log_info(gLog, "%{public}@ restart: superseded before engine restart, skipping",
-                        reason);
-            return;
-        }
-
-        MWTunnelEngine *engine = self->_engine;
-        if (!engine) {
-            os_log_info(gLog, "%{public}@ restart: no engine running, skipping", reason);
-            return;
-        }
-
-        // A path event proves the physical network changed shape, not that the
-        // tunnel broke. Everything the engine dials is per-flow/per-query, so a
-        // live data path self-heals on the new network — while a restart is a
-        // guaranteed multi-second DNS blackout (listener down, fake-IP pool
-        // wiped, every flow dropped) right when the user starts using the
-        // device. Probe end-to-end first and keep a healthy engine running.
-        if ([engine isDataPathHealthyWithTimeoutMs:1500]) {
-            os_log_info(gLog, "%{public}@ restart: data path healthy, skipping restart",
-                        reason);
-            MWEngineLogf(MWLogInfo, @"NE: %@ restart — data path healthy, skipping", reason);
-            return;
-        }
-        // The probe blocked this queue for up to its timeout; a newer path
-        // event may have superseded this restart meanwhile. Let the newest
-        // generation own recovery instead of restarting twice back-to-back.
-        if (atomic_load_explicit(&self->_restartGeneration, memory_order_relaxed) != gen) {
-            os_log_info(gLog, "%{public}@ restart: superseded during health probe, skipping",
-                        reason);
-            return;
-        }
-        os_log_error(gLog, "%{public}@ restart: data path unresponsive, restarting engine",
-                     reason);
-        MWEngineLogf(MWLogError, @"NE: %@ restart — data path unresponsive, restarting",
-                     reason);
-
-        NSError *startErr = nil;
-        if (![engine restartWithError:&startErr]) {
-            os_log_error(gLog, "%{public}@ restart: engine start failed: %{public}@",
-                         reason,
-                         startErr.localizedDescription);
-            MWEngineLogf(MWLogError, @"NE: %@ restart — engine start failed: %@",
-                         reason, startErr.localizedDescription);
-            self->_engine = nil;
-            [self writeState:@"error" profileID:nil errorMessage:startErr.localizedDescription];
-            // A failed restart leaves no working data path. Tear the tunnel down so
-            // NE on-demand / the app can re-establish it cleanly rather than
-            // sitting connected-but-dead.
-            [self cancelTunnelWithError:startErr];
-            return;
-        }
-
-        atomic_store_explicit(&self->_lastEngineStartNs,
-                              clock_gettime_nsec_np(CLOCK_MONOTONIC),
-                              memory_order_relaxed);
-        os_log_info(gLog, "%{public}@ restart: engine restarted", reason);
-        MWEngineLogf(MWLogInfo, @"NE: %@ restart — engine restarted", reason);
-    });
 }
 
 // MARK: - App messages
@@ -455,130 +305,6 @@ static const NSTimeInterval kAddressFamilyRestartGraceS = 30.0;
         return;
     }
     [MWDarwinBridge post:MWNotificationState];
-}
-
-// MARK: - Network path monitoring
-
-- (void)startPathMonitor {
-    uint64_t pathGen = atomic_fetch_add_explicit(&_pathGeneration, 1, memory_order_relaxed) + 1;
-    _pathQueue = dispatch_queue_create("com.tangzixiang.meow.PacketTunnel.path",
-                                       DISPATCH_QUEUE_SERIAL);
-    _havePath = NO;
-    _lastSatisfied = NO;
-    _lastInterfaceType = nw_interface_type_other;
-    _lastHasIPv4 = NO;
-    _lastHasIPv6 = NO;
-
-    nw_path_monitor_t monitor = nw_path_monitor_create();
-    nw_path_monitor_set_queue(monitor, _pathQueue);
-
-    __weak __typeof__(self) weak = self;
-    nw_path_monitor_set_update_handler(monitor, ^(nw_path_t _Nonnull path) {
-        __strong __typeof__(weak) self = weak;
-        if (!self) return;
-        [self handlePathUpdate:path generation:pathGen];
-    });
-    nw_path_monitor_start(monitor);
-    _pathMonitor = monitor;
-}
-
-- (void)stopPathMonitor {
-    atomic_fetch_add_explicit(&_pathGeneration, 1, memory_order_relaxed);
-    atomic_fetch_add_explicit(&_restartGeneration, 1, memory_order_relaxed);
-    if (_pathMonitor) {
-        nw_path_monitor_cancel(_pathMonitor);
-        _pathMonitor = nil;
-    }
-    _pathQueue = nil;
-}
-
-// Caller queue: _pathQueue (serial). All ivar access here is single-threaded.
-- (void)handlePathUpdate:(nw_path_t)path generation:(uint64_t)pathGen {
-    if (atomic_load_explicit(&_pathGeneration, memory_order_relaxed) != pathGen) {
-        os_log_info(gLog, "path: stale monitor update ignored");
-        return;
-    }
-
-    nw_path_status_t status = nw_path_get_status(path);
-    BOOL satisfied = (status == nw_path_status_satisfied);
-
-    nw_interface_type_t iface = nw_interface_type_other;
-    BOOL hasIPv4 = NO;
-    BOOL hasIPv6 = NO;
-    if (satisfied) {
-        if (nw_path_uses_interface_type(path, nw_interface_type_wifi)) {
-            iface = nw_interface_type_wifi;
-        } else if (nw_path_uses_interface_type(path, nw_interface_type_cellular)) {
-            iface = nw_interface_type_cellular;
-        } else if (nw_path_uses_interface_type(path, nw_interface_type_wired)) {
-            iface = nw_interface_type_wired;
-        }
-        hasIPv4 = nw_path_has_ipv4(path);
-        hasIPv6 = nw_path_has_ipv6(path);
-    }
-
-    if (!_havePath) {
-        _havePath = YES;
-        _lastSatisfied = satisfied;
-        _lastInterfaceType = iface;
-        _lastHasIPv4 = hasIPv4;
-        _lastHasIPv6 = hasIPv6;
-        os_log_info(gLog, "path: initial satisfied=%d iface=%d v4=%d v6=%d",
-                    satisfied, iface, hasIPv4, hasIPv6);
-        return;
-    }
-
-    BOOL shouldRestart = NO;
-    if (satisfied && !_lastSatisfied) {
-        os_log_info(gLog, "path: connectivity regained");
-        MWEngineLog(MWLogInfo, @"NE: path — connectivity regained");
-        shouldRestart = YES;
-    } else if (satisfied && iface != _lastInterfaceType) {
-        os_log_info(gLog, "path: interface changed %d -> %d", _lastInterfaceType, iface);
-        MWEngineLogf(MWLogInfo, @"NE: path — interface changed %d -> %d",
-                     _lastInterfaceType, iface);
-        shouldRestart = YES;
-    } else if (satisfied && (hasIPv4 != _lastHasIPv4 || hasIPv6 != _lastHasIPv6)) {
-        // Same interface, same satisfied state, but the address-family set
-        // changed — e.g. the Wi-Fi network silently lost (or gained) IPv6
-        // via expired RAs or an upstream change. Restart the engine + tun2socks
-        // after a debounce so the fresh stack tracks the new network shape —
-        // unless an engine (re)start just happened, in which case this is
-        // almost certainly the late-v6 tail of the same physical reconnect
-        // and the fresh engine will pick the family up lazily on next dial.
-        uint64_t lastStartNs = atomic_load_explicit(&_lastEngineStartNs,
-                                                    memory_order_relaxed);
-        uint64_t nowNs = clock_gettime_nsec_np(CLOCK_MONOTONIC);
-        NSTimeInterval sinceStart = (NSTimeInterval)(nowNs - lastStartNs) / NSEC_PER_SEC;
-        if (lastStartNs != 0 && sinceStart < kAddressFamilyRestartGraceS) {
-            os_log_info(gLog,
-                        "path: address family changed v4 %d -> %d, v6 %d -> %d "
-                        "within %.0fs of engine start, absorbing (no restart)",
-                        _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6, sinceStart);
-            MWEngineLogf(MWLogInfo,
-                         @"NE: path — address family changed v4 %d -> %d, v6 %d -> %d "
-                         @"within %.0fs of engine start, absorbing (no restart)",
-                         _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6, sinceStart);
-        } else {
-            os_log_info(gLog, "path: address family changed v4 %d -> %d, v6 %d -> %d",
-                        _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6);
-            MWEngineLogf(MWLogInfo,
-                         @"NE: path — address family changed v4 %d -> %d, v6 %d -> %d",
-                         _lastHasIPv4, hasIPv4, _lastHasIPv6, hasIPv6);
-            shouldRestart = YES;
-        }
-    }
-
-    _lastSatisfied = satisfied;
-    _lastInterfaceType = iface;
-    _lastHasIPv4 = hasIPv4;
-    _lastHasIPv6 = hasIPv6;
-
-    if (shouldRestart) {
-        os_log_info(gLog, "path: scheduling debounced engine restart");
-        MWEngineLog(MWLogInfo, @"NE: path — scheduling debounced engine restart");
-        [self scheduleEngineRestartForReason:@"path"];
-    }
 }
 
 @end

--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -924,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "axum",
  "base64",
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "base64",
  "libc",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2141,12 +2141,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2264,7 +2264,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3303,7 +3303,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4046,7 +4046,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "axum",
  "base64",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "base64",
  "libc",
@@ -1988,7 +1988,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2080,12 +2080,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=88553178ef005817f96ad2a7c82679838d504e49#88553178ef005817f96ad2a7c82679838d504e49"
+source = "git+https://github.com/madeye/meow-rs?rev=f36b74fd70598f25bc7cabb5d7cbfa996d67c17e#f36b74fd70598f25bc7cabb5d7cbfa996d67c17e"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,8 +68,12 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 88553178 (0.18.0 + meow-rs#350) — adds #PROXY-fragment support on
-# nameserver-policy entries, which the pinned ChinaDNS-style geosite:gfw
+# HEAD: f36b74fd (0.18.0 + meow-rs#351) — redir-host answers carry the upstream's real TTL
+# (remaining cache lifetime) instead of a fixed 60s, and meow-dns exposes
+# reverse_cache_snapshot / restore_reverse_cache so `dns_cache_store` can
+# persist the IP → host table across engine restarts. Previous pin 88553178
+# (0.18.0 + meow-rs#350) added #PROXY-fragment support on nameserver-policy
+# entries, which the pinned ChinaDNS-style geosite:gfw
 # policy below relies on. Previous pin 74e8083a (meow-rs 0.18.0) picked up
 # the rule-IR compilation series
 # (meow-rs#285/#291/#295–#297), lazy metadata enrichment (#292), the VMess
@@ -85,7 +89,7 @@ lwip = "0.3"
 # (119.29.29.29 / 223.5.5.5) — re-applied 2026-07-20 after the PR #321
 # revert, TLS SNI sniffer kept enabled as the reverse-cache backstop; the
 # DoT-only pool was dropped same day (unreachable from target networks).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "f36b74fd70598f25bc7cabb5d7cbfa996d67c17e" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -93,12 +97,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef0058
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "88553178ef005817f96ad2a7c82679838d504e49" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "f36b74fd70598f25bc7cabb5d7cbfa996d67c17e", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "f36b74fd70598f25bc7cabb5d7cbfa996d67c17e" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "f36b74fd70598f25bc7cabb5d7cbfa996d67c17e" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "f36b74fd70598f25bc7cabb5d7cbfa996d67c17e", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "f36b74fd70598f25bc7cabb5d7cbfa996d67c17e" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "f36b74fd70598f25bc7cabb5d7cbfa996d67c17e" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/dns_cache_store.rs
+++ b/core/rust/meow-ios-ffi/src/dns_cache_store.rs
@@ -1,0 +1,289 @@
+//! Disk persistence for the redir-host reverse DNS table.
+//!
+//! In redir-host (Mapping) mode the tunnel recovers hostnames for rule
+//! matching from meow-dns's in-memory IP → host reverse table. That table
+//! dies with the engine, but the connections that depend on it don't: after a
+//! wake restart (or a jetsam kill + relaunch) apps keep dialing IPs they
+//! resolved *before* the restart, and every such flow silently degrades to
+//! IP-only rule matching. This module persists the reverse table to
+//! `<home>/dns-reverse-cache.json` so `start()` can reload it.
+//!
+//! Layering: meow-dns owns the mechanism (`reverse_cache_snapshot` /
+//! `restore_reverse_cache`, with `remaining: Duration` lifetimes); this module
+//! owns the policy — file location, wall-clock anchoring (`Instant` doesn't
+//! survive a process, so entries are persisted with absolute unix-epoch
+//! expiries), save cadence, and corruption handling.
+//!
+//! Save triggers: a periodic task (60 s, skipped when the serialized table is
+//! byte-identical to the last write — idle engines don't touch disk) plus a
+//! final unconditional write in `engine::stop()`. The periodic task is what
+//! covers jetsam kills, which never reach `stop()`.
+
+use meow_dns::{Resolver, ReverseSnapshotEntry};
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{debug, info, warn};
+
+const FILE_NAME: &str = "dns-reverse-cache.json";
+const FORMAT_VERSION: u32 = 1;
+
+/// Periodic save cadence. Coarse on purpose: the table is small (reverse cap
+/// is 16 × 1024 entries ≈ tens of KB serialized in practice) but the NE
+/// shares its jetsam budget with the data path — one bounded write per minute
+/// of DNS activity is plenty to cover an unclean death.
+pub const SAVE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Sanity cap on entries accepted from disk. The in-memory table enforces its
+/// own per-shard LRU caps on restore; this just refuses to buffer an absurd
+/// (corrupt or crafted) file into a `Vec` first. Comfortably above the
+/// engine's global reverse cap (16 shards × 1024).
+const MAX_RESTORE_ENTRIES: usize = 65_536;
+
+#[derive(Serialize, Deserialize)]
+struct PersistedTable {
+    version: u32,
+    entries: Vec<PersistedEntry>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedEntry {
+    ip: IpAddr,
+    host: String,
+    /// Absolute expiry, seconds since the unix epoch. Absolute (not
+    /// remaining) so the value stays valid however long the file sits on
+    /// disk — a phone that was off for an hour restores only what genuinely
+    /// hasn't expired, and an idle engine can skip rewriting an unchanged
+    /// table without the stored expiries drifting stale.
+    expires_at: u64,
+}
+
+/// Serialized bytes of the last table this process wrote (FNV-1a hash), so
+/// the periodic saver can skip disk entirely when nothing changed. 0 = no
+/// write yet this process → first save always writes.
+static LAST_WRITTEN_HASH: AtomicU64 = AtomicU64::new(0);
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn now_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+pub fn store_path() -> Option<PathBuf> {
+    crate::HOME_DIR
+        .lock()
+        .clone()
+        .map(|d| Path::new(&d).join(FILE_NAME))
+}
+
+/// Pure snapshot → persisted conversion, anchored at `now` (unix secs).
+fn to_persisted(entries: Vec<ReverseSnapshotEntry>, now: u64) -> PersistedTable {
+    PersistedTable {
+        version: FORMAT_VERSION,
+        entries: entries
+            .into_iter()
+            .map(|e| PersistedEntry {
+                ip: e.ip,
+                host: e.domain,
+                expires_at: now.saturating_add(e.remaining.as_secs()),
+            })
+            .collect(),
+    }
+}
+
+/// Pure persisted → snapshot conversion, anchored at `now` (unix secs).
+/// Entries already expired on the wall clock are dropped here — the restart
+/// gap is exactly the time the in-memory `Instant` clock couldn't see.
+fn to_snapshot(table: PersistedTable, now: u64) -> Vec<ReverseSnapshotEntry> {
+    if table.version != FORMAT_VERSION {
+        return Vec::new();
+    }
+    table
+        .entries
+        .into_iter()
+        .take(MAX_RESTORE_ENTRIES)
+        .filter_map(|e| {
+            let remaining = e.expires_at.checked_sub(now)?;
+            if remaining == 0 {
+                return None;
+            }
+            Some(ReverseSnapshotEntry {
+                ip: e.ip,
+                domain: e.host,
+                remaining: Duration::from_secs(remaining),
+            })
+        })
+        .collect()
+}
+
+/// Load the persisted table (if any) into `resolver`'s reverse cache. Call
+/// once at engine start, before traffic. Corrupt or unreadable files are
+/// logged and ignored — the table is a warm-start optimization, never worth
+/// failing a start over.
+pub fn restore(resolver: &Resolver) {
+    let Some(path) = store_path() else {
+        return;
+    };
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            warn!("dns reverse cache: read {} failed: {e}", path.display());
+            return;
+        }
+    };
+    let table: PersistedTable = match serde_json::from_slice(&bytes) {
+        Ok(t) => t,
+        Err(e) => {
+            warn!(
+                "dns reverse cache: {} corrupt ({e}), discarding",
+                path.display()
+            );
+            let _ = std::fs::remove_file(&path);
+            return;
+        }
+    };
+    let persisted = table.entries.len();
+    let live = to_snapshot(table, now_epoch_secs());
+    let restored = live.len();
+    resolver.restore_reverse_cache(live);
+    info!("dns reverse cache: restored {restored}/{persisted} entries");
+}
+
+/// Snapshot the reverse table and write it to disk (atomic tmp + rename).
+/// `force` bypasses the unchanged-table skip — `stop()` uses it so the final
+/// state always lands. Returns true when a write happened.
+pub fn save(resolver: &Resolver, force: bool) -> bool {
+    let Some(path) = store_path() else {
+        return false;
+    };
+    let table = to_persisted(resolver.reverse_cache_snapshot(), now_epoch_secs());
+    let bytes = match serde_json::to_vec(&table) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("dns reverse cache: serialize failed: {e}");
+            return false;
+        }
+    };
+    // Snapshot order is IP-sorted (stable), and expiries are absolute, so an
+    // idle table serializes byte-identically (modulo ±1 s rounding jitter on
+    // the epoch anchor) and the periodic saver skips the disk entirely.
+    let hash = fnv1a64(&bytes);
+    if !force && LAST_WRITTEN_HASH.load(Ordering::Relaxed) == hash {
+        debug!("dns reverse cache: unchanged, skipping save");
+        return false;
+    }
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let tmp = path.with_extension("json.tmp");
+    let written = std::fs::write(&tmp, &bytes)
+        .and_then(|()| std::fs::rename(&tmp, &path))
+        .map_err(|e| warn!("dns reverse cache: write {} failed: {e}", path.display()))
+        .is_ok();
+    if written {
+        LAST_WRITTEN_HASH.store(hash, Ordering::Relaxed);
+        debug!(
+            "dns reverse cache: saved {} entries ({} bytes)",
+            table.entries.len(),
+            bytes.len()
+        );
+    }
+    written
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use meow_common::DnsMode;
+    use std::net::Ipv4Addr;
+
+    fn entry(ip: [u8; 4], host: &str, remaining: u64) -> ReverseSnapshotEntry {
+        ReverseSnapshotEntry {
+            ip: IpAddr::V4(Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3])),
+            domain: host.into(),
+            remaining: Duration::from_secs(remaining),
+        }
+    }
+
+    #[test]
+    fn persisted_round_trip_preserves_live_entries() {
+        let now = 1_800_000_000;
+        let table = to_persisted(
+            vec![
+                entry([1, 2, 3, 4], "a.example", 600),
+                entry([5, 6, 7, 8], "b.example", 30),
+            ],
+            now,
+        );
+        let bytes = serde_json::to_vec(&table).unwrap();
+        let parsed: PersistedTable = serde_json::from_slice(&bytes).unwrap();
+        let restored = to_snapshot(parsed, now);
+        assert_eq!(restored.len(), 2);
+        assert_eq!(restored[0].domain, "a.example");
+        assert_eq!(restored[0].remaining, Duration::from_secs(600));
+        assert_eq!(restored[1].remaining, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn restore_discounts_wall_clock_gap_and_drops_expired() {
+        let saved_at = 1_800_000_000;
+        let table = to_persisted(
+            vec![
+                entry([1, 1, 1, 1], "live.example", 600),
+                entry([2, 2, 2, 2], "dead.example", 100),
+            ],
+            saved_at,
+        );
+        // Engine comes back 120 s later: the 100 s entry is gone, the 600 s
+        // one has 480 s left.
+        let restored = to_snapshot(table, saved_at + 120);
+        assert_eq!(restored.len(), 1);
+        assert_eq!(restored[0].domain, "live.example");
+        assert_eq!(restored[0].remaining, Duration::from_secs(480));
+    }
+
+    #[test]
+    fn unknown_version_restores_nothing() {
+        let table = PersistedTable {
+            version: FORMAT_VERSION + 1,
+            entries: vec![PersistedEntry {
+                ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+                host: "x.example".into(),
+                expires_at: u64::MAX,
+            }],
+        };
+        assert!(to_snapshot(table, 0).is_empty());
+    }
+
+    #[test]
+    fn end_to_end_through_resolver() {
+        // Full path minus disk: resolver A's table → persisted JSON →
+        // resolver B answers reverse lookups after the "restart".
+        let a = Resolver::new(vec![], vec![], DnsMode::Mapping, Default::default(), true);
+        let ip = IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34));
+        a.preload_cache("persist.example", &[ip], Duration::from_secs(300));
+
+        let now = now_epoch_secs();
+        let table = to_persisted(a.reverse_cache_snapshot(), now);
+        let bytes = serde_json::to_vec(&table).unwrap();
+
+        let b = Resolver::new(vec![], vec![], DnsMode::Mapping, Default::default(), true);
+        assert!(b.reverse_lookup(ip).is_none());
+        let parsed: PersistedTable = serde_json::from_slice(&bytes).unwrap();
+        b.restore_reverse_cache(to_snapshot(parsed, now));
+        assert_eq!(b.reverse_lookup(ip).as_deref(), Some("persist.example"));
+    }
+}

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -48,6 +48,9 @@ fn bind_socket_addr(listen: &str, port: u16) -> Result<SocketAddr> {
 struct EngineState {
     stats: Arc<Statistics>,
     tunnel: Tunnel,
+    /// Kept so `stop()` can flush the redir-host reverse DNS table to disk
+    /// after the listener tasks are gone (see `dns_cache_store`).
+    resolver: Arc<meow_dns::Resolver>,
     mixed_dial_addr: Option<SocketAddr>,
     dns_dial_addr: Option<SocketAddr>,
     api_task: Option<JoinHandle<()>>,
@@ -226,6 +229,15 @@ pub fn start(config_path: &str) -> Result<()> {
 
     let resolver = cfg.dns.resolver.clone();
 
+    // Warm-start the redir-host reverse (IP → host) table from the previous
+    // engine's persisted snapshot, before any listener can serve traffic.
+    // Apps keep dialing IPs they resolved before a wake restart; without the
+    // reload those flows silently degrade to IP-only rule matching until
+    // their next DNS query.
+    if resolver.mode() == meow_common::DnsMode::Mapping {
+        crate::dns_cache_store::restore(&resolver);
+    }
+
     // Route proxy-upstream hostname resolution through meow-dns instead of
     // libc `getaddrinfo`. On the NE, `getaddrinfo` runs one blocking-pool
     // thread per lookup and re-resolves on every dial, so a wake-from-sleep
@@ -292,6 +304,30 @@ pub fn start(config_path: &str) -> Result<()> {
         listener_tasks.push(crate::get_engine_runtime().spawn(async move {
             if let Err(e) = dns_server.run().await {
                 error!("DNS server error: {}", e);
+            }
+        }));
+    }
+
+    // Periodically persist the reverse table so a jetsam kill — which never
+    // reaches `stop()` — still leaves a warm snapshot on disk. The saver
+    // skips the write when the serialized table is unchanged, so an idle NE
+    // stays off disk entirely.
+    if resolver.mode() == meow_common::DnsMode::Mapping {
+        let saver_resolver = resolver.clone();
+        listener_tasks.push(crate::get_engine_runtime().spawn(async move {
+            let mut tick = tokio::time::interval(crate::dns_cache_store::SAVE_INTERVAL);
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // interval()'s first tick completes immediately; consume it —
+            // start() just restored this exact state.
+            tick.tick().await;
+            loop {
+                tick.tick().await;
+                let r = saver_resolver.clone();
+                // File I/O via spawn_blocking: a stalled disk write must not
+                // be able to occupy an engine worker the data path needs.
+                let _ =
+                    tokio::task::spawn_blocking(move || crate::dns_cache_store::save(&r, false))
+                        .await;
             }
         }));
     }
@@ -373,6 +409,7 @@ pub fn start(config_path: &str) -> Result<()> {
     *slot().lock() = Some(EngineState {
         stats,
         tunnel,
+        resolver,
         mixed_dial_addr,
         dns_dial_addr,
         api_task,
@@ -404,6 +441,15 @@ pub fn stop() {
         h.abort();
         let _ = runtime.block_on(h);
     }
+
+    // Final reverse-table flush, forced past the unchanged-skip: this is the
+    // snapshot the next start() warm-starts from. After the aborts above so
+    // no listener can grow the table behind the write. `stop()` runs outside
+    // the tokio runtime, so blocking file I/O is fine here.
+    if state.resolver.mode() == meow_common::DnsMode::Mapping {
+        crate::dns_cache_store::save(&state.resolver, true);
+    }
+
     info!("meow-rs engine stopped");
 }
 

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -20,6 +20,7 @@
 //! DoH cache, or in-FFI TCP-DNS client.
 
 mod diagnostics;
+mod dns_cache_store;
 mod engine;
 mod file_log;
 mod logging;


### PR DESCRIPTION
Three related changes to how the tunnel behaves around engine lifecycle in redir-host mode:

## 1. Reverse (IP → host) table persisted across engine restarts

New `dns_cache_store` FFI module saves meow-dns's reverse table to `<AppGroup>/dns-reverse-cache.json` (absolute unix-epoch expiries, atomic tmp+rename writes):

- **restore** in `engine::start()` before any listener serves traffic — connections dialed from pre-start DNS answers keep hostname-based rule matching instead of silently degrading to IP-only;
- **periodic save** every 60 s, skipped when the serialized table is byte-identical (idle NE never touches disk); this is what covers jetsam kills, which never reach `stop()`;
- **forced flush** in `engine::stop()` after listeners are torn down.

Entries that expired during the downtime gap are dropped on reload; corrupt files are discarded, never fail a start.

## 2. DNS answers carry the upstream's real TTL (meow-rs pin bump → `f36b74fd`, [meow-rs#351](https://github.com/madeye/meow-rs/pull/351))

Redir-host A/AAAA answers previously got a fixed 60 s TTL; they now carry the remaining cache lifetime (cache hits) or the upstream's clamped TTL (fresh lookups), so clients re-resolve on the upstream's schedule.

## 3. In-place engine restart logic removed entirely

The nw_path_monitor (connectivity / interface / address-family triggers), debounced restart scheduler, wake-time health-probe restart, `MWTunnelEngine.restartWithError`, and all generation/grace bookkeeping are deleted. A restart was a guaranteed multi-second DNS blackout while everything the engine dials is per-flow/per-query and self-heals on the current network. Sleep/wake keep only malloc pressure relief; `meow_tun_health_probe` stays in the FFI as a diagnostics primitive. The footprint watchdog is renamed `maybeRelieveFootprintPressure` (it has only done pressure relief for a while).

## Path B attestation (local CI green)

- [x] `swiftformat --lint .` at repo root → 0 violations (0/126 files require formatting)
- [x] `swiftlint --strict --quiet` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests -testLanguage en` → **TEST SUCCEEDED** (also compiles the modified PacketTunnel ObjC)
- [x] Rust/FFI: `scripts/build-rust.sh` → xcframework written; `cargo test` in `core/rust/meow-ios-ffi` → 62 + 2 passed, 0 failed; `cargo fmt -- --check` + `cargo clippy --all-targets -- -D warnings` → clean; `cargo test --locked` in `core/rust/macos-utun-harness` (lockfile regenerated for the new pin) → compiles + passes
- [x] `git diff origin/main...HEAD --stat` verified — 10 files, exactly the NE restart removal + FFI persistence + pin/lockfile updates, no accidental additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)