### PR TITLE
Remove the periodic pressure relief from the traffic pump

### DIFF
--- a/PacketTunnel/Sources/MWTunnelEngine.m
+++ b/PacketTunnel/Sources/MWTunnelEngine.m
@@ -346,9 +346,6 @@ static const int kLocalDNSPort = 1053;
     [memline writeToURL:statsURL atomically:NO encoding:NSUTF8StringEncoding error:nil];
 
     _pumpTick++;
-    if (_pumpTick % 10 == 0) {
-        malloc_zone_pressure_relief(NULL, 0);
-    }
 
     NSTimeInterval epoch = now + NSTimeIntervalSince1970;
     NSDictionary *snapshot = @{


### PR DESCRIPTION
## Summary

Removes the every-10-tick `malloc_zone_pressure_relief` from `MWTunnelEngine.m`'s `emitTrafficSnapshot`, following the teardown-burst relief removal (#347) and the broader retirement of self-imposed memory management (#344 and prior).

- `_pumpTick` stays: the memstats line and the traffic snapshot still report it.
- The sleep-handler relief in `PacketTunnelProvider.m` is deliberately kept — returning free pages right before device sleep is about surviving suspended-state jetsam, not steady-state footprint tuning.
- `malloc_zone_statistics` heap sampling for memstats is untouched.

## Local CI attestation (Path B)

1. ✅ `swiftformat --lint .` at repo root → 0 files require formatting (126 checked).
2. ✅ `swiftlint --strict --quiet` at repo root → 0 violations.
3. ✅ `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -only-testing:MeowIntegrationTests` → ** TEST SUCCEEDED ** (service-layer diff → MeowTests + MeowIntegrationTests). No Rust/FFI changes, so `scripts/build-rust.sh` / `cargo test` not required.
4. ✅ `git diff origin/main...HEAD --stat` → exactly `PacketTunnel/Sources/MWTunnelEngine.m` (3 deletions), no accidental additions. Main CI baseline green.