### PR TITLE
chore(deps): bump lwip pin to 5f6f0dfe (tvOS build support + sim SDK fix)

### DIFF
--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -924,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1799,7 +1799,7 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 [[package]]
 name = "lwip"
 version = "0.3.15"
-source = "git+https://github.com/madeye/lwip?rev=bd62769574bc828b6c76cd62777d7490a140249d#bd62769574bc828b6c76cd62777d7490a140249d"
+source = "git+https://github.com/madeye/lwip?rev=5f6f0dfe025c967157ff328d94efe488852d8755#5f6f0dfe025c967157ff328d94efe488852d8755"
 dependencies = [
  "bindgen 0.69.5",
  "bytes",
@@ -2264,7 +2264,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3192,7 +3192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3303,7 +3303,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4046,7 +4046,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/macos-utun-harness/Cargo.toml
+++ b/core/rust/macos-utun-harness/Cargo.toml
@@ -31,4 +31,4 @@ ctrlc = "3"
 # the fork's fixes, a different netstack than the one that ships on-device.
 # Keep this rev in lockstep with core/rust/meow-ios-ffi/Cargo.toml.
 [patch.crates-io]
-lwip = { git = "https://github.com/madeye/lwip", rev = "bd62769574bc828b6c76cd62777d7490a140249d" }
+lwip = { git = "https://github.com/madeye/lwip", rev = "5f6f0dfe025c967157ff328d94efe488852d8755" }

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1750,7 +1750,7 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 [[package]]
 name = "lwip"
 version = "0.3.15"
-source = "git+https://github.com/madeye/lwip?rev=bd62769574bc828b6c76cd62777d7490a140249d#bd62769574bc828b6c76cd62777d7490a140249d"
+source = "git+https://github.com/madeye/lwip?rev=5f6f0dfe025c967157ff328d94efe488852d8755#5f6f0dfe025c967157ff328d94efe488852d8755"
 dependencies = [
  "bindgen 0.69.5",
  "bytes",
@@ -2192,7 +2192,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2743,7 +2743,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3111,7 +3111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3222,7 +3222,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3964,7 +3964,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -123,7 +123,11 @@ codegen-units = 1
 strip = "symbols"
 panic = "abort"
 
-# Patched lwip. rev bd627695 replaces the upstream shared-state-plus-
+# Patched lwip. rev 5f6f0dfe = the bd627695 single-owner core plus two
+# build.rs-only cherry-picks from the rust branch (tvOS SDK/bindgen support
+# and correct simulator detection for aarch64-apple-ios-sim, which
+# previously built the simulator slice against the device SDK; plus the
+# Windows bcrypt link fix). rev bd627695 replaces the upstream shared-state-plus-
 # LWIP_MUTEX design with a single-owner core: one task (spawned by
 # NetStack::with_buffer_size, so it lands on the tun2socks runtime) makes
 # every lwIP C call, and TcpStream/TcpListener/UdpSocket/NetStack are pure
@@ -143,4 +147,4 @@ panic = "abort"
 # Upstream to https://github.com/ssrlive/lwip and drop the patch if they
 # take it.
 [patch.crates-io]
-lwip = { git = "https://github.com/madeye/lwip", rev = "bd62769574bc828b6c76cd62777d7490a140249d" }
+lwip = { git = "https://github.com/madeye/lwip", rev = "5f6f0dfe025c967157ff328d94efe488852d8755" }


### PR DESCRIPTION
Advances the `madeye/lwip` pin from `bd627695` to `5f6f0dfe` on `feature/single-owner-core`. The two new commits are **build.rs-only** cherry-picks from lwip PR [madeye/lwip#2](https://github.com/madeye/lwip/pull/2) (thanks @gengjiawen) — the single-owner core itself is untouched:

- **tvOS SDK/bindgen support + correct simulator detection.** Simulator detection moves from `arch == x86_64` to the `-sim` triple suffix. This fixes a real latent issue for us: `aarch64-apple-ios-sim` previously compiled the lwIP C sources *and* ran bindgen against the **device** SDK (`iphoneos`), so our simulator xcframework slice was built against device settings.
- **bcrypt link on Windows** — inert for our targets; taken to keep `build.rs` byte-identical between lwip's `rust` and `feature/single-owner-core` branches so future cherry-picks apply cleanly.

Both `Cargo.lock`s regenerated via `cargo update -p lwip`; the `macos-utun-harness` lockfile is bumped in sync (the PR #317 lesson) and passes `cargo check --locked`. The small `windows-sys 0.61.2 → 0.60.2` reference churn in the locks is cargo's own re-resolution output; `windows-sys` never compiles for iOS/macOS targets.

## Local verification (not a Path B attestation — see below)

- `swiftformat --lint .` → 0 violations
- `swiftlint --strict` → 0 violations
- `scripts/build-rust.sh` → device + sim slices built against the new rev, xcframework written
- `cargo test` in `core/rust/meow-ios-ffi` → 61 passed, 0 failed
- `cargo check --locked` in `core/rust/macos-utun-harness` → clean
- `xcodebuild test … -only-testing:MeowTests -testLanguage en` (iPhone 17 sim) → **208/214 passed; the 6 failures are the known-environmental Shadowsocks bootstrap-DNS tests** (`load_config_from_str (validation)` signature; UDP/53 to 223.5.5.5 times out from this Mac while ICMP succeeds — the documented fail-on-clean-main condition)
- `git diff origin/main...HEAD --stat` → exactly the 4 intended Cargo files

Because the MeowTests run wasn't fully clean locally (environmental DNS), this PR goes through **full remote CI** per the contributor guide rather than an admin bypass.