### PR TITLE
Remove TCP teardown-burst proactive reclaim logic

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -13,21 +13,7 @@
 
 static os_log_t gLog;
 
-// Proactive-reclaim trigger for a TCP teardown burst. When a batch of flows
-// closes together — network handoff (Wi-Fi↔cellular), reconnect, or the app
-// dropping a page full of connections — their relay buffers (owned by meow's
-// `copy_bidirectional_buf`) free at once. That is the peak-fragmentation
-// moment: lots of just-freed pages the allocator is still holding. Returning
-// them now, rather than waiting for the next periodic relief, keeps the
-// footprint low while the extension is awake. We trigger off a drop in
-// `tcp_conns` (a clean integer count) rather than malloc's free-heap figure,
-// which includes non-resident reserved address space and reads larger than the
-// physical footprint itself (~21 MB free at a 12 MB footprint), so it can't
-// gate a reclaim. The short cooldown keeps normal open/close churn from
-// thrashing the allocator.
-static const int64_t kTeardownBurstFlows       = 16;
-static const NSTimeInterval kTeardownCooldownS = 5.0;
-static const int kLocalDNSPort                 = 1053;
+static const int kLocalDNSPort = 1053;
 
 @implementation MWTunnelEngine {
     NEPacketTunnelFlow *_flow;
@@ -48,8 +34,6 @@ static const int kLocalDNSPort                 = 1053;
     int64_t _lastDown;
     NSTimeInterval _lastTime;
     int _pumpTick;
-    int64_t _lastTcpConns;              // prev snapshot's tcp_conns, for teardown-burst detection
-    NSTimeInterval _lastTeardownRelief; // CFAbsoluteTime; 0 = never
 }
 
 + (void)initialize {
@@ -365,21 +349,6 @@ static const int kLocalDNSPort                 = 1053;
     if (_pumpTick % 10 == 0) {
         malloc_zone_pressure_relief(NULL, 0);
     }
-
-    // Proactive reclaim on a TCP teardown burst (see kTeardownBurstFlows). A
-    // sharp drop in live connections means a batch of relay buffers just
-    // freed; return those pages immediately rather than waiting for the next
-    // periodic relief. The cooldown bounds this to at most one extra relief
-    // per kTeardownCooldownS so steady churn can't thrash the allocator.
-    if (_lastTcpConns - tcpConns >= kTeardownBurstFlows &&
-        (now - _lastTeardownRelief) >= kTeardownCooldownS) {
-        os_log_info(gLog,
-                    "teardown burst: tcp_conns %lld→%lld, returning free pages",
-                    _lastTcpConns, tcpConns);
-        malloc_zone_pressure_relief(NULL, 0);
-        _lastTeardownRelief = now;
-    }
-    _lastTcpConns = tcpConns;
 
     NSTimeInterval epoch = now + NSTimeIntervalSince1970;
     NSDictionary *snapshot = @{


### PR DESCRIPTION
## Summary

Removes the burst teardown logic from `MWTunnelEngine.m`'s traffic pump:

- The `kTeardownBurstFlows` (16) and `kTeardownCooldownS` (5.0 s) constants and their rationale comment block.
- The `_lastTcpConns` / `_lastTeardownRelief` ivars used for detection state.
- The conditional `malloc_zone_pressure_relief` call in `emitTrafficSnapshot` that fired when `tcp_conns` dropped by ≥16 between snapshots.

The periodic pressure relief (every 10 pump ticks) is untouched, and `tcp_conns` is still sampled for the memstats line and traffic snapshot. The logic was fully self-contained in this file — no other code or tests reference it.

## Testing

This change was made in a Linux environment without Xcode, so `xcodebuild test` / `swiftlint` could not run locally (the diff is Objective-C only; no Swift, Rust, or YAML touched). Please rely on the remote CI run for build/test verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtNvVbDmWWGMmSCyTmaaEy

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtNvVbDmWWGMmSCyTmaaEy)_