### PR TITLE
fix(strings): rename user-facing "Subscription(s)" to "Config(s)"

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 
 
 /* Tab bar */
-"tabs.subscriptions" = "Subscriptions";
+"tabs.subscriptions" = "Configs";
 "tabs.proxyGroups" = "Proxy Groups";
 "tabs.utility" = "Utility";
 "tabs.settings" = "Settings";
@@ -61,22 +61,22 @@
 
 
 /* Subscriptions */
-"subscriptions.nav.title" = "Subscriptions";
-"subscriptions.home.addTitle" = "Add Subscription";
+"subscriptions.nav.title" = "Configs";
+"subscriptions.home.addTitle" = "Add Config";
 "subscriptions.home.addSubtitle" = "Connect a URL or import a local YAML profile.";
 "subscriptions.section.profiles" = "Profiles";
 "subscriptions.section.engine" = "Engine";
-"subscriptions.add.nav.title" = "Add Subscription";
+"subscriptions.add.nav.title" = "Add Config";
 "subscriptions.add.field.name" = "Name";
 "subscriptions.add.field.url" = "URL";
 "subscriptions.add.button.add" = "Add";
 "subscriptions.add.button.adding" = "Adding…";
 "subscriptions.editInfo.swipe" = "Edit Info";
 "subscriptions.refresh.swipe" = "Refresh";
-"subscriptions.editInfo.nav.title" = "Edit Subscription";
+"subscriptions.editInfo.nav.title" = "Edit Config";
 "subscriptions.editInfo.button.save" = "Save";
 "subscriptions.editInfo.footer" = "Changes to the URL take effect on the next refresh.";
-"subscriptions.import.errorTitle" = "Couldn't import subscription";
+"subscriptions.import.errorTitle" = "Couldn't import config";
 "subscriptions.row.updatedAgo %@" = "Updated %@ ago";
 "subscriptions.row.a11y.edit %@" = "Edit YAML for %@";
 "subscriptions.row.a11y.refresh %@" = "Refresh %@";
@@ -93,32 +93,32 @@
 "qrExport.button.share" = "Share";
 "qrExport.empty" = "Nothing to export — this profile has no Shadowsocks servers.";
 "qrExport.error.tooLong" = "This link is too long to fit in a QR code. Use Copy or Share instead.";
-"qrExport.caption.subscription" = "Scan to import this subscription URL into another client.";
+"qrExport.caption.subscription" = "Scan to import this config URL into another client.";
 "qrExport.caption.shadowsocks" = "Scan to import this server into any Shadowsocks-compatible client.";
 "qrExport.a11y.qrImage %@" = "QR code for %@";
-"subscriptions.toolbar.a11y.add" = "Add subscription";
+"subscriptions.toolbar.a11y.add" = "Add config";
 "subscriptions.toolbar.addFromURL" = "Add from URL";
 "subscriptions.toolbar.importFromFile" = "Import from iCloud Drive…";
 "subscriptions.import.invalidEncoding" = "The selected file isn't valid UTF-8 text.";
-"subscriptions.empty.title" = "No subscriptions yet";
-"subscriptions.empty.description" = "Tap + to add a Mihomo or Clash subscription URL.";
+"subscriptions.empty.title" = "No configs yet";
+"subscriptions.empty.description" = "Tap + to add a Mihomo or Clash config URL.";
 "subscriptions.empty.importFile" = "Import File";
 "subscriptions.toolbar.addShadowsocks" = "Add Shadowsocks Server";
 
 
 /* Deep-link import confirmation (meow://connect) */
-"deepLinkImport.nav.title" = "Import Subscription";
+"deepLinkImport.nav.title" = "Import Config";
 "deepLinkImport.section.subscription" = "This link wants to add:";
 "deepLinkImport.field.name" = "Name";
 "deepLinkImport.field.host" = "Host";
 "deepLinkImport.warning.insecure" = "Insecure connection — this profile can be tampered with in transit. Prefer an https:// link if the provider offers one.";
 "deepLinkImport.warning.acknowledge" = "I understand the risk of importing over HTTP";
-"deepLinkImport.notice.duplicate" = "A subscription with this URL is already imported. Continuing will update it in place instead of adding a duplicate.";
+"deepLinkImport.notice.duplicate" = "A config with this URL is already imported. Continuing will update it in place instead of adding a duplicate.";
 "deepLinkImport.button.import" = "Import";
-"deepLinkImport.button.update" = "Update Existing Subscription";
+"deepLinkImport.button.update" = "Update Existing Config";
 "deepLinkImport.button.importAndActivate" = "Import & Activate";
 "a11y.deepLinkImport.cancel" = "Cancel import";
-"deepLinkImport.a11y.url %@" = "Subscription URL: %@";
+"deepLinkImport.a11y.url %@" = "Config URL: %@";
 
 
 /* Add Shadowsocks server sheet */
@@ -371,7 +371,7 @@
 /* Accessibility — Subscriptions */
 "subscriptions.row.a11y.selected" = "Selected";
 "subscriptions.row.a11y.notSelected" = "Not selected";
-"subscriptions.row.a11y.selectHint" = "Activates this subscription";
+"subscriptions.row.a11y.selectHint" = "Activates this config";
 "subscriptions.row.a11y.editHint" = "Opens YAML editor";
 "subscriptions.row.a11y.refreshHint" = "Fetches the latest config from the remote URL";
 

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -16,7 +16,7 @@
 
 
 /* Tab bar */
-"tabs.subscriptions" = "订阅";
+"tabs.subscriptions" = "配置";
 "tabs.proxyGroups" = "代理组";
 "tabs.utility" = "工具";
 "tabs.settings" = "设置";
@@ -67,22 +67,22 @@
 
 
 /* Subscriptions */
-"subscriptions.nav.title" = "订阅";
-"subscriptions.home.addTitle" = "添加订阅";
+"subscriptions.nav.title" = "配置";
+"subscriptions.home.addTitle" = "添加配置";
 "subscriptions.home.addSubtitle" = "连接 URL，或导入本地 YAML 配置。";
-"subscriptions.section.profiles" = "配置";
+"subscriptions.section.profiles" = "配置文件";
 "subscriptions.section.engine" = "引擎";
-"subscriptions.add.nav.title" = "添加订阅";
+"subscriptions.add.nav.title" = "添加配置";
 "subscriptions.add.field.name" = "名称";
 "subscriptions.add.field.url" = "网址";
 "subscriptions.add.button.add" = "添加";
 "subscriptions.add.button.adding" = "添加中…";
 "subscriptions.editInfo.swipe" = "编辑信息";
 "subscriptions.refresh.swipe" = "刷新";
-"subscriptions.editInfo.nav.title" = "编辑订阅";
+"subscriptions.editInfo.nav.title" = "编辑配置";
 "subscriptions.editInfo.button.save" = "保存";
 "subscriptions.editInfo.footer" = "网址的更改将在下次刷新时生效。";
-"subscriptions.import.errorTitle" = "导入订阅失败";
+"subscriptions.import.errorTitle" = "导入配置失败";
 "subscriptions.row.updatedAgo %@" = "%@前更新";
 "subscriptions.row.a11y.edit %@" = "编辑 %@ 的 YAML";
 "subscriptions.row.a11y.refresh %@" = "刷新 %@";
@@ -99,32 +99,32 @@
 "qrExport.button.share" = "分享";
 "qrExport.empty" = "没有可导出的内容 — 此配置不包含 Shadowsocks 服务器。";
 "qrExport.error.tooLong" = "链接过长，无法生成二维码。请使用复制或分享。";
-"qrExport.caption.subscription" = "扫描即可将此订阅地址导入其他客户端。";
+"qrExport.caption.subscription" = "扫描即可将此配置地址导入其他客户端。";
 "qrExport.caption.shadowsocks" = "扫描即可将此服务器导入任意兼容 Shadowsocks 的客户端。";
 "qrExport.a11y.qrImage %@" = "%@ 的二维码";
-"subscriptions.toolbar.a11y.add" = "添加订阅";
+"subscriptions.toolbar.a11y.add" = "添加配置";
 "subscriptions.toolbar.addFromURL" = "从 URL 添加";
 "subscriptions.toolbar.importFromFile" = "从 iCloud 云盘导入…";
 "subscriptions.import.invalidEncoding" = "所选文件不是有效的 UTF-8 文本。";
-"subscriptions.empty.title" = "暂无订阅";
-"subscriptions.empty.description" = "点击右上角的 + 添加 Mihomo 或 Clash 订阅链接。";
+"subscriptions.empty.title" = "暂无配置";
+"subscriptions.empty.description" = "点击右上角的 + 添加 Mihomo 或 Clash 配置链接。";
 "subscriptions.empty.importFile" = "导入文件";
 "subscriptions.toolbar.addShadowsocks" = "添加 Shadowsocks 服务器";
 
 
 /* Deep-link import confirmation (meow://connect) */
-"deepLinkImport.nav.title" = "导入订阅";
+"deepLinkImport.nav.title" = "导入配置";
 "deepLinkImport.section.subscription" = "此链接想要添加：";
 "deepLinkImport.field.name" = "名称";
 "deepLinkImport.field.host" = "主机";
 "deepLinkImport.warning.insecure" = "不安全的连接 — 此配置在传输过程中可能被篡改。如果服务商提供 https:// 链接，请优先使用。";
 "deepLinkImport.warning.acknowledge" = "我了解通过 HTTP 导入的风险";
-"deepLinkImport.notice.duplicate" = "已导入过此网址对应的订阅。继续操作将就地更新它，而不会新增重复项。";
+"deepLinkImport.notice.duplicate" = "已导入过此网址对应的配置。继续操作将就地更新它，而不会新增重复项。";
 "deepLinkImport.button.import" = "导入";
-"deepLinkImport.button.update" = "更新现有订阅";
+"deepLinkImport.button.update" = "更新现有配置";
 "deepLinkImport.button.importAndActivate" = "导入并激活";
 "a11y.deepLinkImport.cancel" = "取消导入";
-"deepLinkImport.a11y.url %@" = "订阅网址：%@";
+"deepLinkImport.a11y.url %@" = "配置网址：%@";
 
 
 /* Add Shadowsocks server sheet */
@@ -377,7 +377,7 @@
 /* Accessibility — Subscriptions */
 "subscriptions.row.a11y.selected" = "已选中";
 "subscriptions.row.a11y.notSelected" = "未选中";
-"subscriptions.row.a11y.selectHint" = "激活此订阅";
+"subscriptions.row.a11y.selectHint" = "激活此配置";
 "subscriptions.row.a11y.editHint" = "打开 YAML 编辑器";
 "subscriptions.row.a11y.refreshHint" = "从远程地址获取最新配置";
 

--- a/MeowUITests/Flows/ExportQRFlowTests.swift
+++ b/MeowUITests/Flows/ExportQRFlowTests.swift
@@ -15,7 +15,7 @@ final class ExportQRFlowTests: XCTestCase {
         app.launchArguments += ["-UITests", "-ResetState", "-SeedShadowsocksProfile", "My Servers"]
         app.launch()
 
-        app.tabBars.buttons["Subscriptions"].tap()
+        app.tabBars.buttons["Configs"].tap()
         XCTAssertTrue(app.staticTexts["My Servers"].waitForExistence(timeout: 5))
 
         // The generated profile row offers QR export.

--- a/MeowUITests/Flows/RenameSubscriptionFlowTests.swift
+++ b/MeowUITests/Flows/RenameSubscriptionFlowTests.swift
@@ -13,7 +13,7 @@ final class RenameSubscriptionFlowTests: XCTestCase {
         app.launchArguments += ["-UITests", "-ResetState", "-SeedProfile", "My Servers"]
         app.launch()
 
-        app.tabBars.buttons["Subscriptions"].tap()
+        app.tabBars.buttons["Configs"].tap()
         XCTAssertTrue(app.staticTexts["My Servers"].waitForExistence(timeout: 5))
 
         // The always-visible edit-info button opens the rename sheet.

--- a/MeowUITests/Screens/AppShellTests.swift
+++ b/MeowUITests/Screens/AppShellTests.swift
@@ -25,7 +25,7 @@ final class AppShellTests: XCTestCase {
         let meow = MeowApp()
         meow.launch()
 
-        XCTAssertTrue(meow.app.navigationBars["Subscriptions"].waitForExistence(timeout: 5))
+        XCTAssertTrue(meow.app.navigationBars["Configs"].waitForExistence(timeout: 5))
         XCTAssertFalse(meow.app.tabBars.buttons["Home"].exists)
     }
 
@@ -38,7 +38,7 @@ final class AppShellTests: XCTestCase {
         XCTAssertTrue(meow.app.buttons["subscriptions.empty.importFromFile"].exists)
 
         addFromURL.tap()
-        XCTAssertTrue(meow.app.navigationBars["Add Subscription"].waitForExistence(timeout: 5))
+        XCTAssertTrue(meow.app.navigationBars["Add Config"].waitForExistence(timeout: 5))
     }
 
     func testProxyGroupsIsTopLevelTab() {

--- a/MeowUITests/Support/MeowApp.swift
+++ b/MeowUITests/Support/MeowApp.swift
@@ -22,7 +22,7 @@ struct MeowApp {
 
     /// Tab navigation
     var subscriptionsTab: XCUIElement {
-        app.tabBars.buttons["Subscriptions"]
+        app.tabBars.buttons["Configs"]
     }
 
     var proxyGroupsTab: XCUIElement {


### PR DESCRIPTION
## Why

App Review flagged v1.4.0 under **Guideline 2.1(b)** suspecting the app accesses paid digital content — the "Subscriptions" wording in the UI reads like a paid subscription service. It actually refers to remote config URLs (Mihomo/Clash convention). Renaming the user-visible strings to "Configs" removes the trigger.

## What

Display values only — localization keys, type names (`SubscriptionService` etc.), and accessibility identifiers are unchanged:

- **en**: "Subscriptions" → "Configs", "Add/Edit/Import Subscription" → "… Config", empty state, QR-export caption, deep-link import sheet, a11y hints (15 strings).
- **zh-Hans**: 订阅 → 配置 in the same strings; `subscriptions.section.profiles` 配置 → 配置文件 to avoid duplicating the tab's new name.
- **MeowUITests**: the five matchers on the visible "Subscriptions" / "Add Subscription" labels now expect "Configs" / "Add Config".

## Path B local-CI attestation

- [x] `swiftformat --lint .` at repo root → 0 violations
- [x] `swiftlint --strict` at repo root → 0 violations
- [x] `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowUITests -testLanguage en` → **TEST SUCCEEDED** (MeowTests: 209 tests / 36 suites passed; MeowUITests: 34 executed, 0 failures)
- [x] `git diff origin/main...HEAD --stat` verified → exactly the 6 intended files (2× Localizable.strings, 4× MeowUITests), no accidental additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)