### PR TITLE
feat(config): respect user dns block, pin only fake-ip keys

### DIFF
--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -182,7 +182,7 @@ int meow_proxy_select(const char *group, const char *name);
 /**
  * Patch a Clash YAML config for iOS: strips `subscriptions`; keeps the
  * user's `dns` block but pins the fake-ip keys the tunnel requires on top
- * (injecting default nameservers only when the config declares none);
+ * (user nameservers stay first, the built-in defaults are always appended);
  * pins `mixed-port`, `allow-lan`, listener bind address, and DNS listen
  * socket; declares a `GLOBAL` selector headed by the config's primary
  * outbound (so `mode: global` proxies rather than black-holes); injects a

--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -180,7 +180,9 @@ int meow_engine_test_dns(const char *host, int timeout_ms, char *out, int out_ca
 int meow_proxy_select(const char *group, const char *name);
 
 /**
- * Patch a Clash YAML config for iOS: strips `dns` and `subscriptions`;
+ * Patch a Clash YAML config for iOS: strips `subscriptions`; keeps the
+ * user's `dns` block but pins the fake-ip keys the tunnel requires on top
+ * (injecting default nameservers only when the config declares none);
  * pins `mixed-port`, `allow-lan`, listener bind address, and DNS listen
  * socket; declares a `GLOBAL` selector headed by the config's primary
  * outbound (so `mode: global` proxies rather than black-holes); injects a

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -813,7 +813,9 @@ fn inject_global_selector(root: &mut serde_yaml::Mapping, primary: &str) {
     }
 }
 
-/// Patch a Clash YAML config for iOS: strips `dns` and `subscriptions`;
+/// Patch a Clash YAML config for iOS: strips `subscriptions`; keeps the
+/// user's `dns` block but pins the fake-ip keys the tunnel requires on top
+/// (injecting default nameservers only when the config declares none);
 /// pins `mixed-port`, `allow-lan`, listener bind address, and DNS listen
 /// socket; declares a `GLOBAL` selector headed by the config's primary
 /// outbound (so `mode: global` proxies rather than black-holes); injects a
@@ -854,12 +856,12 @@ pub unsafe extern "C" fn meow_patch_config(
         return -1;
     };
 
-    // Strip `dns` and `sniffer` because iOS pins both blocks below: persistent
-    // fake-IP mapping plus TLS SNI inspection on the mixed listener. Strip
-    // `subscriptions` as well (handled app-side). `secret` is intentionally NOT
-    // stripped here — we overwrite it below with a per-install random token so
-    // the REST API on loopback is authenticated rather than open.
-    for key in ["dns", "sniffer", "subscriptions"] {
+    // Strip `sniffer` because iOS pins TLS SNI inspection on the mixed
+    // listener below. Strip `subscriptions` as well (handled app-side).
+    // `secret` is intentionally NOT stripped here — we overwrite it below with
+    // a per-install random token so the REST API on loopback is authenticated
+    // rather than open. `dns` is merged, not stripped — see below.
+    for key in ["sniffer", "subscriptions"] {
         root.remove(serde_yaml::Value::String(key.to_string()));
     }
 
@@ -893,7 +895,15 @@ pub unsafe extern "C" fn meow_patch_config(
         serde_yaml::Value::String(bind_addr.into()),
     );
 
-    let mut dns = serde_yaml::Mapping::new();
+    // Start from the user's own `dns` block so their resolver choices
+    // (nameserver, fallback, fake-ip-filter, …) survive, then pin the keys the
+    // tunnel requires on top: the packet tunnel routes 28.0.0.0/8 into the tun
+    // and reverse-maps fake IPs back to hostnames, so `enhanced-mode`, the
+    // fake-ip range, and the listen socket are not user-configurable.
+    let mut dns = match root.remove(serde_yaml::Value::String("dns".into())) {
+        Some(serde_yaml::Value::Mapping(user_dns)) => user_dns,
+        _ => serde_yaml::Mapping::new(),
+    };
     for (k, v) in [
         ("enable", serde_yaml::Value::Bool(true)),
         (
@@ -909,13 +919,20 @@ pub unsafe extern "C" fn meow_patch_config(
     ] {
         dns.insert(serde_yaml::Value::String(k.into()), v);
     }
-    dns.insert(
-        serde_yaml::Value::String("nameserver".into()),
-        serde_yaml::Value::Sequence(vec![
-            serde_yaml::Value::String("119.29.29.29".into()),
-            serde_yaml::Value::String("223.5.5.5".into()),
-        ]),
-    );
+    let needs_default_nameserver = match dns.get("nameserver") {
+        Some(serde_yaml::Value::Sequence(list)) => list.is_empty(),
+        Some(serde_yaml::Value::Null) | None => true,
+        Some(_) => false,
+    };
+    if needs_default_nameserver {
+        dns.insert(
+            serde_yaml::Value::String("nameserver".into()),
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("119.29.29.29".into()),
+                serde_yaml::Value::String("223.5.5.5".into()),
+            ]),
+        );
+    }
     root.insert(
         serde_yaml::Value::String("dns".into()),
         serde_yaml::Value::Mapping(dns),
@@ -1427,6 +1444,93 @@ rules:
             sniff.get("HTTP").is_none(),
             "user HTTP sniffer was replaced"
         );
+    }
+
+    #[test]
+    fn patch_config_respects_user_dns_but_pins_fake_ip() {
+        let patched = patch_config(
+            r#"
+dns:
+  enable: false
+  enhanced-mode: redir-host
+  listen: 0.0.0.0:53
+  fake-ip-range: 198.18.0.1/16
+  nameserver:
+    - 1.1.1.1
+    - https://dns.google/dns-query
+  fallback:
+    - 8.8.8.8
+  fake-ip-filter:
+    - '*.lan'
+rules:
+  - MATCH,DIRECT
+"#,
+            7890,
+            0,
+            1053,
+        );
+        let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
+        let dns = doc
+            .as_mapping()
+            .and_then(|root| root.get("dns"))
+            .and_then(serde_yaml::Value::as_mapping)
+            .expect("dns mapping");
+
+        // The tunnel-critical keys override whatever the user wrote.
+        assert_eq!(
+            dns.get("enable").and_then(serde_yaml::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            dns.get("enhanced-mode").and_then(serde_yaml::Value::as_str),
+            Some("fake-ip")
+        );
+        assert_eq!(
+            dns.get("fake-ip-range").and_then(serde_yaml::Value::as_str),
+            Some("28.0.0.0/8")
+        );
+        assert_eq!(
+            dns.get("listen").and_then(serde_yaml::Value::as_str),
+            Some("127.0.0.1:1053")
+        );
+
+        // The user's resolver choices survive the patch.
+        let nameservers: Vec<&str> = dns
+            .get("nameserver")
+            .and_then(serde_yaml::Value::as_sequence)
+            .expect("user nameservers kept")
+            .iter()
+            .filter_map(serde_yaml::Value::as_str)
+            .collect();
+        assert_eq!(nameservers, vec!["1.1.1.1", "https://dns.google/dns-query"]);
+        assert!(dns.get("fallback").is_some(), "user fallback kept");
+        assert!(
+            dns.get("fake-ip-filter").is_some(),
+            "user fake-ip-filter kept"
+        );
+    }
+
+    #[test]
+    fn patch_config_injects_default_nameservers_when_absent() {
+        for yaml in [
+            "rules:\n  - MATCH,DIRECT\n",
+            "dns:\n  nameserver: []\nrules:\n  - MATCH,DIRECT\n",
+            "dns:\n  nameserver:\nrules:\n  - MATCH,DIRECT\n",
+        ] {
+            let patched = patch_config(yaml, 7890, 0, 1053);
+            let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
+            let nameservers: Vec<&str> = doc
+                .as_mapping()
+                .and_then(|root| root.get("dns"))
+                .and_then(serde_yaml::Value::as_mapping)
+                .and_then(|dns| dns.get("nameserver"))
+                .and_then(serde_yaml::Value::as_sequence)
+                .expect("default nameservers injected")
+                .iter()
+                .filter_map(serde_yaml::Value::as_str)
+                .collect();
+            assert_eq!(nameservers, vec!["119.29.29.29", "223.5.5.5"], "{yaml}");
+        }
     }
 
     #[test]

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -815,7 +815,7 @@ fn inject_global_selector(root: &mut serde_yaml::Mapping, primary: &str) {
 
 /// Patch a Clash YAML config for iOS: strips `subscriptions`; keeps the
 /// user's `dns` block but pins the fake-ip keys the tunnel requires on top
-/// (injecting default nameservers only when the config declares none);
+/// (user nameservers stay first, the built-in defaults are always appended);
 /// pins `mixed-port`, `allow-lan`, listener bind address, and DNS listen
 /// socket; declares a `GLOBAL` selector headed by the config's primary
 /// outbound (so `mode: global` proxies rather than black-holes); injects a
@@ -919,20 +919,23 @@ pub unsafe extern "C" fn meow_patch_config(
     ] {
         dns.insert(serde_yaml::Value::String(k.into()), v);
     }
-    let needs_default_nameserver = match dns.get("nameserver") {
-        Some(serde_yaml::Value::Sequence(list)) => list.is_empty(),
-        Some(serde_yaml::Value::Null) | None => true,
-        Some(_) => false,
+    // User-supplied nameservers stay first; the built-in defaults are always
+    // appended (deduped) so the tunnel keeps a known-good plain-UDP resolver
+    // even when the user's entries are unreachable or DoH-only.
+    let mut nameservers = match dns.get("nameserver") {
+        Some(serde_yaml::Value::Sequence(list)) => list.clone(),
+        _ => Vec::new(),
     };
-    if needs_default_nameserver {
-        dns.insert(
-            serde_yaml::Value::String("nameserver".into()),
-            serde_yaml::Value::Sequence(vec![
-                serde_yaml::Value::String("119.29.29.29".into()),
-                serde_yaml::Value::String("223.5.5.5".into()),
-            ]),
-        );
+    for default in ["119.29.29.29", "223.5.5.5"] {
+        let entry = serde_yaml::Value::String(default.into());
+        if !nameservers.contains(&entry) {
+            nameservers.push(entry);
+        }
     }
+    dns.insert(
+        serde_yaml::Value::String("nameserver".into()),
+        serde_yaml::Value::Sequence(nameservers),
+    );
     root.insert(
         serde_yaml::Value::String("dns".into()),
         serde_yaml::Value::Mapping(dns),
@@ -1494,7 +1497,8 @@ rules:
             Some("127.0.0.1:1053")
         );
 
-        // The user's resolver choices survive the patch.
+        // The user's resolver choices survive the patch, ahead of the
+        // always-appended built-in defaults.
         let nameservers: Vec<&str> = dns
             .get("nameserver")
             .and_then(serde_yaml::Value::as_sequence)
@@ -1502,7 +1506,15 @@ rules:
             .iter()
             .filter_map(serde_yaml::Value::as_str)
             .collect();
-        assert_eq!(nameservers, vec!["1.1.1.1", "https://dns.google/dns-query"]);
+        assert_eq!(
+            nameservers,
+            vec![
+                "1.1.1.1",
+                "https://dns.google/dns-query",
+                "119.29.29.29",
+                "223.5.5.5"
+            ]
+        );
         assert!(dns.get("fallback").is_some(), "user fallback kept");
         assert!(
             dns.get("fake-ip-filter").is_some(),
@@ -1511,26 +1523,36 @@ rules:
     }
 
     #[test]
-    fn patch_config_injects_default_nameservers_when_absent() {
+    fn patch_config_always_appends_default_nameservers() {
+        fn nameservers(yaml: &str) -> Vec<String> {
+            let patched = patch_config(yaml, 7890, 0, 1053);
+            let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
+            doc.as_mapping()
+                .and_then(|root| root.get("dns"))
+                .and_then(serde_yaml::Value::as_mapping)
+                .and_then(|dns| dns.get("nameserver"))
+                .and_then(serde_yaml::Value::as_sequence)
+                .expect("nameserver list present")
+                .iter()
+                .filter_map(serde_yaml::Value::as_str)
+                .map(str::to_owned)
+                .collect()
+        }
+
+        // Absent, null, or empty user lists get exactly the defaults.
         for yaml in [
             "rules:\n  - MATCH,DIRECT\n",
             "dns:\n  nameserver: []\nrules:\n  - MATCH,DIRECT\n",
             "dns:\n  nameserver:\nrules:\n  - MATCH,DIRECT\n",
         ] {
-            let patched = patch_config(yaml, 7890, 0, 1053);
-            let doc: serde_yaml::Value = serde_yaml::from_str(&patched).expect("patched yaml");
-            let nameservers: Vec<&str> = doc
-                .as_mapping()
-                .and_then(|root| root.get("dns"))
-                .and_then(serde_yaml::Value::as_mapping)
-                .and_then(|dns| dns.get("nameserver"))
-                .and_then(serde_yaml::Value::as_sequence)
-                .expect("default nameservers injected")
-                .iter()
-                .filter_map(serde_yaml::Value::as_str)
-                .collect();
-            assert_eq!(nameservers, vec!["119.29.29.29", "223.5.5.5"], "{yaml}");
+            assert_eq!(nameservers(yaml), ["119.29.29.29", "223.5.5.5"], "{yaml}");
         }
+
+        // A default already listed by the user is not duplicated.
+        assert_eq!(
+            nameservers("dns:\n  nameserver:\n    - 223.5.5.5\nrules:\n  - MATCH,DIRECT\n"),
+            ["223.5.5.5", "119.29.29.29"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `meow_patch_config` no longer strips the user's `dns:` block. It now merges: the user's resolver choices (`nameserver`, `fallback`, `fake-ip-filter`, `nameserver-policy`, …) survive, while the tunnel-critical keys are pinned on top: `enable: true`, `listen`, `enhanced-mode: fake-ip`, `store-fake-ip: true`, `fake-ip-range: 28.0.0.0/8`.
- The built-in `119.29.29.29` / `223.5.5.5` resolvers are **always kept** in the nameserver list: user entries first, defaults appended (deduped), so the tunnel retains a known-good plain-UDP resolver even when user entries are unreachable or DoH-only.
- `meow_core.h` regenerated via cbindgen (doc comment only).

Closes #339

## Tests
- New: `patch_config_respects_user_dns_but_pins_fake_ip` (user nameservers/fallback/fake-ip-filter kept ahead of appended defaults; enable/enhanced-mode/listen/fake-ip-range overridden), `patch_config_always_appends_default_nameservers` (absent / null / empty-list get exactly the defaults; a user-listed default is not duplicated).

## Local CI attestation (Path B)
1. `swiftformat --lint .` → 0/127 files require formatting ✅
2. `swiftlint --strict` → 0 violations ✅
3. Rust/FFI diff: `scripts/build-rust.sh` → xcframework built ✅; `cargo test` in `core/rust/meow-ios-ffi/` → 61 passed, 0 failed ✅; `cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings` → clean ✅. No Swift sources touched; no Swift test references `meow_patch_config` (grepped MeowTests/MeowUITests/MeowIntegrationTests).
4. `git diff origin/main...HEAD --stat` → only `core/rust/meow-ios-ffi/src/lib.rs` + regenerated `MeowCore/include/meow_core.h` ✅