### PR TITLE
feat(ne): graceful engine reload — hot config reload with in-place restart fallback

### DIFF
--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -68,6 +68,15 @@ final class AppModel {
                 await self?.replaySelectedProxies()
             }
         }
+        // In-place engine restarts and hot config reloads (the `reload`
+        // intent) never transition NEVPNStatus, so `onConnected` doesn't fire —
+        // but the rebuilt engine still resets proxy-group selections to YAML
+        // defaults. Replay on the signals the extension sends for both paths.
+        ipcBridge.onEngineDidRestart = { [weak self] in
+            Task { @MainActor in
+                await self?.replaySelectedProxies()
+            }
+        }
         try? FileManager.default.createDirectory(at: AppGroup.meowConfigDir, withIntermediateDirectories: true)
         AppGroup.configureBackup()
         GeoAssetStager.stageIfNeeded()

--- a/App/Sources/Services/AppIPCBridge.swift
+++ b/App/Sources/Services/AppIPCBridge.swift
@@ -16,11 +16,20 @@ final class AppIPCBridge {
 
     private var stateObserver: DarwinObserver?
     private var trafficObserver: DarwinObserver?
+    private var reloadedObserver: DarwinObserver?
     private var mockTrafficTask: Task<Void, Never>?
 
     /// Optional hook for long-lived consumers (e.g. the Utility traffic chart)
     /// that must keep sampling while the Traffic screen is off-screen.
     var onTrafficDidUpdate: ((TrafficSnapshot) -> Void)?
+
+    /// Fired when the engine's config state was reset without a NEVPNStatus
+    /// transition — either an in-place engine restart (a new `startedAt`
+    /// generation while the stage stays `.connected`) or a hot config reload
+    /// (the extension's `reloaded` notification). Both rebuild the engine's
+    /// proxy groups, so consumers that re-sync engine state after a start
+    /// (proxy-selection replay) must listen here too.
+    var onEngineDidRestart: (() -> Void)?
 
     func start() {
         if Self.usesMockIPC {
@@ -36,6 +45,9 @@ final class AppIPCBridge {
         trafficObserver = DarwinBridge.addObserver(for: .traffic) { [weak self] in
             Task { @MainActor in self?.reloadTraffic() }
         }
+        reloadedObserver = DarwinBridge.addObserver(for: .reloaded) { [weak self] in
+            Task { @MainActor in self?.onEngineDidRestart?() }
+        }
     }
 
     func stop() {
@@ -43,8 +55,10 @@ final class AppIPCBridge {
         mockTrafficTask = nil
         stateObserver.map { DarwinBridge.removeObserver($0) }
         trafficObserver.map { DarwinBridge.removeObserver($0) }
+        reloadedObserver.map { DarwinBridge.removeObserver($0) }
         stateObserver = nil
         trafficObserver = nil
+        reloadedObserver = nil
     }
 
     /// Post an intent to the extension. The extension reads it on the next
@@ -71,7 +85,14 @@ final class AppIPCBridge {
 
     private func reloadState() {
         if let state = SharedStore.readState() {
+            let previous = currentState
             currentState = state
+            if previous.stage == .connected,
+               state.stage == .connected,
+               state.startedAt != previous.startedAt
+            {
+                onEngineDidRestart?()
+            }
         }
     }
 

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -119,6 +119,10 @@ struct SettingsView: View {
                     Button("Install NE profile") { Task { await vpnManager.refresh() } }
                     Button("Connect (no profile required)") { Task { await vpnManager.connect() } }
                     Button("Disconnect", role: .destructive) { Task { await vpnManager.disconnect() } }
+                    // Hot config reload (mode/rules/proxies swapped in the
+                    // running engine, no flow drop); falls back to an in-place
+                    // restart if the reload fails and the config validates.
+                    Button("Reload engine config") { ipcBridge.send(.reload) }
                     NavigationLink("Open Diagnostics") {
                         DiagnosticsPanelView()
                             .ignoresSafeArea(edges: .bottom)

--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -81,6 +81,17 @@ void meow_engine_stop(void);
 int meow_engine_is_running(void);
 
 /**
+ * Hot-reload mode/rules/proxies from `config_path` into the running engine
+ * without stopping listeners, DNS, or any in-flight flow. Returns 0 on
+ * success, -1 on error (inspect `meow_core_last_error`) — on error the old
+ * configuration keeps running untouched.
+ *
+ * # Safety
+ * `config_path` must point to a NUL-terminated UTF-8 string.
+ */
+int meow_engine_reload(const char *config_path);
+
+/**
  * Validate a Clash YAML config. Returns 0 on success, -1 on error.
  *
  * # Safety

--- a/MeowShared/Sources/MeowIPC/DarwinNotifications.swift
+++ b/MeowShared/Sources/MeowIPC/DarwinNotifications.swift
@@ -8,6 +8,7 @@ public enum MeowNotification: String, Sendable {
     case command = "com.meow.vpn.command"
     case state = "com.meow.vpn.state"
     case traffic = "com.meow.vpn.traffic"
+    case reloaded = "com.meow.vpn.reloaded"
 
     public var cfName: CFNotificationName {
         CFNotificationName(rawValue as CFString)

--- a/PacketTunnel/Sources/MWDarwinBridge.h
+++ b/PacketTunnel/Sources/MWDarwinBridge.h
@@ -5,6 +5,7 @@ typedef NS_ENUM(NSUInteger, MWNotification) {
     MWNotificationCommand,
     MWNotificationState,
     MWNotificationTraffic,
+    MWNotificationReloaded,
 };
 
 @interface MWDarwinObserver : NSObject

--- a/PacketTunnel/Sources/MWDarwinBridge.m
+++ b/PacketTunnel/Sources/MWDarwinBridge.m
@@ -6,6 +6,7 @@ static NSString *nameFor(MWNotification n) {
         case MWNotificationCommand: return @"com.meow.vpn.command";
         case MWNotificationState:   return @"com.meow.vpn.state";
         case MWNotificationTraffic: return @"com.meow.vpn.traffic";
+        case MWNotificationReloaded: return @"com.meow.vpn.reloaded";
     }
 }
 

--- a/PacketTunnel/Sources/MWTunnelEngine.h
+++ b/PacketTunnel/Sources/MWTunnelEngine.h
@@ -10,6 +10,16 @@
 /// Blocking: runs engine + tun2socks start FFI calls. Call on a background queue.
 - (BOOL)startWithError:(NSError **)error;
 
+/// Blocking: restarts engine + tun2socks in-place, keeping the TUN interface,
+/// the packet read loop, and the writer context alive. Call on the engine
+/// control queue.
+- (BOOL)restartWithError:(NSError **)error;
+
+/// Blocking: hot-reloads mode/rules/proxies into the running engine — no flow
+/// drop, no DNS blackout. On failure the old configuration keeps running
+/// untouched. Call on the engine control queue.
+- (BOOL)reloadConfigWithError:(NSError **)error;
+
 /// Stops engine, tun2socks, ingress loop, traffic pump.
 - (void)stop;
 

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -46,7 +46,8 @@ static const int kLocalDNSPort                 = 1053;
     // Bumped on terminal stop. A readPackets completion handler captures the
     // epoch when it arms and drops itself if the epoch advanced in the meantime,
     // so an in-flight handler from a stopped generation cannot ingest stale
-    // packets or re-arm a second concurrent read chain.
+    // packets or re-arm a second concurrent read chain. In-place restarts
+    // intentionally keep this read chain alive (see restartWithError:).
     _Atomic uint64_t _ingressEpoch;
     _Atomic int64_t _ingressPackets;
     dispatch_source_t _trafficTimer;
@@ -157,6 +158,73 @@ static const int kLocalDNSPort                 = 1053;
 
     [self startIngressLoop];
     [self startTrafficPump];
+    return YES;
+}
+
+// MARK: - Restart
+
+- (BOOL)restartWithError:(NSError **)error {
+    if (!_started) {
+        if (error) *error = [NSError errorWithDomain:@"MWTunnelEngine"
+                                                code:3
+                                            userInfo:@{NSLocalizedDescriptionKey: @"engine not started"}];
+        return NO;
+    }
+
+    os_log_info(gLog, "engine: restart entry");
+
+    [self stopTrafficPump];
+    if (_tunStarted) {
+        meow_tun_stop_blocking();
+        _tunStarted = NO;
+    }
+    meow_engine_stop();
+
+    if (![self startRuntimeWithError:error]) {
+        atomic_store_explicit(&_ingressRunning, NO, memory_order_relaxed);
+        atomic_fetch_add_explicit(&_ingressEpoch, 1, memory_order_relaxed);
+        [self releaseWriterContext];
+        _started = NO;
+        return NO;
+    }
+
+    // Do not call startIngressLoop here. The original readPackets chain remains
+    // armed across the in-place restart; arming another read on the same
+    // NEPacketTunnelFlow can violate the one-read-at-a-time contract.
+    [self startTrafficPump];
+    return YES;
+}
+
+// MARK: - Hot reload
+
+- (BOOL)reloadConfigWithError:(NSError **)error {
+    if (!_started) {
+        if (error) *error = [NSError errorWithDomain:@"MWTunnelEngine"
+                                                code:6
+                                            userInfo:@{NSLocalizedDescriptionKey: @"engine not started"}];
+        return NO;
+    }
+
+    os_log_info(gLog, "engine: hot reload entry");
+
+    // Re-patch first so the reload picks up the same prefs (mixed port,
+    // allowLan) a cold start would. Note the engine only applies
+    // mode/rules/proxies from this file — listener/DNS pins stay as bound at
+    // start (see meow_engine_reload docs).
+    MWPreferences *prefs = [MWPreferences loadFromDefaults:[MWAppGroup defaults]];
+    if (![self writeEffectiveConfigWithPrefs:prefs error:error]) {
+        return NO;
+    }
+
+    NSString *configPath = [MWAppGroup effectiveConfigURL].path;
+    int rc = meow_engine_reload(configPath.UTF8String);
+    if (rc != 0) {
+        NSString *msg = [self lastRustError] ?: @"engine reload failed";
+        if (error) *error = [NSError errorWithDomain:@"MWTunnelEngine"
+                                                code:7
+                                            userInfo:@{NSLocalizedDescriptionKey: msg}];
+        return NO;
+    }
     return YES;
 }
 

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -276,17 +276,75 @@ static os_log_t gLog;
     if ([command isEqualToString:@"stop"]) {
         [self cancelTunnelWithError:nil];
     } else if ([command isEqualToString:@"reload"]) {
-        // `reload` is currently a stop-only shim: the extension cancels the
-        // tunnel and the app is expected to re-trigger `start` once it
-        // observes the disconnected stage. M3 will add hot-reload via the
-        // meow REST API and avoid the round-trip.
-        os_log_info(gLog, "reload intent received (stop-only shim; app must restart)");
-        [self cancelTunnelWithError:nil];
+        // Config reload, hot first: reloadConfigWithError swaps
+        // mode/rules/proxies in the running engine — no flow drop, no DNS
+        // blackout. Fall back to an in-place restart only when the hot
+        // reload fails AND the new config validates on its own: restarting
+        // with a broken config would stop the healthy engine and fail to
+        // bring it back up. If the restart also fails, cancel the tunnel —
+        // the on-demand rule / app then recovers via full process recycle.
+        os_log_info(gLog, "reload intent received");
+        MWEngineLog(MWLogInfo, @"NE: reload intent received");
+        dispatch_async(_engineControlQueue, ^{
+            MWTunnelEngine *engine = self->_engine;
+            if (!engine) {
+                os_log_info(gLog, "reload ignored: engine not running");
+                return;
+            }
+            NSError *reloadErr = nil;
+            if ([engine reloadConfigWithError:&reloadErr]) {
+                // Selector groups were rebuilt → the app must replay persisted
+                // proxy selections. Traffic counters and startedAt (the engine
+                // generation marker) are deliberately untouched.
+                [MWDarwinBridge post:MWNotificationReloaded];
+                os_log_info(gLog, "config hot-reload complete");
+                MWEngineLog(MWLogInfo, @"NE: config hot-reload complete");
+                return;
+            }
+            os_log_error(gLog, "hot reload failed: %{public}@",
+                         reloadErr.localizedDescription);
+            MWEngineLogf(MWLogError, @"NE: hot reload failed: %@",
+                         reloadErr.localizedDescription);
+
+            if (![self effectiveConfigValidates]) {
+                // Broken config: keep the old one running. Log-only — the
+                // engine is still healthy on the previous config, so writing
+                // an "error" stage would misrepresent a connected tunnel.
+                return;
+            }
+
+            NSError *restartErr = nil;
+            if ([engine restartWithError:&restartErr]) {
+                // New startedAt generation: traffic counters rebased to zero and
+                // the app replays persisted proxy selections off this edge.
+                [self writeState:@"connected" profileID:nil errorMessage:nil];
+                os_log_info(gLog, "engine restart complete");
+                MWEngineLog(MWLogInfo, @"NE: engine restart complete");
+            } else {
+                os_log_error(gLog, "engine restart failed: %{public}@ — cancelling tunnel",
+                             restartErr.localizedDescription);
+                MWEngineLogf(MWLogError, @"NE: engine restart failed: %@ — cancelling tunnel",
+                             restartErr.localizedDescription);
+                [self writeState:@"error" profileID:nil
+                    errorMessage:restartErr.localizedDescription];
+                [self cancelTunnelWithError:nil];
+            }
+        });
     }
     // "start" while running: no-op
 }
 
 // MARK: - State
+
+- (BOOL)effectiveConfigValidates {
+    NSString *yaml = [NSString stringWithContentsOfURL:[MWAppGroup effectiveConfigURL]
+                                              encoding:NSUTF8StringEncoding
+                                                 error:nil];
+    if (!yaml) return NO;
+    return meow_engine_validate_config(
+               yaml.UTF8String,
+               (int)[yaml lengthOfBytesUsingEncoding:NSUTF8StringEncoding]) == 0;
+}
 
 - (void)writeState:(NSString *)stage
          profileID:(nullable NSString *)profileID

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -17,6 +17,7 @@ use anyhow::{Context, Result};
 use dashmap::DashMap;
 use meow_api::log_stream::{LogBroadcastLayer, LogMessage};
 use meow_api::ApiServer;
+use meow_config::raw::RawConfig;
 use meow_config::{load_config, load_config_from_str, Config};
 use meow_dns::DnsServer;
 use meow_listener::{MixedListener, SnifferRuntime};
@@ -50,6 +51,10 @@ struct EngineState {
     tunnel: Tunnel,
     mixed_dial_addr: Option<SocketAddr>,
     dns_dial_addr: Option<SocketAddr>,
+    /// Shared with the REST `ApiServer` (it receives a clone of this Arc) so
+    /// a hot-reload can refresh what `GET /configs` reports and what a later
+    /// REST `PUT /configs` diffs against.
+    raw_config: Arc<RwLock<RawConfig>>,
     api_task: Option<JoinHandle<()>>,
     listener_tasks: Vec<JoinHandle<()>>,
 }
@@ -244,26 +249,52 @@ pub fn start(config_path: &str) -> Result<()> {
     tunnel.update_rules(cfg.rules);
     tunnel.update_proxies(cfg.proxies);
 
-    // Start the tunnel's background tasks — currently just the UDP NAT
-    // sweeper, which evicts sessions idle > DEFAULT_UDP_IDLE (60 s) every
-    // DEFAULT_SWEEP_INTERVAL (15 s). Without this call the `nat_table` (and
-    // the `reply_readers` set + detached reader tasks the FFI keys off it)
-    // grows monotonically under UDP flow churn: every new 5-tuple inserts an
-    // `Arc<UdpSession>` that is only removed on a reader-task exit that a
-    // quiet session (one-shot DNS, abandoned QUIC, dead upstream) never
+    // Start the tunnel's background tasks — the UDP NAT sweeper, which evicts
+    // sessions idle > DEFAULT_UDP_IDLE (60 s) every DEFAULT_SWEEP_INTERVAL
+    // (15 s), plus the 1 s stats-sampling ticker. Without the sweeper the
+    // `nat_table` (and the `reply_readers` set + detached reader tasks the FFI
+    // keys off it) grows monotonically under UDP flow churn: every new 5-tuple
+    // inserts an `Arc<UdpSession>` that is only removed on a reader-task exit
+    // that a quiet session (one-shot DNS, abandoned QUIC, dead upstream) never
     // reaches. Over hours that slow growth crosses the ~50 MB NE jetsam cap
     // and the PacketTunnel is killed. `meow-app` calls this after building
-    // its tunnel; the FFI must too. Idempotent — invoked once per engine.
+    // its tunnel; the FFI must too.
     //
-    // `start()` runs on the main thread, OUTSIDE the tokio runtime, and
-    // `spawn_background_tasks` uses a bare `tokio::spawn` (unlike the
+    // We do NOT call upstream `Tunnel::spawn_background_tasks`: its stats
+    // ticker holds a STRONG `Arc<Statistics>` and loops forever with no exit
+    // condition, so every engine start→stop cycle would leak one task plus one
+    // retained `Statistics` — unbounded across in-place restarts. Spawn both
+    // tasks ourselves instead: the sweeper is already Weak-gated upstream
+    // (exits when the nat table drops), and our ticker holds a `Weak` and
+    // exits once this generation's `Statistics` is dropped on engine stop.
+    //
+    // `start()` runs on the main thread, OUTSIDE the tokio runtime, and both
+    // spawns use a bare `tokio::spawn` (unlike the
     // `get_engine_runtime().spawn(...)` callsites below, which carry their own
-    // handle). Enter the runtime context for the call so the sweeper task
-    // lands on the meow-engine runtime instead of panicking with "no reactor
-    // running". The guard only needs to outlive the spawn.
+    // handle). Enter the runtime context for the call so the tasks land on the
+    // meow-engine runtime instead of panicking with "no reactor running". The
+    // guard only needs to outlive the spawn.
     {
         let _enter = crate::get_engine_runtime().enter();
-        tunnel.spawn_background_tasks();
+        meow_tunnel::udp::spawn_nat_sweeper(
+            &tunnel.inner().nat_table,
+            meow_tunnel::udp::DEFAULT_UDP_IDLE,
+            meow_tunnel::udp::DEFAULT_SWEEP_INTERVAL,
+        );
+        let weak_stats = Arc::downgrade(tunnel.statistics());
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(1));
+            // Consume tokio's immediate first tick; the first rate bucket is a
+            // real one-second interval, matching upstream's ticker.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let Some(stats) = weak_stats.upgrade() else {
+                    break;
+                };
+                stats.sample_traffic();
+            }
+        });
     }
 
     let stats = tunnel.statistics().clone();
@@ -346,7 +377,7 @@ pub fn start(config_path: &str) -> Result<()> {
             addr,
             cfg.api.secret.clone(),
             config_path.to_string(),
-            raw_config,
+            raw_config.clone(),
             log_tx,
             proxy_providers,
             rule_providers,
@@ -376,9 +407,37 @@ pub fn start(config_path: &str) -> Result<()> {
         tunnel,
         mixed_dial_addr,
         dns_dial_addr,
+        raw_config,
         api_task,
         listener_tasks,
     });
+    Ok(())
+}
+
+/// Hot-reload mode/rules/proxies from `config_path` into the running engine.
+///
+/// Unlike `stop` → `start`, existing flows are NOT closed: in-flight
+/// connection handlers hold `Arc` clones of the old route table and drain
+/// naturally, only new flows see the new table — no DNS blackout, no TUN
+/// disruption. Selector-group state resets (the proxies map is rebuilt), so
+/// the host app must replay persisted selections after a successful reload.
+///
+/// Deliberately NOT reloaded (they are bound once at `start`): listeners,
+/// the DNS server/resolver, fake-IP, and the REST controller itself. Changes
+/// to those still require a stop→start. Proxy/rule *providers* are also
+/// start-time state here; a reload swaps only the inline rules/proxies.
+pub fn reload(config_path: &str) -> Result<()> {
+    // Load + validate BEFORE touching the running engine: on a parse or
+    // semantic error the old config keeps running untouched.
+    let cfg = load_stripped_config(config_path)?;
+
+    let guard = slot().lock();
+    let state = guard.as_ref().context("engine not running")?;
+    state.tunnel.set_mode(cfg.general.mode);
+    state.tunnel.update_proxies(cfg.proxies);
+    state.tunnel.update_rules(cfg.rules);
+    *state.raw_config.write() = cfg.raw;
+    info!("meow-rs engine config hot-reloaded");
     Ok(())
 }
 

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -297,6 +297,29 @@ pub extern "C" fn meow_engine_is_running() -> c_int {
     }
 }
 
+/// Hot-reload mode/rules/proxies from `config_path` into the running engine
+/// without stopping listeners, DNS, or any in-flight flow. Returns 0 on
+/// success, -1 on error (inspect `meow_core_last_error`) — on error the old
+/// configuration keeps running untouched.
+///
+/// # Safety
+/// `config_path` must point to a NUL-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn meow_engine_reload(config_path: *const c_char) -> c_int {
+    let Some(path) = cstr_to_str(config_path) else {
+        set_error("config_path is null or not utf-8".into());
+        return -1;
+    };
+    logging::bridge_log(&format!("meow_engine_reload: {}", path));
+    match engine::reload(path) {
+        Ok(()) => 0,
+        Err(e) => {
+            set_error(format!("engine reload failed: {}", e));
+            -1
+        }
+    }
+}
+
 /// Validate a Clash YAML config. Returns 0 on success, -1 on error.
 ///
 /// # Safety


### PR DESCRIPTION
## Summary

The `reload` IPC intent was a stop-only shim (and in-place restart was removed entirely in 0cee30f). This makes config reload graceful, hot first:

- **FFI (`meow_engine_reload`)**: validates the patched config, then swaps mode/rules/proxies into the running tunnel. In-flight flows keep their Arc'd route table and drain naturally — **no flow drop, no DNS blackout, no TUN disruption**. Listeners/DNS/fake-IP/REST stay as bound at start. The `raw_config` shared with the REST API is refreshed so `GET /configs` stays accurate.
- **Extension**: `reload` intent hot-reloads first; falls back to an in-place restart (`restartWithError:`, restored) only when the reload fails AND the new config validates on its own (restarting with a broken config would kill a healthy engine). Hot success posts `com.meow.vpn.reloaded`; restart success writes a fresh `startedAt` generation. Traffic counters untouched on the hot path.
- **App**: observes the `reloaded` notification (and the `startedAt` edge) to replay persisted proxy selections — both paths rebuild selector groups. DEBUG-only "Reload engine config" button in Settings.
- **Leak fix**: replaces upstream `Tunnel::spawn_background_tasks` (whose stats ticker held a strong `Arc<Statistics>` forever — one leaked task + retained `Statistics` per start→stop cycle) with a directly-spawned Weak-gated NAT sweeper + Weak-gated stats ticker.

## Local CI attestation (AGENTS.md Path B)

- [x] `swiftformat --lint .` at repo root → 0 violations (0/126 files)
- [x] `swiftlint --strict` at repo root → 0 violations (112 files)
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17'` → **MeowTests** (209), **MeowUITests**, **MeowIntegrationTests** all green; `scripts/build-rust.sh` + `cargo test` in `core/rust/meow-ios-ffi/` green (incl. `tun_start_stop_cycles_do_not_leak`)
- [x] `git diff origin/main...HEAD --stat` verified — 12 files, exactly the intended reload/restart change set, no accidental additions

Main baseline: `gh run list --branch main --workflow=ci.yml --limit=1` → green at time of PR.

## Notes

- Hot path only runs on device (simulator uses mock IPC); verified via Release build installed on a physical iPhone 17 Pro.
- Listener/DNS/fake-IP/port changes remain start-time-only (unchanged "takes effect on reconnect" semantics).