### PR TITLE
fix(home): mirror the selected app icon in the status glyph

### DIFF
--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -18,6 +18,7 @@ final class AppModel {
     let dailyTrafficAccumulator: DailyTrafficAccumulator
     let utilityTrafficChart: UtilityTrafficChartStore
     let utilityLogs: UtilityLogsStore
+    let appIconStore: AppIconStore
 
     /// Monotonically bumped each time `replaySelectedProxies()` finishes a pass
     /// (successful replay, probe-timeout giveup, or no-active-profile no-op).
@@ -54,6 +55,7 @@ final class AppModel {
         )
         utilityTrafficChart = UtilityTrafficChartStore()
         utilityLogs = UtilityLogsStore()
+        appIconStore = AppIconStore()
         ipcBridge.onTrafficDidUpdate = { [utilityTrafficChart] snapshot in
             utilityTrafficChart.ingest(snapshot)
         }

--- a/App/Sources/MeowApp.swift
+++ b/App/Sources/MeowApp.swift
@@ -15,6 +15,7 @@ struct MeowApp: App {
                 .environment(appModel.ipcBridge)
                 .environment(appModel.utilityTrafficChart)
                 .environment(appModel.utilityLogs)
+                .environment(appModel.appIconStore)
                 .task { await appModel.bootstrap() }
         }
         .modelContainer(AppModelContainer.shared.container)

--- a/App/Sources/Models/AppIcon.swift
+++ b/App/Sources/Models/AppIcon.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 /// The Home Screen icons the user can pick in Settings → App Icon. `primary`
@@ -20,6 +21,21 @@ enum AppIcon: String, CaseIterable, Identifiable {
     case sunset = "AppIconSunset"
     /// Black cat resting on a moonlit wall (`AppIconMidnight.appiconset`).
     case midnight = "AppIconMidnight"
+
+    /// Fraction of an icon's width that iOS rounds off when it masks artwork
+    /// for the Home Screen. The picker rows and the in-app status glyph both
+    /// mask with this, so an icon reads as the same shape wherever it appears.
+    static let squircleRadiusRatio: CGFloat = 0.22
+
+    /// Corner-radius fraction the status glyph masks this icon's artwork with.
+    ///
+    /// Zero for the primary mascot: its squircle is baked into the alpha
+    /// channel, and re-masking a shape that is already rounded would only
+    /// shave artwork off the corners. The alternates are full-bleed Home
+    /// Screen art, so the glyph has to round them itself.
+    var glyphCornerRadiusRatio: CGFloat {
+        self == .primary ? 0 : Self.squircleRadiusRatio
+    }
 
     var id: String {
         rawValue
@@ -50,5 +66,19 @@ enum AppIcon: String, CaseIterable, Identifiable {
     /// (an icon dropped in an app update) fall back to `.primary`.
     init(alternateIconName: String?) {
         self = alternateIconName.flatMap(AppIcon.init(rawValue:)) ?? .primary
+    }
+
+    /// Asset the in-app status glyph draws while this icon is installed.
+    ///
+    /// The primary icon ships a dedicated pair of transparent-cornered
+    /// mascots — `AppMarkConnected` hangs a paw over the wall while the tunnel
+    /// is up. The alternates exist only as full-bleed Home Screen art, so they
+    /// reuse the picker's preview and lean on the glyph's stage dot alone to
+    /// show connection state.
+    func glyphAssetName(connected: Bool) -> String {
+        switch self {
+        case .primary: connected ? "AppMarkConnected" : "AppMark"
+        case .leap, .sunset, .midnight: previewAssetName
+        }
     }
 }

--- a/App/Sources/Services/AppIconStore.swift
+++ b/App/Sources/Services/AppIconStore.swift
@@ -1,0 +1,86 @@
+import Observation
+import UIKit
+
+/// The app's single observable copy of the Home Screen icon choice.
+///
+/// iOS keeps that choice in `UIApplication.alternateIconName`, a plain
+/// property with no change notification. Settings used to own the value in
+/// local `@State`, so nothing outside that screen could learn a switch had
+/// happened — the status glyph on Home kept drawing the default artwork until
+/// the next launch. Everything now reads `current` and writes through
+/// `select(_:)`.
+///
+/// The system, not `Preferences`, is still the persistence layer: `current` is
+/// seeded from `alternateIconName` at launch and only advances once iOS has
+/// accepted a switch, so it never claims an icon that isn't installed.
+@MainActor
+@Observable
+final class AppIconStore {
+    /// The icon iOS has installed, as far as this process knows.
+    private(set) var current: AppIcon
+
+    /// `false` where the platform refuses icon switching — an iPad build
+    /// running on macOS, for one. Callers hide the picker rather than let a
+    /// tap fail. A fixed platform capability, so it is read on demand rather
+    /// than cached at launch.
+    var isSupported: Bool {
+        system.supportsAlternateIcons
+    }
+
+    private let system: AlternateIconApplying
+
+    init(system: AlternateIconApplying = SystemAlternateIcons()) {
+        self.system = system
+        current = AppIcon(alternateIconName: system.alternateIconName)
+    }
+
+    /// Switches the Home Screen icon. Returns `false` when iOS declined the
+    /// change (Guided Access, a device-management profile) so the caller can
+    /// explain why; `current` then re-syncs to whatever is really installed.
+    func select(_ icon: AppIcon) async -> Bool {
+        // Compared against the live value rather than `current`: after a
+        // declined attempt `current` describes reality, and re-setting the
+        // installed icon still pops the system's "you changed the icon" alert.
+        guard icon.alternateIconName != system.alternateIconName else {
+            current = icon
+            return true
+        }
+        do {
+            try await system.setAlternateIconName(icon.alternateIconName)
+            current = icon
+            return true
+        } catch {
+            current = AppIcon(alternateIconName: system.alternateIconName)
+            return false
+        }
+    }
+}
+
+/// The slice of `UIApplication` the store needs, extracted so its
+/// accept/decline handling is unit-testable — the real API mutates the
+/// simulator's Home Screen and posts a system alert.
+@MainActor
+protocol AlternateIconApplying {
+    var alternateIconName: String? { get }
+    var supportsAlternateIcons: Bool { get }
+    func setAlternateIconName(_ name: String?) async throws
+}
+
+/// Live implementation. Forwards to `UIApplication.shared` instead of
+/// conforming `UIApplication` itself: `setAlternateIconName` is an
+/// Objective-C completion-handler API that the compiler bridges to `async`,
+/// and an explicit forwarder keeps that off the protocol witness table.
+@MainActor
+struct SystemAlternateIcons: AlternateIconApplying {
+    var alternateIconName: String? {
+        UIApplication.shared.alternateIconName
+    }
+
+    var supportsAlternateIcons: Bool {
+        UIApplication.shared.supportsAlternateIcons
+    }
+
+    func setAlternateIconName(_ name: String?) async throws {
+        try await UIApplication.shared.setAlternateIconName(name)
+    }
+}

--- a/App/Sources/Views/AppIconPickerView.swift
+++ b/App/Sources/Views/AppIconPickerView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 /// Settings → App Icon. Replaces the former inline `Picker`, which listed the
 /// icons by name only and gave no hint what any of them looked like, with a
@@ -10,19 +9,21 @@ import UIKit
 /// primary app icon by its asset name, so reading previews out of the icon
 /// sets would leave the default row blank.
 ///
-/// Selection applies the moment a row is tapped, and the system — not
-/// `Preferences` — persists it in `UIApplication.alternateIconName`. When iOS
-/// declines the switch (Guided Access, a management profile), `selection`
-/// snaps back to the icon actually installed and a banner explains why.
+/// Selection applies the moment a row is tapped. `AppIconStore` owns the
+/// value — the system, not `Preferences`, persists it in
+/// `UIApplication.alternateIconName` — so the checkmark here and the status
+/// glyph on Home always agree on which icon is installed. When iOS declines
+/// the switch (Guided Access, a management profile) nothing moves and a banner
+/// explains why.
 struct AppIconPickerView: View {
-    @Binding var selection: AppIcon
+    @Environment(AppIconStore.self) private var appIconStore
     @State private var failed = false
 
     private let iconSize: CGFloat = 72
 
     var body: some View {
         Group {
-            if UIApplication.shared.supportsAlternateIcons {
+            if appIconStore.isSupported {
                 iconList
             } else {
                 unsupported
@@ -44,7 +45,7 @@ struct AppIconPickerView: View {
 
     private var iconList: some View {
         List(AppIcon.allCases) { icon in
-            AppIconRow(icon: icon, size: iconSize, isSelected: icon == selection) {
+            AppIconRow(icon: icon, size: iconSize, isSelected: icon == appIconStore.current) {
                 select(icon)
             }
         }
@@ -61,19 +62,10 @@ struct AppIconPickerView: View {
     }
 
     private func select(_ icon: AppIcon) {
-        let previous = selection
-        selection = icon
         failed = false
-        // The live UIKit value, not `previous`, decides whether a switch is
-        // needed — `selection` can lag reality after a failed attempt.
-        guard icon.alternateIconName != UIApplication.shared.alternateIconName else { return }
         Task {
-            do {
-                try await UIApplication.shared.setAlternateIconName(icon.alternateIconName)
-            } catch {
-                selection = previous
-                failed = true
-            }
+            let applied = await appIconStore.select(icon)
+            failed = !applied
         }
     }
 }
@@ -87,7 +79,7 @@ private struct AppIconRow: View {
     let action: () -> Void
 
     private var cornerRadius: CGFloat {
-        size * 0.22
+        size * AppIcon.squircleRadiusRatio
     }
 
     var body: some View {

--- a/App/Sources/Views/GlobalVpnSwitchBar.swift
+++ b/App/Sources/Views/GlobalVpnSwitchBar.swift
@@ -185,12 +185,29 @@ struct VpnStatusGlyph: View {
     let stage: VpnStage
     var size: CGFloat = 54
 
+    @Environment(AppIconStore.self) private var appIconStore
+
+    private var icon: AppIcon {
+        appIconStore.current
+    }
+
     var body: some View {
         ZStack {
-            Image(stage == .connected ? "AppMarkConnected" : "AppMark")
+            // Tracks the installed Home Screen icon: the glyph is the app's
+            // self-portrait, so leaving it on the default mascot after a
+            // switch in Settings read as a bug. The mask rounds the
+            // alternates' full-bleed artwork and is a no-op (radius 0) for the
+            // primary mascot, which is pre-masked.
+            Image(icon.glyphAssetName(connected: stage == .connected))
                 .resizable()
                 .scaledToFit()
                 .frame(width: size, height: size)
+                .clipShape(
+                    RoundedRectangle(
+                        cornerRadius: size * icon.glyphCornerRadiusRatio,
+                        style: .continuous,
+                    ),
+                )
         }
         .overlay(alignment: .bottomTrailing) {
             StageDot(stage: stage, size: max(8, size * 0.19))

--- a/App/Sources/Views/SettingsView.swift
+++ b/App/Sources/Views/SettingsView.swift
@@ -3,16 +3,10 @@ import MeowModels
 import NetworkExtension
 import OSLog
 import SwiftUI
-import UIKit
 import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @State private var preferences: Preferences = .load(from: AppGroup.defaults)
-    /// Seeded from the live `UIApplication.alternateIconName` on appear, then
-    /// handed to `AppIconPickerView` as its selection. The picker owns both
-    /// reading the tap and applying the change; this only supplies the
-    /// starting value.
-    @State private var appIcon: AppIcon = .primary
     @State private var memoryMB: Int64?
     @State private var logExportDocument: LogExportDocument?
     @State private var showingLogExporter = false
@@ -22,6 +16,7 @@ struct SettingsView: View {
     #endif
     @Environment(VpnManager.self) private var vpnManager
     @Environment(AppIPCBridge.self) private var ipcBridge
+    @Environment(AppIconStore.self) private var appIconStore
 
     var body: some View {
         Form {
@@ -60,9 +55,9 @@ struct SettingsView: View {
                 .accessibilityIdentifier("settings.picker.logLevel")
                 // Hidden where the platform can't switch icons (e.g. iPad
                 // apps running on macOS report supportsAlternateIcons=false).
-                if UIApplication.shared.supportsAlternateIcons {
+                if appIconStore.isSupported {
                     NavigationLink("settings.label.appIcon") {
-                        AppIconPickerView(selection: $appIcon)
+                        AppIconPickerView()
                     }
                     .accessibilityIdentifier("settings.nav.appIcon")
                     .accessibilityHint(Text("a11y.settings.appIcon.hint"))
@@ -155,7 +150,6 @@ struct SettingsView: View {
                 Task { await vpnManager.refresh() }
             }
             .task {
-                appIcon = AppIcon(alternateIconName: UIApplication.shared.alternateIconName)
                 await pollMemory()
             }
             .fileExporter(

--- a/MeowTests/Models/AppIconTests.swift
+++ b/MeowTests/Models/AppIconTests.swift
@@ -69,6 +69,29 @@ struct AppIconTests {
         }
     }
 
+    @MainActor
+    @Test
+    func `every case has a status-glyph image in both connection states`() {
+        // VpnStatusGlyph mirrors the installed icon; a missing asset would
+        // blank the Home tab's leading glyph and nothing else.
+        for icon in AppIcon.allCases {
+            for connected in [true, false] {
+                let name = icon.glyphAssetName(connected: connected)
+                #expect(UIImage(named: name) != nil, "missing \(name) for \(icon.rawValue)")
+            }
+        }
+    }
+
+    @Test
+    func `only the pre-masked primary mascot skips the glyph squircle`() {
+        // AppMark's squircle lives in its alpha channel; masking it a second
+        // time would clip the artwork instead of shaping it.
+        #expect(AppIcon.primary.glyphCornerRadiusRatio == 0)
+        for icon in AppIcon.allCases where icon != .primary {
+            #expect(icon.glyphCornerRadiusRatio == AppIcon.squircleRadiusRatio)
+        }
+    }
+
     @Test
     func `every alternate icon is registered in the processed Info plist`() throws {
         // actool copies ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES

--- a/MeowTests/Services/AppIconStoreTests.swift
+++ b/MeowTests/Services/AppIconStoreTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+@testable import meow_ios
+import Testing
+
+@MainActor
+@Suite("AppIconStore")
+struct AppIconStoreTests {
+    @Test
+    func `seeds the current icon from what iOS has installed`() {
+        let system = StubAlternateIcons(installed: AppIcon.sunset.alternateIconName)
+        #expect(AppIconStore(system: system).current == .sunset)
+    }
+
+    @Test
+    func `seeds primary when no alternate icon is installed`() {
+        #expect(AppIconStore(system: StubAlternateIcons(installed: nil)).current == .primary)
+    }
+
+    @Test
+    func `an icon dropped in an app update seeds as primary`() {
+        let system = StubAlternateIcons(installed: "AppIconRemovedLastRelease")
+        #expect(AppIconStore(system: system).current == .primary)
+    }
+
+    @Test
+    func `select publishes the new icon once iOS accepts it`() async {
+        let system = StubAlternateIcons(installed: nil)
+        let store = AppIconStore(system: system)
+
+        #expect(await store.select(.midnight))
+
+        #expect(store.current == .midnight)
+        #expect(system.alternateIconName == "AppIconMidnight")
+    }
+
+    @Test
+    func `a declined switch keeps the installed icon and reports failure`() async {
+        // Guided Access and management profiles both make setAlternateIconName
+        // throw; the picker turns the `false` into its error banner.
+        let system = StubAlternateIcons(installed: AppIcon.leap.alternateIconName)
+        system.failure = IconChangeDeclined()
+        let store = AppIconStore(system: system)
+
+        #expect(await store.select(.sunset) == false)
+
+        #expect(store.current == .leap)
+        #expect(system.alternateIconName == "AppIconLeap")
+    }
+
+    @Test
+    func `selecting the installed icon leaves UIKit alone`() async {
+        // A redundant setAlternateIconName call still pops the system's "You
+        // have changed the icon for meow" alert, so re-tapping the current row
+        // must be a no-op.
+        let system = StubAlternateIcons(installed: AppIcon.leap.alternateIconName)
+        let store = AppIconStore(system: system)
+
+        #expect(await store.select(.leap))
+
+        #expect(store.current == .leap)
+        #expect(system.setCallCount == 0)
+    }
+
+    @Test
+    func `select returns to primary by clearing the alternate name`() async {
+        let system = StubAlternateIcons(installed: AppIcon.midnight.alternateIconName)
+        let store = AppIconStore(system: system)
+
+        #expect(await store.select(.primary))
+
+        #expect(store.current == .primary)
+        #expect(system.alternateIconName == nil)
+    }
+
+    @Test
+    func `isSupported mirrors the platform capability`() {
+        #expect(AppIconStore(system: StubAlternateIcons(supportsAlternateIcons: false)).isSupported == false)
+        #expect(AppIconStore(system: StubAlternateIcons(supportsAlternateIcons: true)).isSupported)
+    }
+}
+
+/// Stands in for `UIApplication`'s alternate-icon API — the real one mutates
+/// the simulator's Home Screen and posts a system alert mid-suite.
+@MainActor
+private final class StubAlternateIcons: AlternateIconApplying {
+    var alternateIconName: String?
+    var supportsAlternateIcons: Bool
+    var failure: Error?
+    private(set) var setCallCount = 0
+
+    init(installed: String? = nil, supportsAlternateIcons: Bool = true) {
+        alternateIconName = installed
+        self.supportsAlternateIcons = supportsAlternateIcons
+    }
+
+    func setAlternateIconName(_ name: String?) async throws {
+        setCallCount += 1
+        if let failure {
+            throw failure
+        }
+        alternateIconName = name
+    }
+}
+
+private struct IconChangeDeclined: Error {}

--- a/meow-ios.xcodeproj/project.pbxproj
+++ b/meow-ios.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		4A6D4B20B4094E334F26892F /* TunBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC654683AAE620AA9C1DCEBF /* TunBridgeTests.swift */; };
 		4AFF0859870D8941AC3CE716 /* MeowIPC in Frameworks */ = {isa = PBXBuildFile; productRef = BE92B6925662A398B4A18E9C /* MeowIPC */; };
 		4C1FB9714B9308B7577B9622 /* MeowModels in Frameworks */ = {isa = PBXBuildFile; productRef = 564BE37A8BC742522CCABC5E /* MeowModels */; };
+		4C2A8D51E6B90F73C1284DA6 /* AppIconStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4E9C77A0F3D5628E71A409 /* AppIconStore.swift */; };
 		4E0EE8ED5787010E844F6F87 /* ShadowsocksURIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FF63D9219A475F002F2734 /* ShadowsocksURIEncoder.swift */; };
 		4E366621A02CAF97E4AA2EF2 /* RulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE160D91FCAFCD07383E8CB5 /* RulesTests.swift */; };
 		4F29B935B393F48182AC7CE4 /* MWIPCListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 329B260F122D91D5DDB24C44 /* MWIPCListener.m */; };
@@ -104,6 +105,7 @@
 		997AE63C0D074EA6370C5DA8 /* SwiftDataTestContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7B8DF88EDD0D51301DD316 /* SwiftDataTestContainer.swift */; };
 		9ADDC891C0BCC6053E86E2E2 /* SubscriptionConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601ADF66737508CC359C4936 /* SubscriptionConverter.swift */; };
 		9D59A8F980E180CECE858F27 /* DnsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E8157E43AE62A3A59DDD5C /* DnsTests.swift */; };
+		9D610FA34B8E27C5A6F0138B /* AppIconStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5F30B29C4A18D6F0537B12 /* AppIconStoreTests.swift */; };
 		9D8A3062281941D5B04CD09D /* YamlEditorFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA2BC08659A01899A4DB2CC /* YamlEditorFlowTests.swift */; };
 		9DAD82C550F44D6A48D1675D /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 5E3965E4A9673CFDC438D5F0 /* Yams */; };
 		A0ACD40A0E0CF4DFABDA8903 /* ConnectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC43530025FE948C50C6C78E /* ConnectionsTests.swift */; };
@@ -218,6 +220,7 @@
 		1509E80EF5E3A28E045FE8C9 /* GeoLite2-ASN.mmdb */ = {isa = PBXFileReference; path = "GeoLite2-ASN.mmdb"; sourceTree = "<group>"; };
 		1711243E170547D1DA68FCD6 /* RuleEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleEditorSheet.swift; sourceTree = "<group>"; };
 		1B3F7EB51045141F84569793 /* UtilitySessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySessionStore.swift; sourceTree = "<group>"; };
+		1B4E9C77A0F3D5628E71A409 /* AppIconStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconStore.swift; sourceTree = "<group>"; };
 		1C50CF82F4373D42432869C5 /* MWPacketWriter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWPacketWriter.m; sourceTree = "<group>"; };
 		1CCF322677C8A124E9D9107D /* MWDiagnosticsRunner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MWDiagnosticsRunner.m; sourceTree = "<group>"; };
 		1F7BB3C0C2648B6097E52E53 /* UtilityScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityScreenTests.swift; sourceTree = "<group>"; };
@@ -275,6 +278,7 @@
 		797EA53C272DDA3EC6E73E6F /* MWDarwinBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWDarwinBridge.h; sourceTree = "<group>"; };
 		7D8C1AC6AD4590D6827E6188 /* GeoAssetStagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoAssetStagerTests.swift; sourceTree = "<group>"; };
 		7D936CF5D2CCA1B2D180C2D6 /* AppShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShellTests.swift; sourceTree = "<group>"; };
+		7E5F30B29C4A18D6F0537B12 /* AppIconStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconStoreTests.swift; sourceTree = "<group>"; };
 		819D62E17DBC5BC82869FA81 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
 		86AFFBA5F04A152705EE60CA /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
 		8A1CBAFD55A777C3B13296E2 /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
@@ -508,6 +512,7 @@
 		546289FB1F7F3C7197D240BC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				7E5F30B29C4A18D6F0537B12 /* AppIconStoreTests.swift */,
 				8B8C6076C2AFE3F87452DDEF /* DeepLinkImportConfirmationTests.swift */,
 				7D8C1AC6AD4590D6827E6188 /* GeoAssetStagerTests.swift */,
 				DF623F1E34B38A27E15C6B36 /* QRCodeRendererTests.swift */,
@@ -615,6 +620,7 @@
 			isa = PBXGroup;
 			children = (
 				6C69499C9815F48EC9AB924E /* AppIPCBridge.swift */,
+				1B4E9C77A0F3D5628E71A409 /* AppIconStore.swift */,
 				F582EC213C10F2BB97940B21 /* ClashConfigLinter.swift */,
 				664BEEB7B966973C3D0A5074 /* DailyTrafficAccumulator.swift */,
 				2583E90C66D44FFDC834DAB9 /* DeepLinkImportConfirmation.swift */,
@@ -1166,6 +1172,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D610FA34B8E27C5A6F0138B /* AppIconStoreTests.swift in Sources */,
 				50F7C0F2F8B850202089F7AE /* AppIconTests.swift in Sources */,
 				F3F6C8C58BB119BAA42C632B /* ChinaDirectKeywordsTests.swift in Sources */,
 				A0ACD40A0E0CF4DFABDA8903 /* ConnectionsTests.swift in Sources */,
@@ -1213,6 +1220,7 @@
 				DCC6938C0A43984B033BCD68 /* AppIPCBridge.swift in Sources */,
 				4FF1E4C061CE8323A6C981D1 /* AppIcon.swift in Sources */,
 				1D0E4DFB12DCCF45036E06CA /* AppIconPickerView.swift in Sources */,
+				4C2A8D51E6B90F73C1284DA6 /* AppIconStore.swift in Sources */,
 				ADBD29F9A34A3AF34057D104 /* AppModel.swift in Sources */,
 				B2761759D155051F32B46F2D /* AppModelContainer.swift in Sources */,
 				A582A655A6EA5FF633395AD9 /* ChinaDirectKeywords.swift in Sources */,


### PR DESCRIPTION
Follow-up to #346. Switching the Home Screen icon in Settings → App Icon left the glyph at the top-left of the main screen drawing the default mascot; it only caught up after the app was relaunched.

## Root cause

iOS keeps the choice in `UIApplication.alternateIconName` — a plain property with no change notification. `SettingsView` mirrored it into a local `@State`, so the value was invisible outside that screen, and `VpnStatusGlyph` hard-coded `"AppMark"` / `"AppMarkConnected"`.

## Fix

`AppIconStore` (`@MainActor @Observable`) becomes the single owner, created in `AppModel` and injected through the environment next to the app's other long-lived services:

- seeded from the live `alternateIconName` at launch — the system stays the persistence layer, no new `Preferences` key;
- `current` only advances once iOS **accepts** the switch, so the glyph never shows an icon that isn't installed;
- a declined switch (Guided Access, an MDM profile) re-syncs `current` and returns `false`, which the picker turns into its existing error banner;
- re-selecting the installed icon skips `setAlternateIconName` entirely — a redundant call still pops the system's "You have changed the icon for meow" alert.

`AppIconPickerView` now reads and writes through the store instead of a `@Binding`, which also removes the old dual-ownership hazard where Settings and the picker both tracked the selection.

## Artwork detail

The alternates only ship as full-bleed `.appiconset` art, so the glyph reuses their picker preview imagesets and masks them with `AppIcon.squircleRadiusRatio` (0.22). The primary mascot keeps its own dedicated pair — `AppMarkConnected` hangs a paw over the wall while the tunnel is up — and `glyphCornerRadiusRatio` returns `0` for it, since its squircle is already baked into the alpha channel and masking again would shave the corners rather than shape them. Both `VpnStatusGlyph` call sites (the switch bar at size 42 and the Home card at 54) are fixed by the same change.

## Tests

- `MeowTests/Services/AppIconStoreTests.swift` (new, 8 cases): seeding from installed / nil / an icon dropped in an update, publish-on-accept, keep-and-report-failure on decline, no-op on re-select, return to primary clears the name, `isSupported` passthrough. A `StubAlternateIcons` seam stands in for `UIApplication`, whose real API mutates the simulator Home Screen and posts an alert mid-suite.
- `AppIconTests`: every case has a status-glyph asset in both connection states (a missing one would silently blank the glyph); only the pre-masked primary skips the squircle.

## CI

**Full remote CI required — no admin bypass.** This diff touches Swift, so CLAUDE.md Path B applies, and its attestation can't be made honestly here: this host has no `swift`, `swiftlint`, `swiftformat`, or `xcodebuild`. Verified by hand instead (≤120 columns, brace balance, `.swiftlint.yml` / `.swiftformat` conventions), which is not a substitute for the real jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)