### PR TITLE
fix(subscriptions): reject plain-http config URLs with a clear error

### DIFF
--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -100,6 +100,7 @@
 "subscriptions.toolbar.addFromURL" = "Add from URL";
 "subscriptions.toolbar.importFromFile" = "Import from iCloud Drive…";
 "subscriptions.import.invalidEncoding" = "The selected file isn't valid UTF-8 text.";
+"subscriptions.error.plainHTTP" = "This config URL uses plain HTTP. iOS blocks insecure (non-HTTPS) connections, so the config can't be downloaded. Please use an https:// URL instead.";
 "subscriptions.empty.title" = "No configs yet";
 "subscriptions.empty.description" = "Tap + to add a Mihomo or Clash config URL.";
 "subscriptions.empty.importFile" = "Import File";

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -106,6 +106,7 @@
 "subscriptions.toolbar.addFromURL" = "从 URL 添加";
 "subscriptions.toolbar.importFromFile" = "从 iCloud 云盘导入…";
 "subscriptions.import.invalidEncoding" = "所选文件不是有效的 UTF-8 文本。";
+"subscriptions.error.plainHTTP" = "该配置链接使用未加密的 HTTP。iOS 会拦截非 HTTPS 连接,无法下载配置,请改用 https:// 链接。";
 "subscriptions.empty.title" = "暂无配置";
 "subscriptions.empty.description" = "点击右上角的 + 添加 Mihomo 或 Clash 配置链接。";
 "subscriptions.empty.importFile" = "导入文件";

--- a/App/Sources/Services/DeepLinkImportConfirmation.swift
+++ b/App/Sources/Services/DeepLinkImportConfirmation.swift
@@ -30,9 +30,10 @@ struct DeepLinkImportConfirmation: Identifiable, Equatable {
         link.name
     }
 
-    /// Plain HTTP is still accepted (some subscription hosts don't offer
-    /// TLS), but the confirmation must call it out prominently — the
-    /// profile can be tampered with in transit.
+    /// Plain-HTTP links reach the confirmation sheet (so the user learns
+    /// why they won't work) but the actual import is rejected by
+    /// `SubscriptionService.rejectPlainHTTP` — ATS blocks cleartext HTTP,
+    /// so the fetch could never succeed anyway.
     var isInsecure: Bool {
         link.subscriptionURL.scheme?.lowercased() == "http"
     }

--- a/App/Sources/Services/SubscriptionService.swift
+++ b/App/Sources/Services/SubscriptionService.swift
@@ -137,8 +137,12 @@ final class SubscriptionService {
     /// config is left as-is here. Attaching a URL to a previously local-only
     /// import (empty `url`) promotes it to a refreshable subscription.
     func updateInfo(_ profile: Profile, name: String, url: String) throws {
+        let trimmedURL = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedURL.isEmpty {
+            try Self.rejectPlainHTTP(trimmedURL)
+        }
         profile.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        profile.url = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        profile.url = trimmedURL
         try modelContext.save()
     }
 
@@ -213,7 +217,19 @@ final class SubscriptionService {
 
     // MARK: - Fetch + normalize
 
+    /// Rejects plain-http config URLs up front. ATS
+    /// (`NSAllowsArbitraryLoads` = false in `App/Info.plist`) blocks
+    /// cleartext HTTP in the app process, so the fetch could only ever fail
+    /// with an opaque `NSURLError` — tell the user why instead.
+    static func rejectPlainHTTP(_ url: String) throws {
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.lowercased().hasPrefix("http://") {
+            throw SubscriptionError.insecureHTTPURL
+        }
+    }
+
     private func fetchAndNormalize(url: String) async throws -> String {
+        try Self.rejectPlainHTTP(url)
         guard let remote = URL(string: url) else { throw SubscriptionError.invalidURL }
         var request = URLRequest(url: remote)
         // Most subscription panels gate the served proxy list on User-Agent —
@@ -247,11 +263,26 @@ final class SubscriptionService {
     }
 }
 
-enum SubscriptionError: Error {
+enum SubscriptionError: Error, Equatable {
     case invalidURL
+    case insecureHTTPURL
     case http(status: Int)
     case decodeFailed
     case conversionFailed(String)
+}
+
+extension SubscriptionError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .insecureHTTPURL:
+            String(
+                localized: "subscriptions.error.plainHTTP",
+                comment: "Shown when a config URL uses http:// — iOS ATS blocks cleartext connections",
+            )
+        case .invalidURL, .http, .decodeFailed, .conversionFailed:
+            nil
+        }
+    }
 }
 
 enum SubscriptionFormat {

--- a/MeowTests/Security/URLValidationTests.swift
+++ b/MeowTests/Security/URLValidationTests.swift
@@ -11,8 +11,11 @@ struct URLValidationTests {
     }
 
     @Test(.disabled("blocked on validator"))
-    func `accepts http URLs with warning`() {
-        // #expect(SubscriptionURL.validate("http://example.com") == .insecureHttp)
+    func `rejects plain-http URLs`() {
+        // Covered today by `SubscriptionService.rejectPlainHTTP` (ATS blocks
+        // cleartext HTTP, so http:// links are rejected with an explanation —
+        // see SubscriptionServiceTests). A future standalone validator should
+        // keep rejecting: SubscriptionURL.validate("http://example.com") == .insecureHttp
     }
 
     @Test(.disabled("blocked on validator"))

--- a/MeowTests/Services/SubscriptionServiceTests.swift
+++ b/MeowTests/Services/SubscriptionServiceTests.swift
@@ -100,6 +100,48 @@ struct SubscriptionServiceTests {
         #expect(profile.yamlContent == body)
     }
 
+    // MARK: - Plain-HTTP config URLs are rejected with an explanation (ATS blocks the fetch)
+
+    @Test
+    @MainActor
+    func `add rejects a plain-http URL before touching the network`() async throws {
+        let harness = try makeService()
+
+        await #expect(throws: SubscriptionError.insecureHTTPURL) {
+            _ = try await harness.service.add(name: "Airport", url: "http://example.com/sub.yaml")
+        }
+        #expect(try harness.context.fetch(FetchDescriptor<Profile>()).isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func `updateInfo rejects a plain-http URL and leaves the profile untouched`() throws {
+        let harness = try makeService()
+        let profile = Profile(name: "Old", url: "https://example.com/a.yaml", yamlContent: "mixed-port: 7890\n")
+        harness.context.insert(profile)
+        try harness.context.save()
+
+        #expect(throws: SubscriptionError.insecureHTTPURL) {
+            try harness.service.updateInfo(profile, name: "New", url: "  HTTP://example.com/a.yaml ")
+        }
+        #expect(profile.name == "Old")
+        #expect(profile.url == "https://example.com/a.yaml")
+    }
+
+    @Test
+    @MainActor
+    func `refresh rejects a stored plain-http URL`() async throws {
+        let harness = try makeService()
+        let profile = Profile(name: "Legacy", url: "http://example.com/legacy.yaml", yamlContent: "proxies: []\n")
+        harness.context.insert(profile)
+        try harness.context.save()
+
+        await #expect(throws: SubscriptionError.insecureHTTPURL) {
+            try await harness.service.refresh(profile)
+        }
+        #expect(profile.yamlContent == "proxies: []\n")
+    }
+
     // MARK: - #289: refresh keeps config.yaml in sync only for the selected profile
 
     @Test


### PR DESCRIPTION
## Problem

User report: http:// 机场订阅无法添加。Root cause: ATS (`NSAllowsArbitraryLoads` = false in `App/Info.plist`) blocks cleartext HTTP in the app process, so the subscription fetch can only fail with an opaque `NSURLError` — the user never learns why.

## Fix

Detect plain-http config URLs up front and fail with a localized explanation (use https:// instead):

- `SubscriptionService.rejectPlainHTTP` — case-insensitive `http://` prefix check after trimming.
- Wired into `fetchAndNormalize` (covers **add** and **refresh**, including legacy stored http URLs) and `updateInfo` (**edit**, non-empty URLs only so local-only profiles stay valid).
- New `SubscriptionError.insecureHTTPURL` + `LocalizedError` conformance; en + zh-Hans strings. Existing error-alert wiring in `SubscriptionsView` / edit sheet surfaces it as-is.
- Deep-link imports (`meow://connect?url=http://…`) still reach the confirmation sheet but the import action now fails with the same clear error; stale doc comment updated.
- Updated the disabled `URLValidationTests` placeholder that claimed http should be "accepted with warning".

## Path B attestation (local CI green)

1. `swiftformat --lint .` → 0/127 files require formatting. ✅
2. `swiftlint --strict` → 0 violations in 113 files. ✅
3. `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests -testLanguage en` → 214 tests in 36 suites passed (includes 3 new plain-http rejection tests, verified individually green). ✅
4. `git diff origin/main...HEAD --stat` → 6 files (SubscriptionService, DeepLinkImportConfirmation, 2× Localizable.strings, 2× test files), no accidental additions. ✅

No Rust / project.yml / workflow changes.