### PR TITLE
Remove TCP teardown-burst proactive reclaim logic

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -13,21 +13,7 @@
 
 static os_log_t gLog;
 
-// Proactive-reclaim trigger for a TCP teardown burst. When a batch of flows
-// closes together — network handoff (Wi-Fi↔cellular), reconnect, or the app
-// dropping a page full of connections — their relay buffers (owned by meow's
-// `copy_bidirectional_buf`) free at once. That is the peak-fragmentation
-// moment: lots of just-freed pages the allocator is still holding. Returning
-// them now, rather than waiting for the next periodic relief, keeps the
-// footprint low while the extension is awake. We trigger off a drop in
-// `tcp_conns` (a clean integer count) rather than malloc's free-heap figure,
-// which includes non-resident reserved address space and reads larger than the
-// physical footprint itself (~21 MB free at a 12 MB footprint), so it can't
-// gate a reclaim. The short cooldown keeps normal open/close churn from
-// thrashing the allocator.
-static const int64_t kTeardownBurstFlows       = 16;
-static const NSTimeInterval kTeardownCooldownS = 5.0;
-static const int kLocalDNSPort                 = 1053;
+static const int kLocalDNSPort = 1053;
 
 @implementation MWTunnelEngine {
     NEPacketTunnelFlow *_flow;
@@ -48,8 +34,6 @@ static const int kLocalDNSPort                 = 1053;
     int64_t _lastDown;
     NSTimeInterval _lastTime;
     int _pumpTick;
-    int64_t _lastTcpConns;              // prev snapshot's tcp_conns, for teardown-burst detection
-    NSTimeInterval _lastTeardownRelief; // CFAbsoluteTime; 0 = never
 }
 
 + (void)initialize {
@@ -365,21 +349,6 @@ static const int kLocalDNSPort                 = 1053;
     if (_pumpTick % 10 == 0) {
         malloc_zone_pressure_relief(NULL, 0);
     }
-
-    // Proactive reclaim on a TCP teardown burst (see kTeardownBurstFlows). A
-    // sharp drop in live connections means a batch of relay buffers just
-    // freed; return those pages immediately rather than waiting for the next
-    // periodic relief. The cooldown bounds this to at most one extra relief
-    // per kTeardownCooldownS so steady churn can't thrash the allocator.
-    if (_lastTcpConns - tcpConns >= kTeardownBurstFlows &&
-        (now - _lastTeardownRelief) >= kTeardownCooldownS) {
-        os_log_info(gLog,
-                    "teardown burst: tcp_conns %lld→%lld, returning free pages",
-                    _lastTcpConns, tcpConns);
-        malloc_zone_pressure_relief(NULL, 0);
-        _lastTeardownRelief = now;
-    }
-    _lastTcpConns = tcpConns;
 
     NSTimeInterval epoch = now + NSTimeIntervalSince1970;
     NSDictionary *snapshot = @{


### PR DESCRIPTION
## Summary

Removes the teardown-burst detection from `MWTunnelEngine.m`'s traffic pump (added in PR #211):

- The `kTeardownBurstFlows` (16) and `kTeardownCooldownS` (5.0 s) constants and their rationale comment block.
- The `_lastTcpConns` / `_lastTeardownRelief` ivars used for detection state.
- The conditional `malloc_zone_pressure_relief` call in the snapshot path that fired when `tcp_conns` dropped by ≥16 between samples.

The periodic pressure relief (every 10 pump ticks) is untouched, and `tcp_conns` is still sampled for the traffic snapshot. No other references to the removed symbols exist in code or docs.

Supersedes #345 (same diff from a cloud session, closed because it couldn't carry local-CI attestation). Reuses its commit, rebased base verified against current `origin/main`.

## Local CI attestation (Path B)

1. ✅ `swiftformat --lint .` at repo root → 0 files require formatting (126 checked).
2. ✅ `swiftlint --strict --quiet` at repo root → 0 violations.
3. ✅ `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → ** TEST SUCCEEDED ** (service-layer diff → MeowTests + MeowIntegrationTests). No Rust/FFI changes, so `scripts/build-rust.sh` / `cargo test` not required.
4. ✅ `git diff origin/main...HEAD --stat` → exactly `PacketTunnel/Sources/MWTunnelEngine.m | 33 +-` (1 insertion, 32 deletions), no accidental additions. Main CI baseline green (run 30411928115).