### PR TITLE
feat(subscriptions): per-profile auto-update cadence + left-swipe refresh

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -76,6 +76,11 @@
 "subscriptions.editInfo.nav.title" = "Edit Config";
 "subscriptions.editInfo.button.save" = "Save";
 "subscriptions.editInfo.footer" = "Changes to the URL take effect on the next refresh.";
+"subscriptions.editInfo.updateInterval" = "Auto-update";
+"subscriptions.editInfo.updateInterval.footer" = "meow refetches this config when you open the app and the chosen interval has elapsed. Swipe a row either direction to update it right now.";
+"subscriptions.updateInterval.manual" = "Never";
+"subscriptions.updateInterval.daily" = "Every day";
+"subscriptions.updateInterval.weekly" = "Every week";
 "subscriptions.import.errorTitle" = "Couldn't import config";
 "subscriptions.row.updatedAgo %@" = "Updated %@ ago";
 "subscriptions.row.a11y.edit %@" = "Edit YAML for %@";
@@ -383,6 +388,7 @@
 "subscriptions.row.a11y.selectHint" = "Activates this config";
 "subscriptions.row.a11y.editHint" = "Opens YAML editor";
 "subscriptions.row.a11y.refreshHint" = "Fetches the latest config from the remote URL";
+"subscriptions.editInfo.a11y.updateIntervalHint" = "Chooses how often this config refetches itself";
 
 
 /* Accessibility — Traffic charts */

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -82,6 +82,11 @@
 "subscriptions.editInfo.nav.title" = "编辑配置";
 "subscriptions.editInfo.button.save" = "保存";
 "subscriptions.editInfo.footer" = "网址的更改将在下次刷新时生效。";
+"subscriptions.editInfo.updateInterval" = "自动更新";
+"subscriptions.editInfo.updateInterval.footer" = "打开 app 时，若距上次更新已超过所选间隔，meow 会自动重新拉取此配置。左右滑动配置行可立即更新。";
+"subscriptions.updateInterval.manual" = "不自动更新";
+"subscriptions.updateInterval.daily" = "每天更新";
+"subscriptions.updateInterval.weekly" = "每周更新";
 "subscriptions.import.errorTitle" = "导入配置失败";
 "subscriptions.row.updatedAgo %@" = "%@前更新";
 "subscriptions.row.a11y.edit %@" = "编辑 %@ 的 YAML";
@@ -389,6 +394,7 @@
 "subscriptions.row.a11y.selectHint" = "激活此配置";
 "subscriptions.row.a11y.editHint" = "打开 YAML 编辑器";
 "subscriptions.row.a11y.refreshHint" = "从远程地址获取最新配置";
+"subscriptions.editInfo.a11y.updateIntervalHint" = "选择此配置自动重新拉取的频率";
 
 
 /* Accessibility — Traffic charts */

--- a/App/Sources/AppModel.swift
+++ b/App/Sources/AppModel.swift
@@ -16,6 +16,7 @@ final class AppModel {
     let subscriptionService: SubscriptionService
     let ipcBridge: AppIPCBridge
     let dailyTrafficAccumulator: DailyTrafficAccumulator
+    let profileAutoUpdater: ProfileAutoUpdater
     let utilityTrafficChart: UtilityTrafficChartStore
     let utilityLogs: UtilityLogsStore
 
@@ -52,6 +53,10 @@ final class AppModel {
         dailyTrafficAccumulator = DailyTrafficAccumulator(
             modelContext: AppModelContainer.shared.container.mainContext,
         )
+        profileAutoUpdater = ProfileAutoUpdater(
+            modelContext: AppModelContainer.shared.container.mainContext,
+            service: subscriptionService,
+        )
         utilityTrafficChart = UtilityTrafficChartStore()
         utilityLogs = UtilityLogsStore()
         ipcBridge.onTrafficDidUpdate = { [utilityTrafficChart] snapshot in
@@ -83,6 +88,11 @@ final class AppModel {
         await vpnManager.refresh()
         ipcBridge.start()
         dailyTrafficAccumulator.start()
+        // Kicked off here as well as from the scene-phase observer in
+        // `MeowApp` so a cold launch runs its first due-check without waiting
+        // for a phase *change* — the initial `.active` never fires an
+        // `onChange`. `start()` is idempotent, so the two paths can't stack.
+        profileAutoUpdater.start()
         utilityLogs.startStreaming(api: meowAPI)
     }
 

--- a/App/Sources/MeowApp.swift
+++ b/App/Sources/MeowApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @main
 struct MeowApp: App {
     @State private var appModel = AppModel()
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
@@ -18,5 +19,19 @@ struct MeowApp: App {
                 .task { await appModel.bootstrap() }
         }
         .modelContainer(AppModelContainer.shared.container)
+        .onChange(of: scenePhase) { _, phase in
+            // Only `.background` stops the auto-update timer. `.inactive`
+            // fires for transient interruptions (notification centre, app
+            // switcher preview) where tearing the timer down and rebuilding
+            // it would run a due-check on every glance at the app.
+            switch phase {
+            case .active:
+                appModel.profileAutoUpdater.start()
+            case .background:
+                appModel.profileAutoUpdater.stop()
+            default:
+                break
+            }
+        }
     }
 }

--- a/App/Sources/Models/Profile.swift
+++ b/App/Sources/Models/Profile.swift
@@ -19,6 +19,13 @@ final class Profile {
     /// JSON-encoded `[groupName: proxyName]` — last manual selections restored
     /// on reconnect.
     var selectedProxiesJSON: String
+    /// Raw `ProfileUpdateInterval` backing this profile's automatic-refresh
+    /// cadence. Stored as the enum's raw string rather than the enum itself so
+    /// an unrecognised value decodes to a fallback instead of failing the
+    /// store open — same reasoning as `selectedProxiesJSON`. The default value
+    /// is what lets SwiftData migrate existing stores in place: profiles that
+    /// predate the setting read back as `.manual`.
+    var updateIntervalRaw: String = ProfileUpdateInterval.fallback.rawValue
 
     init(
         id: UUID = UUID(),
@@ -31,6 +38,7 @@ final class Profile {
         txBytes: Int64 = 0,
         rxBytes: Int64 = 0,
         selectedProxiesJSON: String = "{}",
+        updateInterval: ProfileUpdateInterval = .fallback,
     ) {
         self.id = id
         self.name = name
@@ -42,6 +50,13 @@ final class Profile {
         self.txBytes = txBytes
         self.rxBytes = rxBytes
         self.selectedProxiesJSON = selectedProxiesJSON
+        updateIntervalRaw = updateInterval.rawValue
+    }
+
+    /// Typed view of `updateIntervalRaw`.
+    var updateInterval: ProfileUpdateInterval {
+        get { ProfileUpdateInterval(storedRawValue: updateIntervalRaw) }
+        set { updateIntervalRaw = newValue.rawValue }
     }
 
     var selectedProxies: [String: String] {

--- a/App/Sources/Models/ProfileUpdateInterval.swift
+++ b/App/Sources/Models/ProfileUpdateInterval.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// How often a profile re-fetches its subscription URL without the user
+/// asking. Persisted per profile as a raw string (`Profile.updateIntervalRaw`)
+/// and evaluated by `ProfileAutoUpdater`.
+enum ProfileUpdateInterval: String, CaseIterable, Identifiable {
+    /// Never refetches on its own — updates come from the user (either row
+    /// swipe direction, or a YAML edit).
+    case manual
+    case daily
+    case weekly
+
+    /// What a profile gets when no cadence has been chosen for it. Profiles
+    /// created before this setting existed therefore keep exactly their
+    /// pre-feature behaviour: no fetch happens until the user opts in.
+    static let fallback: ProfileUpdateInterval = .manual
+
+    var id: String {
+        rawValue
+    }
+
+    /// How stale `Profile.lastUpdated` has to be before an automatic refresh
+    /// is due. `nil` means "never due".
+    var refreshAfter: TimeInterval? {
+        switch self {
+        case .manual: nil
+        case .daily: 24 * 60 * 60
+        case .weekly: 7 * 24 * 60 * 60
+        }
+    }
+
+    /// Localizable.strings key for the picker option and the row badge.
+    var titleKey: String {
+        switch self {
+        case .manual: "subscriptions.updateInterval.manual"
+        case .daily: "subscriptions.updateInterval.daily"
+        case .weekly: "subscriptions.updateInterval.weekly"
+        }
+    }
+
+    /// Decodes the persisted raw value. An unrecognised string — written by a
+    /// newer build whose store was then opened by an older one — degrades to
+    /// `fallback` instead of trapping on a failable initializer.
+    init(storedRawValue: String) {
+        self = ProfileUpdateInterval(rawValue: storedRawValue) ?? .fallback
+    }
+}

--- a/App/Sources/Services/ProfileAutoUpdater.swift
+++ b/App/Sources/Services/ProfileAutoUpdater.swift
@@ -1,0 +1,130 @@
+import Foundation
+import os
+import SwiftData
+
+/// Refetches subscription profiles whose per-profile cadence
+/// (`Profile.updateInterval`) has elapsed.
+///
+/// The app has no background-refresh entitlement — `UIBackgroundModes` is
+/// spent on the tunnel extension — so "every day" / "every week" means "the
+/// first foreground pass at or after the profile's due time", not a wake-up
+/// while the app is dead. That's the cadence a subscription actually needs:
+/// the app process is the only writer of `config.yaml`, so a refresh that
+/// can't run until the app is open loses nothing.
+///
+/// Bookkeeping rides entirely on `Profile.lastUpdated`, which
+/// `SubscriptionService.refresh(_:)` already stamps on success. So a manual
+/// refresh (row swipe) also postpones the next automatic one, and there's no
+/// second timestamp that can drift out of sync with the first.
+@MainActor
+final class ProfileAutoUpdater {
+    /// Gap between due-checks while the app stays in the foreground. Coarse on
+    /// purpose: the shortest cadence offered is daily, so minute precision
+    /// buys nothing, and a tight loop would hammer a URL that's failing.
+    static let tickInterval: Duration = .seconds(30 * 60)
+
+    private let modelContext: ModelContext
+    private let service: SubscriptionService
+    private let now: () -> Date
+    private let log = Logger(subsystem: "com.tangzixiang.meow.app", category: "profile-auto-update")
+
+    private var tickTask: Task<Void, Never>?
+    /// Guards against overlapping passes: a foreground transition landing on
+    /// top of a running tick would otherwise refetch the same due profile
+    /// twice concurrently.
+    private var isRefreshing = false
+
+    init(
+        modelContext: ModelContext,
+        service: SubscriptionService,
+        now: @escaping () -> Date = Date.init,
+    ) {
+        self.modelContext = modelContext
+        self.service = service
+        self.now = now
+    }
+
+    /// Runs a due-check immediately, then every `tickInterval` until `stop()`.
+    ///
+    /// Idempotent: calling it while already started is a no-op, so a
+    /// transient `.inactive` → `.active` scene bounce (notification centre,
+    /// app switcher) neither stacks timers nor fires a redundant pass.
+    func start() {
+        guard tickTask == nil else { return }
+        tickTask = Task { [weak self] in
+            // The first pass runs immediately — a launch or a return from
+            // background is exactly when a daily/weekly window is most likely
+            // to have elapsed unnoticed.
+            await self?.refreshDueProfiles()
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: ProfileAutoUpdater.tickInterval)
+                } catch {
+                    return // cancelled mid-sleep
+                }
+                await self?.refreshDueProfiles()
+            }
+        }
+    }
+
+    func stop() {
+        tickTask?.cancel()
+        tickTask = nil
+    }
+
+    /// One due-check pass: refetch every profile whose cadence has elapsed.
+    ///
+    /// A failure is logged and skipped rather than propagated — one dead
+    /// subscription URL must not stop the others from updating. Since
+    /// `lastUpdated` only advances on a successful fetch, a profile that
+    /// failed here stays due and is retried on the next pass.
+    func refreshDueProfiles() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        let all: [Profile]
+        do {
+            all = try modelContext.fetch(FetchDescriptor<Profile>())
+        } catch {
+            log.error("profile fetch failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        let due = ProfileAutoUpdater.dueProfiles(in: all, at: now())
+        guard !due.isEmpty else { return }
+        log.notice("\(due.count, privacy: .public) profile(s) due for auto-update")
+        for profile in due {
+            do {
+                try await service.refresh(profile)
+            } catch {
+                log.error(
+                    """
+                    auto-update failed id=\(profile.id.uuidString, privacy: .public) \
+                    err=\(String(describing: error), privacy: .public)
+                    """,
+                )
+            }
+        }
+    }
+
+    /// Profiles whose automatic-refresh window has elapsed as of `date`.
+    static func dueProfiles(in profiles: [Profile], at date: Date) -> [Profile] {
+        profiles.filter { isDue($0, at: date) }
+    }
+
+    /// The cadence policy, kept pure and static so it's testable without a
+    /// network stub or a live timer.
+    static func isDue(_ profile: Profile, at date: Date) -> Bool {
+        // Local YAML imports have no remote to refetch.
+        guard !profile.url.isEmpty else { return false }
+        guard let window = profile.updateInterval.refreshAfter else { return false }
+        let age = date.timeIntervalSince(profile.lastUpdated)
+        // A stamp in the future can only come from a device clock that has
+        // since been corrected backwards. Treat it as due: the refresh
+        // restamps `lastUpdated` to now, which unsticks the cadence rather
+        // than freezing this profile until real time catches up.
+        guard age >= 0 else { return true }
+        return age >= window
+    }
+}

--- a/App/Sources/Services/SubscriptionService.swift
+++ b/App/Sources/Services/SubscriptionService.swift
@@ -132,17 +132,29 @@ final class SubscriptionService {
         try modelContext.save()
     }
 
-    /// Edit a profile's display name and update URL without touching its YAML
-    /// body. A changed URL takes effect on the next `refresh(_:)` — the stored
-    /// config is left as-is here. Attaching a URL to a previously local-only
-    /// import (empty `url`) promotes it to a refreshable subscription.
-    func updateInfo(_ profile: Profile, name: String, url: String) throws {
+    /// Edit a profile's display name, update URL, and auto-update cadence
+    /// without touching its YAML body. A changed URL takes effect on the next
+    /// `refresh(_:)` — the stored config is left as-is here. Attaching a URL to
+    /// a previously local-only import (empty `url`) promotes it to a
+    /// refreshable subscription.
+    ///
+    /// A cadence is only meaningful with a URL to fetch, so clearing the URL
+    /// also forces `.manual`: the editor hides the cadence picker for URL-less
+    /// profiles, and persisting a value the UI can't show would silently
+    /// resume that cadence if a URL were ever re-attached.
+    func updateInfo(
+        _ profile: Profile,
+        name: String,
+        url: String,
+        updateInterval: ProfileUpdateInterval,
+    ) throws {
         let trimmedURL = url.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedURL.isEmpty {
             try Self.rejectPlainHTTP(trimmedURL)
         }
         profile.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
         profile.url = trimmedURL
+        profile.updateInterval = trimmedURL.isEmpty ? .manual : updateInterval
         try modelContext.save()
     }
 

--- a/App/Sources/Views/SubscriptionsView.swift
+++ b/App/Sources/Views/SubscriptionsView.swift
@@ -39,12 +39,7 @@ struct SubscriptionsView: View {
                                         .accessibilityHidden(true)
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text(profile.name).font(.headline)
-                                        Text(
-                                            "subscriptions.row.updatedAgo \(profile.lastUpdated, style: .relative)",
-                                            comment: "Subscription row subtitle; %@ = relative time since last update",
-                                        )
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
+                                        rowSubtitle(profile)
                                     }
                                     Spacer(minLength: 0)
                                 }
@@ -123,7 +118,23 @@ struct SubscriptionsView: View {
                         .tint(AppTheme.accent)
                         .accessibilityIdentifier("subscriptions.row.editInfo")
                     }
+                    // Refresh is declared first so it — not Delete — is what a
+                    // full left-swipe triggers. Deleting the selected profile
+                    // also clears `config.yaml`, which is far too destructive
+                    // to sit behind an accidental flick; Delete stays one tap
+                    // away on a partial swipe.
                     .swipeActions(edge: .trailing) {
+                        if !profile.url.isEmpty {
+                            Button {
+                                Task { try? await service.refresh(profile) }
+                            } label: {
+                                Label("subscriptions.refresh.swipe", systemImage: "arrow.clockwise")
+                            }
+                            .tint(.blue)
+                            .accessibilityLabel(Text("subscriptions.row.a11y.refresh \(profile.name)"))
+                            .accessibilityHint(Text("subscriptions.row.a11y.refreshHint"))
+                            .accessibilityIdentifier("subscriptions.row.refreshTrailing")
+                        }
                         Button(role: .destructive) {
                             try? service.delete(profile)
                         } label: {
@@ -184,6 +195,28 @@ struct SubscriptionsView: View {
         } message: {
             Text(error ?? "")
         }
+    }
+
+    /// "Updated 3 min ago", plus a clock badge naming the cadence for a
+    /// profile that auto-updates — without it the setting is invisible outside
+    /// the edit sheet. URL-less profiles never auto-update (nothing to
+    /// refetch), so they never show the badge regardless of stored value.
+    private func rowSubtitle(_ profile: Profile) -> some View {
+        HStack(spacing: 6) {
+            Text(
+                "subscriptions.row.updatedAgo \(profile.lastUpdated, style: .relative)",
+                comment: "Subscription row subtitle; %@ = relative time since last update",
+            )
+            if profile.updateInterval != .manual, !profile.url.isEmpty {
+                Label(
+                    LocalizedStringKey(profile.updateInterval.titleKey),
+                    systemImage: "clock.arrow.circlepath",
+                )
+                .accessibilityIdentifier("subscriptions.row.autoUpdateBadge")
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
     }
 
     private var emptySubscriptionCard: some View {
@@ -270,7 +303,11 @@ struct SubscriptionsView: View {
         .accessibilityLabel(Text("subscriptions.toolbar.a11y.add"))
         .accessibilityIdentifier(identifier)
     }
+}
 
+// MARK: - File import
+
+extension SubscriptionsView {
     /// File picker accepts YAML proper plus `.txt` and unspecified data —
     /// iCloud Drive routinely serves Clash configs uploaded from desktops
     /// where the OS tagged them as `public.plain-text` or just `public.data`,
@@ -401,9 +438,10 @@ private struct AddSubscriptionSheet: View {
     }
 }
 
-/// Edits a subscription's name and update URL only — the YAML body is left
-/// untouched (that's what the pencil / `YamlEditorView` is for). A changed URL
-/// is picked up on the next refresh, not immediately. See issue #182.
+/// Edits a subscription's name, update URL, and auto-update cadence only — the
+/// YAML body is left untouched (that's what the pencil / `YamlEditorView` is
+/// for). A changed URL is picked up on the next refresh, not immediately. See
+/// issue #182.
 private struct EditSubscriptionInfoSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(SubscriptionService.self) private var service
@@ -411,12 +449,14 @@ private struct EditSubscriptionInfoSheet: View {
     @Binding var error: String?
     @State private var name: String
     @State private var url: String
+    @State private var updateInterval: ProfileUpdateInterval
 
     init(profile: Profile, error: Binding<String?>) {
         self.profile = profile
         _error = error
         _name = State(initialValue: profile.name)
         _url = State(initialValue: profile.url)
+        _updateInterval = State(initialValue: profile.updateInterval)
     }
 
     var body: some View {
@@ -433,6 +473,23 @@ private struct EditSubscriptionInfoSheet: View {
                 } footer: {
                     Text("subscriptions.editInfo.footer")
                 }
+                // A cadence needs a URL to fetch, so the picker follows what's
+                // typed in the field rather than what was saved: attaching a
+                // URL to a local import reveals it, clearing one hides it (and
+                // `updateInfo` forces `.manual` to match).
+                if !url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Section {
+                        Picker("subscriptions.editInfo.updateInterval", selection: $updateInterval) {
+                            ForEach(ProfileUpdateInterval.allCases) { interval in
+                                Text(LocalizedStringKey(interval.titleKey)).tag(interval)
+                            }
+                        }
+                        .accessibilityIdentifier("subscriptions.editInfo.updateIntervalPicker")
+                        .accessibilityHint(Text("subscriptions.editInfo.a11y.updateIntervalHint"))
+                    } footer: {
+                        Text("subscriptions.editInfo.updateInterval.footer")
+                    }
+                }
             }
             .navigationTitle("subscriptions.editInfo.nav.title")
             .navigationBarTitleDisplayMode(.inline)
@@ -443,7 +500,12 @@ private struct EditSubscriptionInfoSheet: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("subscriptions.editInfo.button.save") {
                         do {
-                            try service.updateInfo(profile, name: name, url: url)
+                            try service.updateInfo(
+                                profile,
+                                name: name,
+                                url: url,
+                                updateInterval: updateInterval,
+                            )
                             dismiss()
                         } catch {
                             self.error = error.localizedDescription

--- a/MeowTests/Models/ProfileUpdateIntervalTests.swift
+++ b/MeowTests/Models/ProfileUpdateIntervalTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+@testable import meow_ios
+import Testing
+
+/// The auto-update cadence enum and its `Profile` accessor. The cadence is
+/// persisted as a raw string rather than an enum, so the decode path (including
+/// values this build doesn't know) is part of the contract.
+@Suite("ProfileUpdateInterval", .tags(.model))
+struct ProfileUpdateIntervalTests {
+    @Test
+    func `manual never comes due, daily and weekly carry their windows`() {
+        #expect(ProfileUpdateInterval.manual.refreshAfter == nil)
+        #expect(ProfileUpdateInterval.daily.refreshAfter == 86400)
+        #expect(ProfileUpdateInterval.weekly.refreshAfter == 604_800)
+    }
+
+    @Test
+    func `all three options are offered to the picker, manual first`() {
+        #expect(ProfileUpdateInterval.allCases == [.manual, .daily, .weekly])
+    }
+
+    @Test
+    func `each case has a distinct title key`() {
+        let keys = Set(ProfileUpdateInterval.allCases.map(\.titleKey))
+        #expect(keys.count == ProfileUpdateInterval.allCases.count)
+    }
+
+    @Test
+    func `known raw values decode, unknown ones degrade to manual`() {
+        #expect(ProfileUpdateInterval(storedRawValue: "daily") == .daily)
+        #expect(ProfileUpdateInterval(storedRawValue: "weekly") == .weekly)
+        // Written by a newer build, then read back by this one.
+        #expect(ProfileUpdateInterval(storedRawValue: "hourly") == .manual)
+        #expect(ProfileUpdateInterval(storedRawValue: "") == .manual)
+    }
+
+    @Test
+    func `a profile defaults to manual so pre-feature profiles stay quiet`() {
+        let profile = Profile(name: "p", url: "https://example.com/a.yaml", yamlContent: "")
+        #expect(profile.updateInterval == .manual)
+        #expect(profile.updateIntervalRaw == "manual")
+    }
+
+    @Test
+    func `the interval accessor round-trips through the stored raw value`() {
+        let profile = Profile(
+            name: "p",
+            url: "https://example.com/a.yaml",
+            yamlContent: "",
+            updateInterval: .weekly,
+        )
+        #expect(profile.updateIntervalRaw == "weekly")
+
+        profile.updateInterval = .daily
+        #expect(profile.updateIntervalRaw == "daily")
+        #expect(profile.updateInterval == .daily)
+    }
+
+    @Test
+    func `an unknown stored raw value reads back as manual`() {
+        let profile = Profile(name: "p", url: "https://example.com/a.yaml", yamlContent: "")
+        profile.updateIntervalRaw = "fortnightly"
+        #expect(profile.updateInterval == .manual)
+    }
+}

--- a/MeowTests/Services/ProfileAutoUpdaterTests.swift
+++ b/MeowTests/Services/ProfileAutoUpdaterTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+@testable import meow_ios
+import SwiftData
+import Testing
+
+/// `ProfileAutoUpdater` decides *which* profiles are stale (the pure
+/// `isDue`/`dueProfiles` policy) and then hands each one to
+/// `SubscriptionService.refresh(_:)`. Both halves are covered here: the policy
+/// against a frozen clock, and the pass itself against stubbed HTTP.
+///
+/// The timer loop (`start()`/`stop()`) is deliberately untested — it only
+/// sleeps and calls `refreshDueProfiles()`, and a 30-minute tick can't be
+/// exercised without either a fake clock abstraction or a real wait.
+@Suite("ProfileAutoUpdater", .tags(.service))
+struct ProfileAutoUpdaterTests {
+    // MARK: - Cadence policy
+
+    @Test
+    @MainActor
+    func `a manual profile is never due, however stale`() {
+        let now = Date()
+        let profile = makeProfile(interval: .manual, lastUpdated: now.addingTimeInterval(-365 * 86400))
+        #expect(!ProfileAutoUpdater.isDue(profile, at: now))
+    }
+
+    @Test
+    @MainActor
+    func `a daily profile comes due exactly one day after its last update`() {
+        let now = Date()
+        let justUnder = makeProfile(interval: .daily, lastUpdated: now.addingTimeInterval(-86399))
+        let exactly = makeProfile(interval: .daily, lastUpdated: now.addingTimeInterval(-86400))
+        let wellOver = makeProfile(interval: .daily, lastUpdated: now.addingTimeInterval(-3 * 86400))
+
+        #expect(!ProfileAutoUpdater.isDue(justUnder, at: now))
+        #expect(ProfileAutoUpdater.isDue(exactly, at: now))
+        #expect(ProfileAutoUpdater.isDue(wellOver, at: now))
+    }
+
+    @Test
+    @MainActor
+    func `a weekly profile ignores the daily boundary and comes due after seven days`() {
+        let now = Date()
+        let twoDaysOld = makeProfile(interval: .weekly, lastUpdated: now.addingTimeInterval(-2 * 86400))
+        let sevenDaysOld = makeProfile(interval: .weekly, lastUpdated: now.addingTimeInterval(-7 * 86400))
+
+        #expect(!ProfileAutoUpdater.isDue(twoDaysOld, at: now))
+        #expect(ProfileAutoUpdater.isDue(sevenDaysOld, at: now))
+    }
+
+    @Test
+    @MainActor
+    func `a local import is never due — there is no remote to refetch`() {
+        let now = Date()
+        let local = makeProfile(url: "", interval: .daily, lastUpdated: now.addingTimeInterval(-30 * 86400))
+        #expect(!ProfileAutoUpdater.isDue(local, at: now))
+    }
+
+    @Test
+    @MainActor
+    func `a stamp in the future is due rather than frozen`() {
+        // Only reachable via a device clock that was set forward and later
+        // corrected. Refetching restamps `lastUpdated` to now, which unsticks
+        // the cadence instead of stalling it until real time catches up.
+        let now = Date()
+        let skewed = makeProfile(interval: .daily, lastUpdated: now.addingTimeInterval(30 * 86400))
+        #expect(ProfileAutoUpdater.isDue(skewed, at: now))
+    }
+
+    @Test
+    @MainActor
+    func `dueProfiles keeps only the stale ones`() {
+        let now = Date()
+        let stale = makeProfile(interval: .daily, lastUpdated: now.addingTimeInterval(-2 * 86400))
+        let fresh = makeProfile(interval: .daily, lastUpdated: now.addingTimeInterval(-60))
+        let manual = makeProfile(interval: .manual, lastUpdated: now.addingTimeInterval(-2 * 86400))
+
+        let due = ProfileAutoUpdater.dueProfiles(in: [stale, fresh, manual], at: now)
+
+        #expect(due.count == 1)
+        #expect(due.first === stale)
+    }
+
+    // MARK: - A refresh pass
+
+    @Test
+    @MainActor
+    func `a pass refetches the due profile and leaves the others alone`() async throws {
+        let dueURL = "https://example.com/auto-due.yaml"
+        let freshURL = "https://example.com/auto-fresh.yaml"
+        let original = "proxies: []\n"
+        let refreshed = "proxies:\n  - name: refreshed\n    type: direct\n"
+        defer {
+            URLProtocolStub.removeStub(URL(string: dueURL)!)
+            URLProtocolStub.removeStub(URL(string: freshURL)!)
+        }
+        // Both URLs are stubbed, so "fresh wasn't refetched" is a real
+        // assertion about the cadence rather than a missing-stub failure.
+        let session = stubbedSession([
+            dueURL: .init(body: Data(refreshed.utf8)),
+            freshURL: .init(body: Data(refreshed.utf8)),
+        ])
+
+        let now = Date()
+        let harness = try makeUpdater(now: now, session: session)
+        let staleStamp = now.addingTimeInterval(-25 * 3600)
+        let due = makeProfile(url: dueURL, interval: .daily, lastUpdated: staleStamp, yaml: original)
+        let fresh = makeProfile(
+            url: freshURL,
+            interval: .daily,
+            lastUpdated: now.addingTimeInterval(-60),
+            yaml: original,
+        )
+        let manual = makeProfile(url: dueURL, interval: .manual, lastUpdated: staleStamp, yaml: original)
+        for profile in [due, fresh, manual] {
+            harness.context.insert(profile)
+        }
+        try harness.context.save()
+
+        await harness.updater.refreshDueProfiles()
+
+        #expect(due.yamlContent == refreshed)
+        #expect(due.lastUpdated > staleStamp)
+        #expect(fresh.yamlContent == original)
+        #expect(manual.yamlContent == original)
+        // Having been refetched, the profile is quiet again for a day — the
+        // next pass an hour from now must not fetch it a second time.
+        #expect(!ProfileAutoUpdater.isDue(due, at: due.lastUpdated.addingTimeInterval(3600)))
+    }
+
+    @Test
+    @MainActor
+    func `one failing subscription does not stop the others`() async throws {
+        let brokenURL = "https://example.com/auto-broken.yaml"
+        let goodURL = "https://example.com/auto-good.yaml"
+        let original = "proxies: []\n"
+        let refreshed = "proxies:\n  - name: refreshed\n    type: direct\n"
+        defer {
+            URLProtocolStub.removeStub(URL(string: brokenURL)!)
+            URLProtocolStub.removeStub(URL(string: goodURL)!)
+        }
+        let session = stubbedSession([
+            brokenURL: .init(statusCode: 500),
+            goodURL: .init(body: Data(refreshed.utf8)),
+        ])
+
+        let now = Date()
+        let harness = try makeUpdater(now: now, session: session)
+        let staleStamp = now.addingTimeInterval(-8 * 86400)
+        let broken = makeProfile(url: brokenURL, interval: .daily, lastUpdated: staleStamp, yaml: original)
+        let good = makeProfile(url: goodURL, interval: .weekly, lastUpdated: staleStamp, yaml: original)
+        harness.context.insert(broken)
+        harness.context.insert(good)
+        try harness.context.save()
+
+        // The pass must not rethrow — an HTTP 500 on one profile is logged and
+        // skipped, not escalated.
+        await harness.updater.refreshDueProfiles()
+
+        #expect(good.yamlContent == refreshed)
+        #expect(broken.yamlContent == original)
+        // `lastUpdated` only advances on success, so the failed profile is
+        // still due and gets retried on the next pass.
+        #expect(broken.lastUpdated < now.addingTimeInterval(-7 * 86400))
+        #expect(ProfileAutoUpdater.isDue(broken, at: now))
+    }
+
+    // MARK: - Harness
+
+    private struct Harness {
+        let updater: ProfileAutoUpdater
+        let context: ModelContext
+    }
+
+    @MainActor
+    private func makeProfile(
+        url: String = "https://example.com/auto.yaml",
+        interval: ProfileUpdateInterval,
+        lastUpdated: Date,
+        yaml: String = "proxies: []\n",
+    ) -> Profile {
+        Profile(
+            name: "p",
+            url: url,
+            yamlContent: yaml,
+            lastUpdated: lastUpdated,
+            updateInterval: interval,
+        )
+    }
+
+    /// In-memory store plus a temp-directory active-config file and a private
+    /// `UserDefaults` suite — never the real App Group container.
+    @MainActor
+    private func makeUpdater(now: Date, session: URLSession) throws -> Harness {
+        let container = try ModelContainer(
+            for: Profile.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true),
+        )
+        let context = ModelContext(container)
+        let dir = FileManager.default.temporaryDirectory
+            .appending(path: "ProfileAutoUpdaterTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+        guard let defaults = UserDefaults(suiteName: "ProfileAutoUpdaterTests-\(UUID().uuidString)") else {
+            throw HarnessError.defaultsSuiteUnavailable
+        }
+        let service = SubscriptionService(
+            modelContext: context,
+            session: session,
+            activeConfigDirectory: { dir },
+            activeConfigURL: { dir.appending(path: "config.yaml") },
+            preferences: defaults,
+        )
+        let updater = ProfileAutoUpdater(modelContext: context, service: service, now: { now })
+        return Harness(updater: updater, context: context)
+    }
+
+    private func stubbedSession(_ responses: [String: URLProtocolStub.Response]) -> URLSession {
+        for (url, response) in responses {
+            URLProtocolStub.stub(URL(string: url)!, with: response)
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolStub.self]
+        return URLSession(configuration: config)
+    }
+}
+
+private enum HarnessError: Error {
+    case defaultsSuiteUnavailable
+}

--- a/MeowTests/Services/SubscriptionServiceTests.swift
+++ b/MeowTests/Services/SubscriptionServiceTests.swift
@@ -69,7 +69,12 @@ struct SubscriptionServiceTests {
         context.insert(profile)
         try context.save()
 
-        try service.updateInfo(profile, name: "New Name", url: "https://example.com/b.yaml")
+        try service.updateInfo(
+            profile,
+            name: "New Name",
+            url: "https://example.com/b.yaml",
+            updateInterval: .manual,
+        )
 
         #expect(profile.name == "New Name")
         #expect(profile.url == "https://example.com/b.yaml")
@@ -93,11 +98,40 @@ struct SubscriptionServiceTests {
         try context.save()
 
         // Attaching a URL to a previously local-only import promotes it.
-        try service.updateInfo(profile, name: "  Trimmed  ", url: "  https://example.com/c.yaml  ")
+        try service.updateInfo(
+            profile,
+            name: "  Trimmed  ",
+            url: "  https://example.com/c.yaml  ",
+            updateInterval: .daily,
+        )
 
         #expect(profile.name == "Trimmed")
         #expect(profile.url == "https://example.com/c.yaml")
         #expect(profile.yamlContent == body)
+        #expect(profile.updateInterval == .daily)
+    }
+
+    @Test
+    @MainActor
+    func `updateInfo forces manual cadence when the URL is cleared`() throws {
+        let harness = try makeService()
+        let service = harness.service
+        let context = harness.context
+        let profile = Profile(
+            name: "Sub",
+            url: "https://example.com/a.yaml",
+            yamlContent: "proxies: []\n",
+            updateInterval: .weekly,
+        )
+        context.insert(profile)
+        try context.save()
+
+        // Cadence is meaningless without a URL to refetch, and the editor
+        // hides the picker in that state — so it must not survive the save.
+        try service.updateInfo(profile, name: "Sub", url: "  ", updateInterval: .weekly)
+
+        #expect(profile.url.isEmpty)
+        #expect(profile.updateInterval == .manual)
     }
 
     // MARK: - Plain-HTTP config URLs are rejected with an explanation (ATS blocks the fetch)
@@ -122,7 +156,12 @@ struct SubscriptionServiceTests {
         try harness.context.save()
 
         #expect(throws: SubscriptionError.insecureHTTPURL) {
-            try harness.service.updateInfo(profile, name: "New", url: "  HTTP://example.com/a.yaml ")
+            try harness.service.updateInfo(
+                profile,
+                name: "New",
+                url: "  HTTP://example.com/a.yaml ",
+                updateInterval: profile.updateInterval,
+            )
         }
         #expect(profile.name == "Old")
         #expect(profile.url == "https://example.com/a.yaml")

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Latest version: **v1.4.0** (July 2026) — dark mode across the app, QR-code
 export for `ss://` profiles and subscription URLs, and a refreshed cat
 branding. Since then, `main` also picked up a wake-from-idle reliability
 fix — after sleep/wake the tunnel probes its data path and only restarts
-when the probe fails — plus a meow-rs engine bump to 0.18.0 and a leading
-swipe menu for refreshing individual subscriptions. See the
+when the probe fails — plus a meow-rs engine bump to 0.18.0, a leading
+swipe menu for refreshing individual subscriptions, and a per-profile
+auto-update cadence (never / every day / every week) with refresh now on
+both swipe directions. See the
 [release notes](https://github.com/meow-rs/meow-ios/releases) for earlier
 per-version changelogs.
 


### PR DESCRIPTION
Adds an **Auto-update** setting to each subscription — **Never / Every day / Every week** — and puts **Refresh on the left-swipe (trailing) edge** as well as the existing right-swipe one.

## Cadence

- `ProfileUpdateInterval` (`manual` / `daily` / `weekly`) is persisted on `Profile` as a **raw string**, mirroring `selectedProxiesJSON`: an unrecognised value decodes to `.manual` rather than failing the store open, and the defaulted property is what lets SwiftData migrate existing stores in place. Profiles that predate the setting read back as `.manual`, so **nothing starts fetching on its own after an upgrade** — the user opts in per profile.
- `ProfileAutoUpdater` runs a due-check on foreground, then every 30 min while the app stays there. There's no background-refresh entitlement (`UIBackgroundModes` is spent on the tunnel), so "every day" means *"the first foreground pass at or after the due time"* — which is all a subscription needs, since the app process is the only writer of `config.yaml`.
- Bookkeeping rides entirely on the existing `Profile.lastUpdated`, so a **manual refresh also postpones the automatic one** and there's no second timestamp that can drift out of sync. `lastUpdated` only advances on success, so a failed profile stays due and is retried next pass; one dead URL is logged and skipped rather than stopping the others.
- A cadence is meaningless without a URL to fetch, so the three states stay consistent: the picker only appears once the URL field is non-empty, URL-less profiles are never due, and `updateInfo` forces `.manual` when the URL is cleared.
- The timer is started/stopped on scene phase. Only `.background` stops it — `.inactive` fires for transient interruptions (notification centre, app-switcher preview), where tearing the timer down and rebuilding it would run a due-check on every glance at the app.

## Swipe

- **Behaviour change worth a second opinion:** Refresh is declared *first* on the trailing edge, which makes it — not Delete — what a **full** left-swipe triggers. Rationale: deleting the selected profile also clears `config.yaml`, which is far too destructive to sit behind an accidental flick. Delete is still there, one tap away on a partial swipe. If you'd rather keep full-swipe-to-delete, moving the `Button(role: .destructive)` back above the refresh button is the whole change.
- Rows that auto-update now carry a clock badge naming the cadence — without it the setting is invisible outside the edit sheet.

## Also

Moves the file-import helpers (`yamlContentTypes` / `handleImport` / `readSecurityScoped`) into an extension. The new row subtitle pushed `SubscriptionsView`'s type body from 291 to 314 code lines, past swiftlint's `type_body_length` warning of 300 (an **error** under `--strict`); extension bodies don't count toward it, which is the same reason the QR-export extension already exists. The body is 269 now.

## Tests

- `ProfileUpdateIntervalTests` — window values, `allCases` order, decode fallback for unknown/empty raw values, `Profile` defaults to `.manual`, accessor round-trip.
- `ProfileAutoUpdaterTests` — cadence boundaries (86399 not due vs 86400 due), weekly ignoring the daily boundary, URL-less never due, a backwards-corrected clock (future stamp) treated as due rather than frozen, plus two refresh passes against stubbed HTTP: one asserting the fresh and manual profiles aren't refetched, one asserting a 500 on one profile doesn't stop the other and leaves it still-due.
- `SubscriptionServiceTests` — existing `updateInfo` cases extended for the new parameter, plus a new case pinning "clearing the URL forces `.manual`".

## Verification — full CI, green

This PR went through a full remote CI run rather than a CLAUDE.md **Path B** admin bypass, because nothing could be verified locally: the authoring environment is a Linux box with no Swift toolchain (`xcodebuild`, `swiftlint`, `swiftformat`, `swift` all absent).

[Run 30528158016](https://github.com/madeye/meow-ios/actions/runs/30528158016) — all 7 jobs pass: `lint`, `build-core`, `unit-test`, `ui-test`, `archive`, `aux-rust-geosite-mrs-builder`, `aux-rust-macos-utun-harness`. Both new suites report clean (`Suite "ProfileAutoUpdater" passed`, `Suite "ProfileUpdateInterval" passed`).

The first push failed `lint` on one thing hand-checking couldn't catch: swiftformat's `redundantSendable` wanted the explicit `Sendable` off `ProfileUpdateInterval` (non-public enums get it implicitly; the repo's other explicit conformances are all protocols or `public` MeowShared types). Fixed and amended. swiftlint was clean on the first try.

What was verified by hand before pushing, since the compiler wasn't available:

- [x] Line length ≤ 120 on every touched file; `file_length` (max 521) and `type_body_length` (max 269) under the configured thresholds; longest function body 41 lines vs the 50 warning.
- [x] Localization parity re-checked with a script: 321 keys in each of `en.lproj` / `zh-Hans.lproj`, zero missing / orphaned / empty values, zero format-specifier mismatches.
- [x] Every `updateInfo(` and `Profile(` callsite in the repo audited for source compatibility (the new `Profile` parameter is defaulted and trailing).
- [x] Braces balanced; trailing-comma and multi-line-string-literal styles match existing patterns already passing CI (e.g. `AppModel.swift:159`).
- [x] `main`'s baseline is green, and this branch is rebased onto the current tip (`3cd97d9`) — the localization diff sits alongside the new app-icon keys without conflict, and parity was re-checked after the rebase.

**No XCUITest was added** — I can't run a simulator here, and a UI test I can't execute is more likely to turn CI red than to catch anything. Coverage is unit-level only. The picker, the trailing-swipe button, and the badge carry accessibility identifiers (`subscriptions.editInfo.updateIntervalPicker`, `subscriptions.row.refreshTrailing`, `subscriptions.row.autoUpdateBadge`) so a UI test can be added later without touching the views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
