### PR TITLE
fix(dns): after-hours DNS blackout — loud listener death, lifecycle hardening, probe-gated wake recovery

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.h
+++ b/PacketTunnel/Sources/MWTunnelEngine.h
@@ -23,6 +23,14 @@
 /// Stops engine, tun2socks, ingress loop, traffic pump.
 - (void)stop;
 
+/// Blocking end-to-end data-path probe: injects a synthetic in-TUN DNS query
+/// and waits (≤ timeoutMs) for its reply to traverse the full ingress → lwip
+/// → meow-dns → egress pipeline. YES = the path is demonstrably live; NO =
+/// wedged, not started, or timed out — restart-worthy. Call on the engine
+/// control queue, never on a runtime callback thread; callers must serialize
+/// probes.
+- (BOOL)isDataPathHealthyWithTimeoutMs:(int32_t)timeoutMs;
+
 @property (nonatomic, readonly) BOOL isEngineRunning;
 @property (nonatomic, readonly) BOOL tunStarted;
 

--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -1,4 +1,5 @@
 #import "MWTunnelEngine.h"
+#import "MWTunnelSettings.h"
 #import "MWAppGroup.h"
 #import "MWPreferences.h"
 #import "MWPacketWriter.h"
@@ -250,6 +251,21 @@ static const int kLocalDNSPort                 = 1053;
     meow_engine_stop();
 
     [self releaseWriterContext];
+}
+
+// MARK: - Data-path health
+
+- (BOOL)isDataPathHealthyWithTimeoutMs:(int32_t)timeoutMs {
+    // Probe addresses must match NEPacketTunnelNetworkSettings: the forged
+    // query is src=<tun address>:53535 → dst=<advertised DNS server>:53, the
+    // exact shape of a real mDNSResponder query arriving on the TUN. In
+    // fake-IP mode the answer is synthesised locally, so a healthy verdict
+    // never depends on upstream reachability — safe right after a wake while
+    // the physical interface is still reassociating.
+    int rc = meow_tun_health_probe(MWTunnelClientIPv4Address.UTF8String,
+                                   MWTunnelDNSServerIPv4Address.UTF8String,
+                                   timeoutMs);
+    return rc == 0;
 }
 
 // MARK: - Engine state

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -144,13 +144,51 @@ static os_log_t gLog;
 }
 
 - (void)wake {
-    // No restart, no probe: the engine runs uninterrupted across sleep/wake.
-    // In-place engine restarts (wake-health, path-change, address-family) were
-    // removed — a restart was a guaranteed multi-second DNS blackout, while
-    // everything the engine dials is per-flow/per-query and self-heals on the
-    // current network.
-    os_log_info(gLog, "wake: tun remained active");
-    MWEngineLog(MWLogInfo, @"NE: wake — tun remained active");
+    // Probe-gated recovery, not a blind restart. Blind wake restarts were a
+    // guaranteed multi-second DNS blackout and were removed in 0cee30f; but
+    // their removal left the known in-process wedge class (lwIP data-path
+    // freeze across background sleep/wake: process alive, VPN icon on, only
+    // packets stop) with NO recovery at all in Release builds — the
+    // "DNS stops working after hours in background" phenotype. The probe is
+    // an end-to-end synthetic DNS query through the real packet pipeline; a
+    // healthy path returns in milliseconds and nothing is restarted. Only a
+    // twice-confirmed wedged path pays the restart blackout, which is strictly
+    // better than staying dead until the user toggles the VPN.
+    os_log_info(gLog, "wake: probing data path");
+    dispatch_async(_engineControlQueue, ^{
+        MWTunnelEngine *engine = self->_engine;
+        if (!engine || !engine.tunStarted) {
+            os_log_info(gLog, "wake: engine not running — nothing to probe");
+            return;
+        }
+        if ([engine isDataPathHealthyWithTimeoutMs:2000]) {
+            MWEngineLog(MWLogInfo, @"NE: wake — data path healthy");
+            return;
+        }
+        // Confirm before restarting: a post-wake ingress replay burst can
+        // drop probe frames (ingest is drop-on-full), so one failed probe is
+        // not yet evidence of a wedge.
+        if ([engine isDataPathHealthyWithTimeoutMs:2000]) {
+            MWEngineLog(MWLogInfo, @"NE: wake — data path healthy on second probe");
+            return;
+        }
+        os_log_error(gLog, "wake: data path wedged — in-place engine restart");
+        MWEngineLog(MWLogError, @"NE: wake — data path wedged; in-place engine restart");
+        NSError *err = nil;
+        if ([engine restartWithError:&err]) {
+            // New startedAt generation: the app replays persisted proxy
+            // selections off this edge, same as the reload-intent restart.
+            [self writeState:@"connected" profileID:nil errorMessage:nil];
+            MWEngineLog(MWLogInfo, @"NE: wake-health restart complete");
+        } else {
+            os_log_error(gLog, "wake-health restart failed: %{public}@",
+                         err.localizedDescription);
+            MWEngineLogf(MWLogError, @"NE: wake-health restart failed: %@ — cancelling tunnel",
+                         err.localizedDescription);
+            [self writeState:@"error" profileID:nil errorMessage:err.localizedDescription];
+            [self cancelTunnelWithError:nil];
+        }
+    });
 }
 
 // MARK: - App messages

--- a/PacketTunnel/Sources/PacketTunnelProvider.m
+++ b/PacketTunnel/Sources/PacketTunnelProvider.m
@@ -76,6 +76,21 @@ static os_log_t gLog;
             __strong __typeof__(weak) self = weak;
             if (!self) { completionHandler(nil); return; }
 
+            // Duplicate-start guard: a second startTunnel on a live process must
+            // not allocate a second engine generation. Without this, the second
+            // generation's meow_tun_start fails ("already running") and its
+            // error path calls meow_engine_stop() — tearing down the engine the
+            // FIRST generation is still serving. The old tun keeps running with
+            // no engine behind it: every DNS query and new TCP flow is silently
+            // dropped while the VPN icon stays on.
+            if (self->_engine) {
+                os_log_info(gLog, "startTunnel: engine already running — duplicate start ignored");
+                MWEngineLog(MWLogInfo, @"NE: duplicate startTunnel ignored — engine already running");
+                [self writeState:@"connected" profileID:profileID errorMessage:nil];
+                completionHandler(nil);
+                return;
+            }
+
             MWTunnelEngine *engine = [[MWTunnelEngine alloc] initWithPacketFlow:self.packetFlow];
             NSError *startErr = nil;
             if (![engine startWithError:&startErr]) {

--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -924,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "axum",
  "base64",
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "base64",
  "libc",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2141,12 +2141,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2264,7 +2264,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3303,7 +3303,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4046,7 +4046,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -876,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "axum",
  "base64",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "base64",
  "libc",
@@ -1988,7 +1988,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2080,12 +2080,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+source = "git+https://github.com/madeye/meow-rs?rev=bd132e069baf06a338ca91e08f5e9a3412f71828#bd132e069baf06a338ca91e08f5e9a3412f71828"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2191,7 +2191,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2493,7 +2493,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2742,7 +2742,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3221,7 +3221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3963,7 +3963,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,7 +68,11 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 74e8083a (meow-rs 0.18.0) — picks up the rule-IR compilation series
+# HEAD: bd132e06 = 74e8083a + the DnsServer lifecycle fix
+# (meow-rs#362: eager bind() so EADDRINUSE surfaces at engine start,
+# Weak<UdpSocket> workers so an aborted serve loop releases port 1053
+# immediately, panic-guarded workers). Branched off the previous pin
+# 74e8083a so nothing else changes. 74e8083a picks up the rule-IR series
 # (meow-rs#285/#291/#295–#297), lazy metadata enrichment (#292), the VMess
 # AEAD wire-format interop fix (#320), VLESS/Snell UDP-over-TCP read/write
 # fairness (#319), relay-direction fairness per buffer cycle (#347), atomic
@@ -80,7 +84,7 @@ lwip = "0.3"
 # issue #255). meow-dns runs in fake-ip mode: the FFI config parser pins
 # `enhanced-mode: fake-ip` with `fake-ip-range: 28.0.0.0/8` (the 2026-07-17
 # redir-host/DoT switch was reverted in PR #321).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "bd132e069baf06a338ca91e08f5e9a3412f71828" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -88,12 +92,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "bd132e069baf06a338ca91e08f5e9a3412f71828", features = ["boring-tls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "bd132e069baf06a338ca91e08f5e9a3412f71828" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "bd132e069baf06a338ca91e08f5e9a3412f71828" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "bd132e069baf06a338ca91e08f5e9a3412f71828", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "bd132e069baf06a338ca91e08f5e9a3412f71828" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "bd132e069baf06a338ca91e08f5e9a3412f71828" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -319,10 +319,31 @@ pub fn start(config_path: &str) -> Result<()> {
     let mixed_dial_addr = cfg.listeners.mixed_port.map(loopback_addr);
     let dns_dial_addr = cfg.dns.listen_addr.map(|addr| loopback_addr(addr.port()));
 
+    // Resolve every fallible listener input BEFORE spawning anything, so an
+    // error `?`-return can't leak an already-spawned listener task (a leaked
+    // DNS task would keep port 1053 bound and fail the next start()).
+    let named_listener_addrs: Vec<SocketAddr> = cfg
+        .listeners
+        .named
+        .iter()
+        .map(|nl| {
+            bind_socket_addr(&nl.listen, nl.port).with_context(|| format!("listener '{}'", nl.name))
+        })
+        .collect::<Result<_>>()?;
+
     if let Some(listen_addr) = cfg.dns.listen_addr {
+        // Bind eagerly and propagate failure: `dns_dial_addr` above is only a
+        // promise that tun2socks can dial the DNS listener, and before this
+        // split a bind failure inside the spawned `run()` was log-only — the
+        // engine reported healthy while every DNS query timed out into an
+        // unbound loopback port. A DNS-less engine is not a working engine;
+        // fail start() instead.
         let dns_server = DnsServer::new(resolver.clone(), listen_addr);
+        let bound = crate::get_engine_runtime()
+            .block_on(dns_server.bind())
+            .with_context(|| format!("binding DNS listener on {listen_addr}"))?;
         listener_tasks.push(crate::get_engine_runtime().spawn(async move {
-            if let Err(e) = dns_server.run().await {
+            if let Err(e) = bound.run().await {
                 error!("DNS server error: {}", e);
             }
         }));
@@ -330,9 +351,7 @@ pub fn start(config_path: &str) -> Result<()> {
 
     let sniffer_runtime = Arc::new(SnifferRuntime::new(cfg.sniffer.clone()));
     let auth = cfg.auth.clone();
-    for nl in &cfg.listeners.named {
-        let addr = bind_socket_addr(&nl.listen, nl.port)
-            .with_context(|| format!("listener '{}'", nl.name))?;
+    for (nl, addr) in cfg.listeners.named.iter().zip(named_listener_addrs) {
         match nl.listener_type {
             meow_config::ListenerType::Mixed
             | meow_config::ListenerType::Http

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -328,6 +328,12 @@ static STACK_INGRESS_DROP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
 
 static UDP_CAP_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
 
+// Throttle slot for loopback-socket failures on the DNS dispatch path. A
+// fresh ephemeral UDP socket is bound per query; bind/send errors there were
+// silently swallowed (`.ok()?`), which made fd exhaustion present as exactly
+// the "DNS dead, TCP alive, no logs" phenotype. Throttled via warn_capped.
+static DNS_LOOPBACK_ERR_LOG_LAST_MS: AtomicU64 = AtomicU64::new(0);
+
 // Throttle slot for the UDP reply-writer-backpressure drop log. When the
 // shared `udp_reply_tx` channel is momentarily full the reply reader drops the
 // datagram (UDP is lossy) and keeps the session alive; without a log this
@@ -1753,8 +1759,23 @@ async fn query_dns_listener(query: &[u8], dns_addr: SocketAddr) -> Option<Vec<u8
             SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], 0))
         }
     };
-    let socket = UdpSocket::bind(bind_addr).await.ok()?;
-    socket.send_to(query, dns_addr).await.ok()?;
+    let socket = match UdpSocket::bind(bind_addr).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn_capped(
+                &DNS_LOOPBACK_ERR_LOG_LAST_MS,
+                &format!("tun2socks: DNS loopback socket bind failed (fd exhaustion?): {e}"),
+            );
+            return None;
+        }
+    };
+    if let Err(e) = socket.send_to(query, dns_addr).await {
+        warn_capped(
+            &DNS_LOOPBACK_ERR_LOG_LAST_MS,
+            &format!("tun2socks: DNS loopback send to {dns_addr} failed: {e}"),
+        );
+        return None;
+    }
     let mut buf = [0u8; 4096];
     let recv = tokio::time::timeout(DNS_TASK_TIMEOUT, socket.recv_from(&mut buf)).await;
     let (n, _from) = recv.ok()?.ok()?;


### PR DESCRIPTION
## Root cause

Since 0cee30f removed all in-place restart logic (and 2a4afcc restored fake-ip the same day, voiding its redir-host persistence rationale), Release builds had **no recovery path at all** for a wedged data path — the reload intent is DEBUG-only and wake was a no-op. Any in-process wedge (the recurring lwIP background-freeze phenotype) presented as "DNS stops working after hours in background" with the VPN icon on, permanently, until a manual VPN toggle. Full diagnosis in the session notes; fake-ip table/TTL/cache logic audited sound.

## Changes

**Commit 1 — hardening (`ff15a2d`):**
- Pin bump 74e8083a → bd132e06 (madeye/meow-rs#362): `DnsServer::bind()` split so bind errors surface eagerly; workers hold `Weak<UdpSocket>` (abort provably releases port 1053, no stop→start EADDRINUSE window); panic-guarded workers (a panicking query no longer permanently blackholes 1/4 of DNS).
- engine.rs: eager DNS bind, `start()` fails on bind error instead of silently running DNS-less; fallible listener-addr parsing moved before any spawn.
- tun2socks.rs: per-query loopback socket bind/send errors logged (fd exhaustion was invisible).
- PacketTunnelProvider.m: duplicate-`startTunnel` guard (second start's error path was `meow_engine_stop()`-ing the live generation).

**Commit 2 — probe-gated wake recovery (`b899f33`):**
- `wake` runs `meow_tun_health_probe` on the engine control queue; healthy path = no-op in milliseconds; only a twice-confirmed wedged path pays an in-place restart; failed restart cancels the tunnel. No path monitor / blind restarts return.

## Local CI attestation (Path B)

1. `swiftformat --lint .` → 0/126 files require formatting ✅
2. `swiftlint --strict` → 0 violations ✅
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests -testLanguage en` → 209 tests / 36 suites, TEST SUCCEEDED ✅
4. Rust: `cargo test` in meow-ios-ffi (59+2 green), `cargo test --locked` in macos-utun-harness (lockfile regenerated), `scripts/build-rust.sh` ✅; upstream `cargo test -p meow-dns` green incl. 2 new regression tests
5. `git diff origin/main...HEAD --stat` verified — 8 files, exactly the intended changes ✅

Depends on madeye/meow-rs#362 (pin references its branch SHA directly, so this builds regardless of merge order).

Ad Hoc Release build from this branch side-loaded on-device 2026-07-27 for the overnight background soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)