### PR TITLE
feat(tun2socks): bump lwip to single-owner core, delete the LWIP_MUTEX era

### DIFF
--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -924,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1428,7 +1428,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1799,8 +1799,7 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 [[package]]
 name = "lwip"
 version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7051f756d2ad2ee15f003ce2178646908a9d50bc966bd37dcd1eea8ce2bb13"
+source = "git+https://github.com/madeye/lwip?rev=bd62769574bc828b6c76cd62777d7490a140249d#bd62769574bc828b6c76cd62777d7490a140249d"
 dependencies = [
  "bindgen 0.69.5",
  "bytes",
@@ -1809,6 +1808,7 @@ dependencies = [
  "log",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2264,7 +2264,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2542,7 +2542,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2579,9 +2579,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2817,7 +2817,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3192,7 +3192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3303,7 +3303,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4046,7 +4046,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4119,15 +4119,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/core/rust/macos-utun-harness/Cargo.toml
+++ b/core/rust/macos-utun-harness/Cargo.toml
@@ -24,3 +24,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
+
+# meow-ios-ffi's lwip patch must be repeated here: [patch] sections only
+# apply from the manifest of the workspace being built, so without this the
+# harness silently resolves UPSTREAM lwip 0.3.15 from crates.io — none of
+# the fork's fixes, a different netstack than the one that ships on-device.
+# Keep this rev in lockstep with core/rust/meow-ios-ffi/Cargo.toml.
+[patch.crates-io]
+lwip = { git = "https://github.com/madeye/lwip", rev = "bd62769574bc828b6c76cd62777d7490a140249d" }

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -876,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1380,7 +1380,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1750,7 +1750,7 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 [[package]]
 name = "lwip"
 version = "0.3.15"
-source = "git+https://github.com/madeye/lwip?rev=78566b68b453f079cca42860f037de47248ec96e#78566b68b453f079cca42860f037de47248ec96e"
+source = "git+https://github.com/madeye/lwip?rev=bd62769574bc828b6c76cd62777d7490a140249d#bd62769574bc828b6c76cd62777d7490a140249d"
 dependencies = [
  "bindgen 0.69.5",
  "bytes",
@@ -1759,6 +1759,7 @@ dependencies = [
  "log",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2191,7 +2192,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2454,7 +2455,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2491,9 +2492,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2729,7 +2730,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2742,7 +2743,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3221,7 +3222,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3963,7 +3964,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4036,15 +4037,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -123,28 +123,24 @@ codegen-units = 1
 strip = "symbols"
 panic = "abort"
 
-# Patched lwip: upstream 0.3.15's `Stream::poll_next` impls
-# (TcpListenerImpl / NetStackImpl / UdpSocket) mutate shared state
-# (queue/rx/waker) WITHOUT holding LWIP_MUTEX, while the lwIP callbacks
-# (tcp_accept_cb / output / udp_recv_cb) mutate the same state under the
-# lock. On the 2-worker runtime this races: a concurrent VecDeque realloc
-# in TcpListenerImpl::queue corrupts Box<TcpStreamImpl> ownership and hands
-# out a stream whose mpsc Receiver is freed -> SIGSEGV (use-after-free) in
-# TcpStreamImpl::poll_read under sustained TCP-flow churn (~115 flows/s,
-# crashes ~55s). The fork acquires LWIP_MUTEX at the top of each poll_next.
-# Verified: 20k+ flows over 180s at full churn on 2 workers, no crash, RSS
-# flat.
+# Patched lwip. rev bd627695 replaces the upstream shared-state-plus-
+# LWIP_MUTEX design with a single-owner core: one task (spawned by
+# NetStack::with_buffer_size, so it lands on the tun2socks runtime) makes
+# every lwIP C call, and TcpStream/TcpListener/UdpSocket/NetStack are pure
+# channel endpoints. There is no lock anymore, which structurally removes
+# the wedge classes the earlier patch revs fixed piecemeal or worked
+# around: the 0.3.15 poll_next UAF under flow churn (handles no longer
+# touch C state at all), the spin-lock livelock family
+# (project_lwip_timer_livelock), the guard-held-across-Pending deadlock,
+# and hand-rolled waker bugs (poll_flush Pending-without-waker). Earlier
+# behavioral fixes are preserved in the rewrite: frames are dropped (not
+# deadlocked) on pbuf_alloc failure, and close-after-tx-shutdown sets
+# TF_RXCLOSED so FIN_WAIT_2 pcbs reap in 20 s instead of leaking.
 #
-# rev 5adf5e24 adds two idle-blackout fixes on top (2026-06-06 incident:
-# tunnel stops redirecting traffic after hours of idle):
-#   1. NetStackImpl::poll_flush returned Poll::Pending without a waker on
-#      pbuf_alloc failure, permanently deadlocking the single task that
-#      drives both stack directions. Now drops the frame (IP is lossy).
-#   2. TcpStreamImpl::drop leaked TX-half-closed pcbs in FIN_WAIT_1/2
-#      forever (TF_RXCLOSED unset -> lwIP slowtmr never reaps them); now
-#      tcp_close()s so the 20 s FIN_WAIT_2 timeout applies.
+# Consumer contract: one live stack generation per process; run_tun2socks
+# awaits NetStack::core_done() at teardown to enforce it.
 #
-# Upstream all of this to https://github.com/ssrlive/lwip and drop the
-# patch once a fixed release ships.
+# Upstream to https://github.com/ssrlive/lwip and drop the patch if they
+# take it.
 [patch.crates-io]
-lwip = { git = "https://github.com/madeye/lwip", rev = "78566b68b453f079cca42860f037de47248ec96e" }
+lwip = { git = "https://github.com/madeye/lwip", rev = "bd62769574bc828b6c76cd62777d7490a140249d" }

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -857,6 +857,13 @@ async fn run_tun2socks(
     let (mut stack, mut tcp_listener, udp_socket) =
         lwip::NetStack::with_buffer_size(1024, 256).map_err(|e| io::Error::other(e.to_string()))?;
 
+    // Flips once the single-owner lwip core task has finished its
+    // deterministic teardown (every pcb closed, hooks cleared). Awaited at
+    // the end of this generation so the next `start()`'s
+    // wait-for-predecessor covers the core task too — lwIP's pcb lists are
+    // process globals, and two live cores would corrupt them.
+    let mut lwip_core_done = stack.core_done();
+
     let (udp_write, mut udp_read) = udp_socket.split();
 
     let (udp_reply_tx, mut udp_reply_rx) = mpsc::channel::<UdpMsg>(256);
@@ -1073,26 +1080,32 @@ async fn run_tun2socks(
         }
     }
 
-    // Await cancellation of lwIP-owning tasks before this outer generation
-    // finishes. Dropping JoinHandles after `abort()` would detach those tasks,
-    // letting the next `start()` build a fresh NetStack while old NetStack,
-    // TcpListener, UdpSocket, or TcpStream drops are still mutating lwIP globals
-    // on another runtime worker.
+    // Await cancellation of our forwarding tasks before this outer generation
+    // finishes. Handle drops no longer touch lwIP state (the single-owner
+    // core owns every C call), but joining after `abort()` still matters:
+    // detached tasks would keep pumping channels — and holding lwip handles —
+    // while the next generation spins up.
     abort_and_join("tcp accept", tcp_accept_handle).await;
 
     close_all_tcp_flows();
     tcp_flow_tasks.close();
     tcp_flow_tasks.wait().await;
 
-    // UdpSocket::drop in the pinned lwip fork does not take LWIP_MUTEX, so keep
-    // the socket alive until both possible concurrent users have stopped: the
-    // UDP writer's send_to path and the stack driver's input/callback path.
     abort_and_join("udp writer", udp_writer_handle).await;
     abort_and_join("stack driver", stack_handle).await;
     abort_and_join("udp accept", udp_accept_handle).await;
     abort_and_join("egress", egress_handle).await;
     abort_and_join("tcp idle sweeper", tcp_idle_sweeper_handle).await;
     drop(udp_reply_tx);
+
+    // Every lwip handle (stack, listener, udp halves, streams) is dropped by
+    // now, which triggers the core task's teardown of every pcb. Wait for it
+    // to finish so two cores never overlap on the process-global lwIP state;
+    // a wedged core surfaces via `start()`'s "still waiting for previous
+    // instance teardown" logging rather than as silent corruption.
+    if lwip_core_done.wait_for(|done| *done).await.is_err() {
+        logging::bridge_log("tun2socks: lwip core exited without done signal");
+    }
 
     logging::bridge_log("tun2socks: exiting");
     Ok(())


### PR DESCRIPTION
## What

Pins [madeye/lwip `bd627695`](https://github.com/madeye/lwip/commit/bd62769574bc828b6c76cd62777d7490a140249d) (branch `feature/single-owner-core`): the fork's Rust layer is restructured from shared-state-plus-global-spin-lock to lwIP's own supported threading model — a **single core task** (spawned on the tun2socks runtime) makes every lwIP C call, and `NetStack`/`TcpStream`/`TcpListener`/`UdpSocket` handles become pure channel endpoints, safe to poll or drop from any thread/runtime.

## Why

Every lock-related production wedge family goes away structurally, not piecemeal:
- spin-livelock on the small worker pool (`project_lwip_timer_livelock`, recurred 2026-06-15)
- guard-legally-held-across-`Pending` deadlock (lock taken across `poll_recv` in the old stream paths)
- cross-runtime QoS/priority inversion (TCP flow tasks on `meow-engine` no longer touch the C core)
- the 0.3.15 `poll_next` UAF-under-churn class (handle `Drop` never touches C state; closing the per-stream channel *is* the ordered close signal)
- hand-rolled waker bugs (the `poll_flush` Pending-without-waker 2026-06-06 blackout shape) — replaced by tokio channel wakers

Preserved behavior from earlier fork revs: frames dropped (not deadlocked) on `pbuf_alloc` failure; close-after-tx-shutdown sets `TF_RXCLOSED` so FIN_WAIT_2 pcbs reap in 20 s.

## FFI changes

- `run_tun2socks` grabs `NetStack::core_done()` and awaits it after task teardown, so generation serialization now covers the core task's deterministic pcb teardown (one-live-stack contract). A wedged core surfaces via the existing "still waiting for previous instance teardown" logging.
- **Harness fix:** `macos-utun-harness` had no `[patch.crates-io]` — it was silently resolving *upstream* lwip 0.3.15 from crates.io and stress-testing a different netstack than ships on-device. Patch entry added, both lockfiles regenerated.

## Fork-side notes (for review over there)

- New `tests/udp_loopback.rs`: full data path (ingress frame → `udp_recv_cb` → handle → `send_to` → egress frame) across two sequential stack generations.
- `tcp_err_cb` means lwIP already freed the pcb; a shared `dead: Arc<AtomicBool>` is set synchronously in the callback and checked before every C call, closing the race where a `Recved`/`Kick` command queued ahead of `PcbErr` would hit the dangling pointer.

## Local CI attestation (Path B)

- [x] `swiftformat --lint .` — 0 violations
- [x] `swiftlint --strict` — 0 violations
- [x] `cargo test` in `core/rust/meow-ios-ffi` — 61/61 green; `cargo clippy --all-targets` + `cargo fmt --check` clean
- [x] `cargo test --locked` in `core/rust/macos-utun-harness` — green against the fork
- [x] fork: `cargo test` (incl. new e2e), clippy, fmt — clean
- [x] `scripts/build-rust.sh` — xcframework builds
- [x] `xcodebuild test … -only-testing:MeowTests` (iPhone 17 sim, `-testLanguage en`) — TEST SUCCEEDED, run twice (against both fork revs)
- [x] `git diff origin/main...HEAD --stat` verified — only the 5 intended files

## Not done yet (deliberately, before any TestFlight build)

- meow-utun live soak (Tart VM `stress_rss` + the flow-churn scenario that SIGSEGV'd upstream 0.3.15)
- on-device overnight sleep/wake soak

Recommend full remote CI on this one rather than admin-bypass — it swaps the netstack's concurrency model.