### PR TITLE
fix(tun2socks): bound hung DIRECT dials in the engine; remove inert dial watchdog

### DIFF
--- a/MeowCore/include/meow_core.h
+++ b/MeowCore/include/meow_core.h
@@ -294,29 +294,6 @@ int meow_tun_health_probe(const char *src_ip, const char *dns_ip, int timeout_ms
 int meow_tun_close_all_tcp_flows(void);
 
 /**
- * Set the per-flow dial deadline, in milliseconds. Bounds the time
- * `dispatch_tcp` waits for the relay's first byte of progress on the
- * netstack stream before declaring the dial hung and dropping the
- * future. See docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md
- * for context.
- *
- * Default 10000 ms. Pass `0` to disable the watchdog (relies on the
- * 30 s idle sweeper to reap stuck flows). Negative values are rejected.
- *
- * Takes effect on the next flow accepted; does not abort in-flight
- * flows mid-wait.
- *
- * Returns 0 on success, -1 on invalid input.
- */
-int meow_tun_set_dial_deadline_ms(int ms);
-
-/**
- * Read the currently-configured per-flow dial deadline, in
- * milliseconds. `0` means the watchdog is disabled.
- */
-int meow_tun_dial_deadline_ms(void);
-
-/**
  * Set the TCP first-payload wait budget, in milliseconds. lwIP completes
  * the local 3-way handshake on its own, so without this gate every SYN
  * entering the TUN created a real meow connection (SOCKS5 CONNECT through
@@ -346,8 +323,8 @@ int meow_tun_tcp_first_payload_wait_ms(void);
 
 /**
  * Set the per-UDP-session first-reply deadline, in milliseconds. The
- * symmetric counterpart to `meow_tun_set_dial_deadline_ms` for the UDP
- * path — UDP doesn't connect, but iOS auto-bypass can silently drop
+ * UDP counterpart of the engine-side `tcp-connect-timeout` bound —
+ * UDP doesn't connect, but iOS auto-bypass can silently drop
  * the outbound sendto when the scoped-routing cache is stale, leaving
  * the reply reader parked on `read_packet` forever. Bounding the
  * *first* reply lets us evict a dead session so the next app datagram
@@ -372,7 +349,7 @@ int meow_tun_udp_first_reply_deadline_ms(void);
 
 /**
  * Set the per-TCP-flow idle TTL, in milliseconds. The complement to
- * `meow_tun_set_dial_deadline_ms` for flows whose dial *succeeded* but
+ * the engine-side `tcp-connect-timeout` bound, for flows whose dial *succeeded* but
  * then went permanently quiet — e.g. the upstream proxy EOF'd an idle
  * connection and the (suspended) app never FINs back, parking the relay
  * forever while it pins an accept-cap permit and an lwip pcb. Hours of

--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2081,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "meow-anytls"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "axum",
  "base64",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2202,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "base64",
  "libc",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2373,12 +2373,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2840,7 +2840,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2877,7 +2877,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -972,7 +972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1485,7 +1485,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "meow-anytls"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "meow-api"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "axum",
  "base64",
@@ -2082,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "meow-common"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "meow-config"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "meow-dns"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "meow-listener"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "base64",
  "libc",
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "meow-proxy"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2266,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "meow-rules"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2283,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "meow-transport"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2313,12 +2313,12 @@ dependencies = [
 [[package]]
 name = "meow-trie"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 
 [[package]]
 name = "meow-tunnel"
 version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2452,7 +2452,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2753,7 +2753,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2790,7 +2790,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3085,7 +3085,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3462,7 +3462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3573,7 +3573,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4374,7 +4374,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,7 +68,14 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: c5557577 (meow-rs 0.20.1) — picks up the AnyTLS outbound + REALITY
+# HEAD: 041c986a (branch ios/connect-timeout-0.20.1 = 0.20.1 c5557577 + the
+# tcp-connect-timeout wiring, PR'd to main separately; keep the branch
+# alive — this Cargo pin is its only anchor, same pattern as the lwip
+# fork pin). Adds the global `tcp-connect-timeout:` (seconds) config
+# field wired into DirectAdapter::with_connect_timeout so a hung direct
+# dial errors instead of hanging; `prepare_ios_config` injects 10 s.
+#
+# Base 0.20.1 (c5557577) picked up the AnyTLS outbound + REALITY
 # rework (#377: REALITY moved in-tree onto rustls primitives so it no longer
 # needs boring-tls; VLESS over grpc/h2 unblocked, ALPN defaults to h2 for
 # those transports), DNS hardening (#368 upstream response validation, #362
@@ -84,7 +91,7 @@ lwip = "0.3"
 # VMess AEAD interop fix. meow-dns runs in fake-ip mode: the FFI config
 # parser pins `enhanced-mode: fake-ip` with `fake-ip-range: 28.0.0.0/8`
 # (the 2026-07-17 redir-host/DoT switch was reverted in PR #321).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -101,12 +108,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e
 # the lwip tun2socks path; would drag netstack-smoltcp/tun-rs dead weight
 # into the NE binary) and `external-ui-download` (force-disabled at compile
 # time on iOS; would only add the zip crate).
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3", features = ["boring-tls", "anytls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc", features = ["boring-tls", "anytls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -71,7 +71,9 @@ fn install_tls_provider() {
 /// Normalize the effective YAML before `load_config`: iOS owns exactly one
 /// mixed listener (`mixed-port`) and exactly one DNS listener (`dns.listen`).
 /// Drop other listener shorthands / explicit listener arrays so subscriptions
-/// cannot create duplicate ports or unexpected inbound sockets.
+/// cannot create duplicate ports or unexpected inbound sockets. Also inject
+/// the iOS default `tcp-connect-timeout` (bounded DIRECT dial) when the
+/// config doesn't set one — see the inline comment for rationale.
 ///
 /// Operates on a generic `serde_yaml::Value` rather than projecting through
 /// `RawConfig`: the latter has no `#[serde(flatten)]` catch-all and no
@@ -84,6 +86,20 @@ fn prepare_ios_config(yaml: &str) -> Result<String> {
     if let serde_yaml::Value::Mapping(m) = &mut doc {
         for key in ["port", "socks-port", "tproxy-port", "listeners"] {
             m.remove(serde_yaml::Value::String(key.to_string()));
+        }
+        // Bound the built-in DIRECT adapter's `TcpStream::connect`. iOS
+        // scoped-routing / reachability-cache transients can leave a direct
+        // connect hanging indefinitely (see
+        // docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md);
+        // without a bound the flow is reaped only by the 600 s idle
+        // sweeper. 10 s: safely above cold cellular handshakes against
+        // distant CN PoPs (~5-8 s observed) and below Mobile Safari's
+        // ~12 s request-timeout floor, so the app's own retry loop kicks
+        // in. Injected only when the user's config doesn't set it, so a
+        // subscription/user override wins.
+        let key = serde_yaml::Value::String("tcp-connect-timeout".to_string());
+        if !m.contains_key(&key) {
+            m.insert(key, serde_yaml::Value::Number(10.into()));
         }
     }
     serde_yaml::to_string(&doc).context("serializing stripped config YAML")
@@ -540,6 +556,34 @@ log-level: info
         assert_eq!(m.get("mixed-port").and_then(|v| v.as_i64()), Some(7892));
         assert_eq!(m.get("mode").and_then(|v| v.as_str()), Some("rule"));
         assert_eq!(m.get("log-level").and_then(|v| v.as_str()), Some("info"));
+    }
+
+    #[test]
+    fn prepare_injects_default_tcp_connect_timeout() {
+        let out = prepare_ios_config("mode: rule\n").expect("strip ok");
+        let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(
+            doc.as_mapping()
+                .unwrap()
+                .get(serde_yaml::Value::String("tcp-connect-timeout".into()))
+                .and_then(|v| v.as_i64()),
+            Some(10),
+            "iOS default DIRECT connect bound must be injected"
+        );
+    }
+
+    #[test]
+    fn prepare_preserves_user_tcp_connect_timeout() {
+        let out = prepare_ios_config("mode: rule\ntcp-connect-timeout: 42\n").expect("strip ok");
+        let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(
+            doc.as_mapping()
+                .unwrap()
+                .get(serde_yaml::Value::String("tcp-connect-timeout".into()))
+                .and_then(|v| v.as_i64()),
+            Some(42),
+            "a user/subscription-set value must win over the injected default"
+        );
     }
 
     #[test]

--- a/core/rust/meow-ios-ffi/src/lib.rs
+++ b/core/rust/meow-ios-ffi/src/lib.rs
@@ -1170,35 +1170,13 @@ pub extern "C" fn meow_tun_close_all_tcp_flows() -> c_int {
     n as c_int
 }
 
-/// Set the per-flow dial deadline, in milliseconds. Bounds the time
-/// `dispatch_tcp` waits for the relay's first byte of progress on the
-/// netstack stream before declaring the dial hung and dropping the
-/// future. See docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md
-/// for context.
-///
-/// Default 10000 ms. Pass `0` to disable the watchdog (relies on the
-/// 30 s idle sweeper to reap stuck flows). Negative values are rejected.
-///
-/// Takes effect on the next flow accepted; does not abort in-flight
-/// flows mid-wait.
-///
-/// Returns 0 on success, -1 on invalid input.
-#[no_mangle]
-pub extern "C" fn meow_tun_set_dial_deadline_ms(ms: c_int) -> c_int {
-    if ms < 0 {
-        set_error("dial deadline must be >= 0".into());
-        return -1;
-    }
-    tun2socks::set_dial_deadline_ms(ms as u64);
-    0
-}
-
-/// Read the currently-configured per-flow dial deadline, in
-/// milliseconds. `0` means the watchdog is disabled.
-#[no_mangle]
-pub extern "C" fn meow_tun_dial_deadline_ms() -> c_int {
-    tun2socks::dial_deadline_ms() as c_int
-}
+// The old `meow_tun_set_dial_deadline_ms` / `meow_tun_dial_deadline_ms`
+// FFI pair is gone: the per-flow "dial deadline" watchdog it configured
+// had been inert since the meow-listener refactor and was removed. Hung
+// DIRECT dials are now bounded inside the engine via the
+// `tcp-connect-timeout` config field that `prepare_ios_config` injects
+// (default 10 s) — see the note above the first-payload gate in
+// tun2socks.rs.
 
 /// Set the TCP first-payload wait budget, in milliseconds. lwIP completes
 /// the local 3-way handshake on its own, so without this gate every SYN
@@ -1236,8 +1214,8 @@ pub extern "C" fn meow_tun_tcp_first_payload_wait_ms() -> c_int {
 }
 
 /// Set the per-UDP-session first-reply deadline, in milliseconds. The
-/// symmetric counterpart to `meow_tun_set_dial_deadline_ms` for the UDP
-/// path — UDP doesn't connect, but iOS auto-bypass can silently drop
+/// UDP counterpart of the engine-side `tcp-connect-timeout` bound —
+/// UDP doesn't connect, but iOS auto-bypass can silently drop
 /// the outbound sendto when the scoped-routing cache is stale, leaving
 /// the reply reader parked on `read_packet` forever. Bounding the
 /// *first* reply lets us evict a dead session so the next app datagram
@@ -1269,7 +1247,7 @@ pub extern "C" fn meow_tun_udp_first_reply_deadline_ms() -> c_int {
 }
 
 /// Set the per-TCP-flow idle TTL, in milliseconds. The complement to
-/// `meow_tun_set_dial_deadline_ms` for flows whose dial *succeeded* but
+/// the engine-side `tcp-connect-timeout` bound, for flows whose dial *succeeded* but
 /// then went permanently quiet — e.g. the upstream proxy EOF'd an idle
 /// connection and the (suspended) app never FINs back, parking the relay
 /// forever while it pins an accept-cap permit and an lwip pcb. Hours of

--- a/core/rust/meow-ios-ffi/src/tun2socks.rs
+++ b/core/rust/meow-ios-ffi/src/tun2socks.rs
@@ -121,40 +121,20 @@ fn run_handle_slot() -> &'static Mutex<Option<tokio::task::JoinHandle<()>>> {
 // without it a burst is bounded only by upstream/relay backpressure and the
 // 30 s idle sweeper — watch RSS against the ~50 MB NE jetsam ceiling.
 
-// Per-flow dial deadline. Bounds the time `dispatch_tcp` waits for the
-// relay's first byte of progress on the netstack stream before declaring
-// the dial hung and dropping the future. See
-// docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md for the
-// failure mode: `DirectAdapter::dial_tcp` awaits `TcpStream::connect`
-// with no timeout, and an iOS reachability-cache / scoped-routing
-// transient can leave the connect hanging until cap-pressure eviction
-// reaps the flow. With the deadline, the app sees a RST in
-// `DIAL_DEADLINE_MS` ms instead of 30 s, the `tcp_accept_sem` permit is
-// released promptly, and `ConnectionGuard`'s Drop runs the meow
-// session cleanup on the discarded future.
-//
-// 10 s default: safely above cold cellular handshakes against distant
-// CN PoPs (~5-8 s observed) and below Mobile Safari's ~12 s
-// request-timeout floor, so the app's own retry loop kicks in.
-// Tunable at runtime via [`set_dial_deadline_ms`] /
-// `meow_tun_set_dial_deadline_ms` — set to 0 to disable the watchdog.
-const DIAL_DEADLINE_MS_DEFAULT: u64 = 10_000;
-static DIAL_DEADLINE_MS: AtomicU64 = AtomicU64::new(DIAL_DEADLINE_MS_DEFAULT);
-
-/// Set the per-flow dial deadline, in milliseconds. `0` disables the
-/// deadline (no watchdog — flows that hang in `dial_tcp` will only be
-/// reaped when the accept cap forces a longest-idle eviction). Returns
-/// true unconditionally.
-pub fn set_dial_deadline_ms(ms: u64) -> bool {
-    DIAL_DEADLINE_MS.store(ms, Ordering::Relaxed);
-    true
-}
-
-/// Read the currently-configured dial deadline, in milliseconds. `0`
-/// means the watchdog is disabled.
-pub fn dial_deadline_ms() -> u64 {
-    DIAL_DEADLINE_MS.load(Ordering::Relaxed)
-}
+// Hung-dial bounding lives in the engine now, not here. The old per-flow
+// "dial deadline" watchdog (`DIAL_DEADLINE_MS` / `run_dial_watchdog`,
+// removed) tried to detect a hung `DirectAdapter::dial_tcp` (see
+// docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md) from relay
+// progress — but since the meow-listener refactor the SOCKS5 CONNECT
+// reply is eager and `dispatch_tcp` bumped `last_active_ms` before the
+// watchdog started, so it parked immediately and could never fire. The
+// signal was unfixable at this layer anyway: "no relay progress yet" is
+// indistinguishable from a legitimate plaintext long-poll waiting on its
+// first downstream byte. The bound now sits where the hang actually is:
+// `prepare_ios_config` (engine.rs) injects `tcp-connect-timeout: 10`,
+// which meow-config wires into `DirectAdapter::with_connect_timeout` —
+// established flows are untouched by construction, and a hung connect
+// errors out of `dial_tcp`, closing the loopback leg so the app sees RST.
 
 // First-payload gate on the TCP dial. lwIP completes the local 3-way
 // handshake on its own (SYN in → SYN-ACK out), so *every* SYN that enters
@@ -197,8 +177,9 @@ pub fn tcp_first_payload_wait_ms() -> u64 {
     TCP_FIRST_PAYLOAD_WAIT_MS.load(Ordering::Relaxed)
 }
 
-// Per-UDP-session first-reply deadline. The symmetric counterpart to
-// DIAL_DEADLINE_MS for the UDP path. UDP doesn't connect, so there's no
+// Per-UDP-session first-reply deadline. The UDP counterpart of the
+// engine-side `tcp-connect-timeout` bound (see the note above the
+// first-payload gate). UDP doesn't connect, so there's no
 // `TcpStream::connect` hang to bound — but iOS auto-bypass can silently
 // drop the outbound sendto when the kernel's scoped-routing cache is
 // stale, in which case the upstream never sees the datagram and the
@@ -207,7 +188,7 @@ pub fn tcp_first_payload_wait_ms() -> u64 {
 // evicted from `nat_table` + `reply_readers`, so the next app datagram
 // dispatches a fresh socket against (hopefully) a refreshed iOS route.
 //
-// 10 s default to match TCP's `DIAL_DEADLINE_MS`. The cost for legit
+// 10 s default to match the engine's TCP connect bound. The cost for legit
 // no-reply UDP traffic (fire-and-forget telemetry, mDNS) is a
 // dispatch + bind churn every 10 s — negligible relative to even a
 // single round-trip's allocation cost. Tunable at runtime via
@@ -1253,9 +1234,7 @@ async fn dispatch_tcp(
         return;
     };
 
-    let accepted_at_ms = state.last_active_ms.load(Ordering::Relaxed);
-    let dial_deadline = DIAL_DEADLINE_MS.load(Ordering::Relaxed);
-    let watchdog_state = state.clone();
+    let eof_state = state.clone();
 
     let local_eof = Arc::new(Notify::new());
     let mut local = IdleTracking {
@@ -1301,14 +1280,6 @@ async fn dispatch_tcp(
         }
     }
 
-    local
-        .state
-        .last_active_ms
-        .store(now_ms().max(accepted_at_ms + 1), Ordering::Relaxed);
-
-    let eof_state = watchdog_state.clone();
-    let dial_watchdog = run_dial_watchdog(watchdog_state, accepted_at_ms, dial_deadline);
-    tokio::pin!(dial_watchdog);
     let relay = tokio::io::copy_bidirectional(&mut local, &mut proxy);
     tokio::pin!(relay);
 
@@ -1327,12 +1298,6 @@ async fn dispatch_tcp(
                     }
                 }
             }
-        }
-        _ = &mut dial_watchdog => {
-            warn!(
-                "tun2socks: mixed-listener dial deadline exceeded for {} -> {} after {} ms; dropping flow",
-                src, dst, dial_deadline,
-            );
         }
     }
 }
@@ -1377,53 +1342,6 @@ async fn await_first_payload<R: AsyncRead + Unpin>(local: &mut R, wait_ms: u64) 
             FirstPayload::Payload(buf)
         }
         Err(_) => FirstPayload::DialWithout,
-    }
-}
-
-/// Dial-deadline watchdog body. Resolves when the per-flow dial has been
-/// idle past the budget; parks forever once the relay starts so the
-/// `select!` arm in `dispatch_tcp` lets the relay future own the rest of
-/// the lifetime.
-///
-/// `dial_deadline_ms == 0` opts out (watchdog parks forever, behaviour
-/// matches the pre-fix pipeline that relied solely on cap-pressure
-/// eviction). Otherwise the watchdog ticks every 500 ms — fine grained
-/// enough to make sub-second `dial_deadline_ms` settings (used by tests)
-/// converge in <=2 ticks, coarse enough not to be a measurable wake-up
-/// cost under steady state.
-///
-/// Factored out of `dispatch_tcp` so unit tests can drive it without
-/// standing up the engine, netstack, and tcp-listener plumbing the
-/// real call site requires. See the `dial_watchdog_*` tests at the
-/// bottom of this file for the contract pinned in CI.
-async fn run_dial_watchdog(state: Arc<FlowState>, accepted_at_ms: u64, dial_deadline_ms: u64) {
-    if dial_deadline_ms == 0 {
-        std::future::pending::<()>().await;
-        return;
-    }
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(dial_deadline_ms);
-    loop {
-        // 500 ms is the longest a sub-second deadline can wait without
-        // overshooting the budget by more than one tick. Pick something
-        // smaller (say 100 ms) only if test flakiness from the 500 ms
-        // floor becomes a real issue.
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        if state.last_active_ms.load(Ordering::Relaxed) > accepted_at_ms {
-            // Relay started — dial succeeded. Park; the relay future
-            // now controls the task's lifetime.
-            std::future::pending::<()>().await;
-            return;
-        }
-        if tokio::time::Instant::now() >= deadline {
-            // Final re-check to close the tick-to-deadline race: touch()
-            // could have fired in the sleep wake-up between the load
-            // above and the deadline check.
-            if state.last_active_ms.load(Ordering::Relaxed) > accepted_at_ms {
-                std::future::pending::<()>().await;
-                return;
-            }
-            return;
-        }
     }
 }
 
@@ -2954,128 +2872,6 @@ mod tests {
         let mut buf = [0u8; 5];
         tun.read_exact(&mut buf).await.unwrap();
         assert_eq!(&buf, b"hello");
-    }
-
-    /// Tier 3 regression harness — see
-    /// `docs/INVESTIGATION-2026-05-18-tcp-direct-rule-disconnect.md`.
-    ///
-    /// Models the failure mode that operators reported as 断流: the
-    /// upstream relay never starts (e.g. `DirectAdapter::dial_tcp`'s
-    /// underlying `TcpStream::connect` is hung on a TEST-NET-1
-    /// black-hole / iOS routing-cache transient), so
-    /// `IdleTracking::touch` never runs and `FlowState.last_active_ms`
-    /// stays frozen at its accept-time value. The watchdog must reap
-    /// the flow within the configured `dial_deadline_ms` budget rather
-    /// than waiting on cap-pressure eviction.
-    #[tokio::test(start_paused = true)]
-    async fn dial_watchdog_fires_when_relay_never_starts() {
-        let now = now_ms();
-        let state = Arc::new(FlowState {
-            last_active_ms: AtomicU64::new(now),
-        });
-
-        let started = tokio::time::Instant::now();
-        // Run with a 750 ms deadline (chosen above the 500 ms tick floor
-        // so we hit exactly one tick before the deadline check) and
-        // assert it resolves within a generous bound.
-        let outer = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            run_dial_watchdog(state.clone(), now, 750),
-        )
-        .await;
-
-        assert!(
-            outer.is_ok(),
-            "watchdog did not resolve within outer 3 s guard — regression"
-        );
-        let elapsed = started.elapsed();
-        // Sub-1500 ms upper bound: the watchdog should fire after at most
-        // ⌈750 / 500⌉ = 2 sleep ticks (1000 ms) plus the final re-check.
-        assert!(
-            elapsed < std::time::Duration::from_millis(1_500),
-            "watchdog took {:?}, expected <1.5 s with a 750 ms deadline",
-            elapsed
-        );
-        // The watchdog must not mutate `last_active_ms` — that's the
-        // relay's job. Pin the contract so a future refactor can't
-        // accidentally trample the field and mask a dial-hang regression.
-        assert_eq!(state.last_active_ms.load(Ordering::Relaxed), now);
-    }
-
-    /// Mirror of the above for the "dial succeeded normally" case: the
-    /// relay advances `last_active_ms` before the deadline expires, and
-    /// the watchdog must park forever (i.e. not return) so the relay
-    /// future owns the rest of the flow's lifetime. Drives the same
-    /// `select!`-arm semantics as `dispatch_tcp` without standing up
-    /// the netstack.
-    #[tokio::test(start_paused = true)]
-    async fn dial_watchdog_parks_when_relay_starts_in_time() {
-        let now = now_ms();
-        let state = Arc::new(FlowState {
-            last_active_ms: AtomicU64::new(now),
-        });
-
-        // Bump `last_active_ms` after 200 ms — simulates the first
-        // `IdleTracking::touch()` once the relay reads the app's first
-        // payload. The watchdog should observe the advance on its first
-        // 500 ms tick and park.
-        let state_for_bump = state.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-            state_for_bump
-                .last_active_ms
-                .store(now + 1, Ordering::Relaxed);
-        });
-
-        // 750 ms deadline; outer 2 s guard. If the watchdog mistakenly
-        // returns despite the bump, the outer timeout doesn't fire and
-        // `outer.is_err()` fails.
-        let outer = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            run_dial_watchdog(state, now, 750),
-        )
-        .await;
-        assert!(
-            outer.is_err(),
-            "watchdog returned despite the relay starting before the deadline — regression",
-        );
-    }
-
-    /// `dial_deadline_ms == 0` is the documented opt-out: the watchdog
-    /// must never fire, even if the relay never starts. Falls back to
-    /// cap-pressure eviction as the only line of defence.
-    #[tokio::test(start_paused = true)]
-    async fn dial_watchdog_zero_deadline_opts_out() {
-        let now = now_ms();
-        let state = Arc::new(FlowState {
-            last_active_ms: AtomicU64::new(now),
-        });
-
-        // 5 s outer guard with a 0 deadline: the watchdog should never
-        // resolve in that window.
-        let outer = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            run_dial_watchdog(state, now, 0),
-        )
-        .await;
-        assert!(
-            outer.is_err(),
-            "0-ms deadline must opt out of the watchdog (parked forever)",
-        );
-    }
-
-    #[test]
-    fn dial_deadline_ms_roundtrip_and_zero_disables() {
-        let prev = dial_deadline_ms();
-        // Default initial value matches the documented threshold.
-        // (Other tests don't touch this knob, so the first read sees it.)
-        assert!(set_dial_deadline_ms(7_500));
-        assert_eq!(dial_deadline_ms(), 7_500);
-        assert!(set_dial_deadline_ms(0));
-        assert_eq!(dial_deadline_ms(), 0, "0 must be accepted to opt out");
-        // Restore so other parallel tests that may sample the knob see the
-        // configured default.
-        set_dial_deadline_ms(prev);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #367's incidental finding: the per-flow "dial deadline" watchdog has been dead code since the meow-listener refactor — meow replies to SOCKS5 CONNECT eagerly and `dispatch_tcp` bumped `last_active_ms` above the watchdog's accept-time baseline *before* starting it, so it parked immediately and could never fire. Hung `DirectAdapter` dials (the 2026-05-18 断流 failure mode) were reaped only by the 600 s idle sweeper. The signal was also unfixable at the tun2socks layer: "no relay progress yet" is indistinguishable from a plaintext long-poll waiting on its first downstream byte.

This moves the bound to where the hang actually is — the connect inside meow:

- **meow-rs pin bump** c5557577 → 041c986a (`ios/connect-timeout-0.20.1` = 0.20.1 + `tcp-connect-timeout` config wiring into `DirectAdapter::with_connect_timeout`; forward-ported to upstream main as madeye/meow-rs#404). Full protocol set unchanged — `boring-tls` + `anytls` features preserved, `every_compiled_protocol_parses` (ss/trojan/vless/vmess/snell/hysteria2/anytls) green on the new pin.
- **`prepare_ios_config` injects `tcp-connect-timeout: 10`** (a user/subscription-set value wins). A hung direct connect now errors out of `dial_tcp`, closing the loopback leg so the app sees RST promptly. Established flows are untouched by construction — no long-poll false positives.
- **Delete the inert machinery**: `run_dial_watchdog`, `DIAL_DEADLINE_MS`, the `meow_tun_{set_,}dial_deadline_ms` FFI pair (zero consumers in Swift/tests/harness), their tests; `meow_core.h` regenerated.
- **`macos-utun-harness/Cargo.lock` regenerated** for the pin bump (the PR #317 lesson); `cargo check --locked` green.

## Path B local-CI attestation

1. `swiftformat --lint .` at repo root → 0 files require formatting (127 checked). ✅
2. `swiftlint --strict --quiet` at repo root → 0 violations. ✅
3. Test suites matching the diff, run locally on iOS 26 simulator:
   - `xcodebuild test -project meow-ios.xcodeproj -scheme meow-ios -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeowTests` → **TEST SUCCEEDED** ✅
   - `scripts/build-rust.sh` → completed, header + xcframework regenerated ✅
   - `cargo test --lib` in `core/rust/meow-ios-ffi/` → 70 passed, 0 failed (includes new `prepare_injects_default_tcp_connect_timeout` / `prepare_preserves_user_tcp_connect_timeout`) ✅
   - `cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings` in `core/rust/meow-ios-ffi/` → clean ✅
   - `cargo check --locked` in `core/rust/macos-utun-harness/` → clean ✅
   - Pinned meow-rs branch: full workspace `cargo test --lib` → 12/12 suites ok ✅
4. `git diff origin/main...HEAD --stat` verified → exactly Cargo.toml + 2 lockfiles + engine.rs + lib.rs + tun2socks.rs + meow_core.h (128 insertions, 326 deletions), no accidental additions. ✅