### PR TITLE
chore(deps): bump meow-rs pin to v0.20.1, enable anytls (full protocol set)

### DIFF
--- a/App/Sources/Services/ClashConfigLinter.swift
+++ b/App/Sources/Services/ClashConfigLinter.swift
@@ -100,7 +100,7 @@ enum ClashConfigLinter {
     private static let validProxyTypes: Set<String> = [
         "ss", "trojan", "vless", "vmess", "socks5", "http",
         "wireguard", "tuic", "hysteria", "hysteria2",
-        "ssh", "snell", "direct", "reject",
+        "ssh", "snell", "anytls", "direct", "reject",
     ]
 
     private static func checkProxies(
@@ -138,7 +138,7 @@ enum ClashConfigLinter {
         let typeStr = m[Node("type")]?.scalar?.string ?? ""
         let needsServer: Set = [
             "ss", "trojan", "vless", "vmess", "socks5", "http",
-            "tuic", "hysteria", "hysteria2", "snell",
+            "tuic", "hysteria", "hysteria2", "snell", "anytls",
         ]
         if needsServer.contains(typeStr) {
             if m[Node("server")] == nil {

--- a/core/rust/geosite-mrs-builder/Cargo.lock
+++ b/core/rust/geosite-mrs-builder/Cargo.lock
@@ -135,6 +135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,8 +454,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -464,14 +470,16 @@ dependencies = [
  "socket2 0.5.10",
  "subtle",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "meow-rules"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "ipnet",
  "iprange",
@@ -487,11 +495,8 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.11.0"
-source = "git+https://github.com/madeye/meow-rs?rev=f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a#f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a"
-dependencies = [
- "smallvec",
-]
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 
 [[package]]
 name = "minimal-lexical"
@@ -519,6 +524,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
@@ -581,6 +592,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -823,9 +840,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "smol_str"
@@ -909,6 +923,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1071,7 +1115,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1089,14 +1142,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1106,10 +1176,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1118,10 +1200,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1130,10 +1224,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1142,10 +1248,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/core/rust/geosite-mrs-builder/Cargo.toml
+++ b/core/rust/geosite-mrs-builder/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
-meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "f5dd5707ad8138a37361b0c6a8ec58c736e3bf0a" }
+meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
 
 # `.mrs` writing pulls zstd via meow-rules; no extra dep needed here.

--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -53,6 +53,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +140,45 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"
@@ -283,6 +331,15 @@ dependencies = [
  "rustc-hash 2.1.2",
  "shlex",
  "syn",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -495,6 +552,19 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -811,6 +881,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +996,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1100,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "fslock"
@@ -1274,7 +1379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
- "idna",
+ "idna 1.1.0",
  "ipnet",
  "jni",
  "once_cell",
@@ -1435,6 +1540,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1653,16 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -1553,6 +1692,26 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1698,6 +1857,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1922,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1864,6 +2058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,9 +2079,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "meow-anytls"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "libc",
+ "md5",
+ "meow-common",
+ "notify",
+ "once_cell",
+ "rand 0.9.4",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "sha2",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "trust-dns-resolver",
+ "x509-parser",
+]
+
+[[package]]
 name = "meow-api"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "axum",
  "base64",
@@ -1913,8 +2143,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1937,8 +2167,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1971,8 +2201,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2033,8 +2263,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "base64",
  "libc",
@@ -2048,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2070,6 +2300,7 @@ dependencies = [
  "http",
  "libc",
  "md-5",
+ "meow-anytls",
  "meow-common",
  "meow-dns",
  "meow-transport",
@@ -2094,8 +2325,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2111,8 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2136,17 +2367,18 @@ dependencies = [
  "tracing",
  "webpki-root-certs",
  "webpki-roots 0.26.11",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "meow-trie"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2198,6 +2430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2250,6 +2483,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,10 +2528,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2296,6 +2575,15 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
 
 [[package]]
 name = "once_cell"
@@ -2373,6 +2661,16 @@ dependencies = [
  "base64ct",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -2607,11 +2905,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2624,6 +2933,16 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2678,6 +2997,20 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -2808,6 +3141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,6 +3189,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3699,6 +4050,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.7",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.7",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3733,10 +4128,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -3773,7 +4183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
 ]
@@ -4387,6 +4797,34 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -53,6 +53,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +140,45 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "async-trait"
@@ -283,6 +331,15 @@ dependencies = [
  "rustc-hash 2.1.2",
  "shlex 1.3.0",
  "syn",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -486,6 +543,19 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -778,6 +848,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +946,18 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -956,6 +1052,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "fslock"
@@ -1226,7 +1331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
- "idna",
+ "idna 1.1.0",
  "ipnet",
  "jni",
  "once_cell",
@@ -1387,6 +1492,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1605,16 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -1505,6 +1644,26 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1649,6 +1808,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1873,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1802,6 +1996,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,9 +2017,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "meow-anytls"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "libc",
+ "md5",
+ "meow-common",
+ "notify",
+ "once_cell",
+ "rand 0.9.4",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "sha2",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "trust-dns-resolver",
+ "x509-parser",
+]
+
+[[package]]
 name = "meow-api"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "axum",
  "base64",
@@ -1851,8 +2081,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1875,8 +2105,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1909,8 +2139,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -1973,8 +2203,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "base64",
  "libc",
@@ -1988,8 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2010,6 +2240,7 @@ dependencies = [
  "http",
  "libc",
  "md-5",
+ "meow-anytls",
  "meow-common",
  "meow-dns",
  "meow-transport",
@@ -2034,8 +2265,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2051,8 +2282,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2076,17 +2307,18 @@ dependencies = [
  "tracing",
  "webpki-root-certs",
  "webpki-roots 0.26.11",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "meow-trie"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.18.0"
-source = "git+https://github.com/madeye/meow-rs?rev=74e8083a151ca1708864a306189375188d74381a#74e8083a151ca1708864a306189375188d74381a"
+version = "0.20.1"
+source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2138,6 +2370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2178,6 +2411,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,10 +2456,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2208,6 +2487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2286,6 +2574,16 @@ dependencies = [
  "base64ct",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -2520,11 +2818,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2537,6 +2846,16 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2591,6 +2910,20 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -2721,6 +3054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,6 +3102,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3617,6 +3968,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.7",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.7",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,10 +4046,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -3691,7 +4101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
 ]
@@ -4305,6 +4715,34 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,19 +68,23 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 74e8083a (meow-rs 0.18.0) — picks up the rule-IR compilation series
-# (meow-rs#285/#291/#295–#297), lazy metadata enrichment (#292), the VMess
-# AEAD wire-format interop fix (#320), VLESS/Snell UDP-over-TCP read/write
-# fairness (#319), relay-direction fairness per buffer cycle (#347), atomic
-# traffic-snapshot publishing (#339/#341), RouteTable behind RwLock instead
-# of arc-swap (#335), DNS LRU tables no longer preallocated at capacity
-# (#337), and mihomo compat improvements (#313/#333). Windows/OpenWrt/CLI
-# work in 0.17–0.18 doesn't affect this crate. Previous pin 498967e
-# (0.16.0) made DelayHistory `time` serialize as RFC 3339 (meow-rs#290,
-# issue #255). meow-dns runs in fake-ip mode: the FFI config parser pins
-# `enhanced-mode: fake-ip` with `fake-ip-range: 28.0.0.0/8` (the 2026-07-17
-# redir-host/DoT switch was reverted in PR #321).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+# HEAD: c5557577 (meow-rs 0.20.1) — picks up the AnyTLS outbound + REALITY
+# rework (#377: REALITY moved in-tree onto rustls primitives so it no longer
+# needs boring-tls; VLESS over grpc/h2 unblocked, ALPN defaults to h2 for
+# those transports), DNS hardening (#368 upstream response validation, #362
+# eager-bind + panic-guarded workers, #351 real answer TTLs + reverse-cache
+# snapshot/restore, #350 #PROXY nameserver-policy fragments), listener HTTP
+# hardening (#369 strict byte header parsing, #372 Content-Length
+# normalization / TE rejection on HTTP/1.0, #370 close plain HTTP after one
+# request), delta-based traffic sampling (#357), /connections push-interval
+# 100ms floor (#359), group-level filter/exclude on provider members, and
+# the event-listener RUSTSEC-2026-0221 bump. Windows TUN-listener and
+# macOS pf/tproxy work in 0.19–0.20 doesn't affect this crate. Previous
+# pin 74e8083a (0.18.0) brought the rule-IR compilation series and the
+# VMess AEAD interop fix. meow-dns runs in fake-ip mode: the FFI config
+# parser pins `enhanced-mode: fake-ip` with `fake-ip-range: 28.0.0.0/8`
+# (the 2026-07-17 redir-host/DoT switch was reverted in PR #321).
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -88,12 +92,21 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1
 # fingerprint field falls back to a stub-warn. Cost: boring-sys vendors
 # BoringSSL, adding ~several MB to the stripped extension binary —
 # watch the 50 MB NE budget after a release archive.
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a", features = ["boring-tls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "74e8083a151ca1708864a306189375188d74381a" }
+#
+# `anytls` opts into the AnyTLS outbound (off by default upstream, but part
+# of the meow-app `full` release bundle). Together with the defaults this
+# matches upstream's full protocol set: ss, trojan, vless (+vision,
+# +encryption, REALITY), vmess, snell, hysteria2, anytls, ech-tls-tunnel.
+# Deliberately NOT enabled: `listener-tun` (Windows TUN inbound — iOS uses
+# the lwip tun2socks path; would drag netstack-smoltcp/tun-rs dead weight
+# into the NE binary) and `external-ui-download` (force-disabled at compile
+# time on iOS; would only add the zip crate).
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3", features = ["boring-tls", "anytls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -800,4 +800,49 @@ mod config_parse_tests {
             "all 22 user-defined groups plus injected GLOBAL must resolve",
         );
     }
+
+    /// One proxy of every protocol compiled into this build (meow-config
+    /// defaults + the explicit `anytls` opt-in). Asserted by name so a
+    /// silently dropped feature flag — which warn-skips the entry in lenient
+    /// parsing instead of erroring — fails loudly here. Companion to the
+    /// `ss`-only regression test above; see the meow-config dep comment in
+    /// Cargo.toml for the full feature inventory.
+    #[test]
+    fn every_compiled_protocol_parses() {
+        let yaml = r#"
+proxies:
+  - {name: p-ss, type: ss, server: 1.2.3.4, port: 8388, cipher: aes-256-gcm, password: pw}
+  - {name: p-trojan, type: trojan, server: 1.2.3.4, port: 443, password: pw}
+  - {name: p-vless, type: vless, server: 1.2.3.4, port: 443, uuid: 8b1e3b64-3c7e-4a2d-9c7d-000000000001}
+  - {name: p-vmess, type: vmess, server: 1.2.3.4, port: 443, uuid: 8b1e3b64-3c7e-4a2d-9c7d-000000000002}
+  - {name: p-snell, type: snell, server: 1.2.3.4, port: 8388, psk: secret}
+  - {name: p-hysteria2, type: hysteria2, server: 1.2.3.4, port: 443, password: pw}
+  - {name: p-anytls, type: anytls, server: 1.2.3.4, port: 443, password: pw}
+rules:
+  - MATCH,DIRECT
+"#;
+        let stripped = super::prepare_ios_config(yaml).expect("strip ok");
+        let rt = tokio::runtime::Runtime::new().expect("tokio rt");
+        // block_on provides the live reactor the anytls adapter's pool-reaper
+        // spawn needs at parse time.
+        let cfg = rt
+            .block_on(meow_config::load_config_from_str(&stripped))
+            .expect("full-protocol config must load");
+
+        for name in [
+            "p-ss",
+            "p-trojan",
+            "p-vless",
+            "p-vmess",
+            "p-snell",
+            "p-hysteria2",
+            "p-anytls",
+        ] {
+            assert!(
+                cfg.proxies.contains_key(name),
+                "{name} missing after parse — its protocol feature was \
+                 compiled out or the parser rejected the minimal entry",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Bumps all `meow-*` git pins from `74e8083a` (0.18.0) to `c5557577` (**v0.20.1**, 27 commits): AnyTLS outbound + REALITY-on-rustls rework (meow-rs#377), VLESS over grpc/h2 unblocked, DNS hardening (#368/#362/#351/#350), listener HTTP hardening (#369/#372/#370), delta-based traffic sampling (#357), `/connections` push-interval floor (#359), event-listener RUSTSEC-2026-0221 bump.
- Enables `anytls` on `meow-config` — together with the default features our build now matches upstream's `full` protocol bundle: ss, trojan, vless (+vision, +encryption, REALITY), vmess, snell, hysteria2, anytls, ech-tls-tunnel; plus boring-tls/ECH and grpc/h2/ws/httpupgrade transports. `listener-tun` (Windows TUN inbound; would drag netstack-smoltcp/tun-rs into the NE binary) and `external-ui-download` (force-disabled on iOS) deliberately stay off.
- Bumps geosite-mrs-builder's `meow-rules` pin to the same rev; regenerates all three Cargo.locks (aux-crate CI runs `--locked`).
- New `engine.rs` regression test: one proxy of every compiled protocol must parse by name (a dropped feature flag warn-skips entries in lenient parsing — this makes it fail loudly).
- `ClashConfigLinter` accepts `anytls` as a known proxy type (requires server/port).

## Local verification
- `cargo check` + `cargo test` in `core/rust/meow-ios-ffi` → 62 passed, 0 failed (includes the new protocol-coverage test); `cargo fmt -- --check` clean.
- `cargo test --locked` in `core/rust/geosite-mrs-builder` and `core/rust/macos-utun-harness` → green.
- `scripts/build-rust.sh` → xcframework builds clean at 0.20.1.
- `swiftformat --lint .` → 0 violations; `swiftlint --strict` → 0 violations.
- `xcodebuild test` (MeowTests + MeowIntegrationTests, iPhone 17 sim): all green **except** the 6 known environmental Shadowsocks failures — AliDNS 223.5.5.5 is unreachable from this network (verified with `dig`; fails on clean main too). Per CLAUDE.md, that disqualifies a Path B bypass, so this PR goes through **full remote CI**.