### PR TITLE
chore(release): regenerate Info.plists for build 2026073101

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026073001</string>
+	<string>2026073101</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>2026073001</string>
+	<string>2026073101</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Two-line mechanical fix: PR #354 bumped project.yml but skipped the generate-xcodeproj.sh regen, so App/Info.plist + PacketTunnel/Info.plist still carried 2026073001. The TestFlight archive therefore uploaded as an ASC-auto-bumped 2026073002 (will be expired once 2026073101 is up).

## Path B attestation
- [x] `swiftformat --lint .` → 0 violations
- [x] `swiftlint --strict` → 0 violations
- [x] Test suites: full remote CI (all 7 jobs) passed on PR #354 against identical Swift/Rust sources; this diff is the 2-line generated-plist version sync only. The App Store archive build (running next) compiles the full app against this exact tree.
- [x] `git diff origin/main...HEAD --stat` verified: exactly App/Info.plist + PacketTunnel/Info.plist, 1 line each.