### PR TITLE
chore: meow-rs 0.21.0 + 1.6.0 (build 2026082201)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2026080601</string>
+	<string>2026082201</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>

--- a/PacketTunnel/Info.plist
+++ b/PacketTunnel/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>2026080601</string>
+	<string>2026082201</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/core/rust/geosite-mrs-builder/Cargo.lock
+++ b/core/rust/geosite-mrs-builder/Cargo.lock
@@ -454,8 +454,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -478,8 +478,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "ipnet",
  "iprange",
@@ -495,8 +495,8 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=c5557577fd181e8535d721662c189bec166a21b3#c5557577fd181e8535d721662c189bec166a21b3"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 
 [[package]]
 name = "minimal-lexical"

--- a/core/rust/geosite-mrs-builder/Cargo.toml
+++ b/core/rust/geosite-mrs-builder/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
-meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "c5557577fd181e8535d721662c189bec166a21b3" }
+meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
 
 # `.mrs` writing pulls zstd via meow-rules; no extra dep needed here.

--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -2080,8 +2080,8 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2110,8 +2110,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "axum",
  "base64",
@@ -2143,8 +2143,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2167,8 +2167,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2201,8 +2201,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2263,8 +2263,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "base64",
  "libc",
@@ -2278,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2293,6 +2293,7 @@ dependencies = [
  "crc32fast",
  "ctr",
  "futures",
+ "h2",
  "h3",
  "h3-quinn",
  "hex",
@@ -2318,15 +2319,17 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tracing",
  "webpki-roots 0.26.11",
  "x25519-dalek",
+ "yamux",
 ]
 
 [[package]]
 name = "meow-rules"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2342,8 +2345,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2372,13 +2375,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2471,6 +2474,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3582,6 +3591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3848,6 +3863,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -4815,6 +4831,21 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "yamux"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767113d8f66a81e461362462aa71d8d0108cbf3430d4442fb88a04e31be81165"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -2018,8 +2018,8 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2048,8 +2048,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "axum",
  "base64",
@@ -2081,8 +2081,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2105,8 +2105,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2139,8 +2139,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2203,8 +2203,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "base64",
  "libc",
@@ -2218,8 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2233,6 +2233,7 @@ dependencies = [
  "crc32fast",
  "ctr",
  "futures",
+ "h2",
  "h3",
  "h3-quinn",
  "hex",
@@ -2258,15 +2259,17 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tracing",
  "webpki-roots 0.26.11",
  "x25519-dalek",
+ "yamux",
 ]
 
 [[package]]
 name = "meow-rules"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2282,8 +2285,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2312,13 +2315,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.20.1"
-source = "git+https://github.com/madeye/meow-rs?rev=041c986a24d28316498de6ad01a4460ae62b42cc#041c986a24d28316498de6ad01a4460ae62b42cc"
+version = "0.21.0"
+source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2399,6 +2402,12 @@ dependencies = [
  "hybrid-array",
  "num-traits",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3501,6 +3510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,6 +3781,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -4733,6 +4749,21 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "yamux"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767113d8f66a81e461362462aa71d8d0108cbf3430d4442fb88a04e31be81165"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,12 +68,51 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: 041c986a (branch ios/connect-timeout-0.20.1 = 0.20.1 c5557577 + the
-# tcp-connect-timeout wiring, PR'd to main separately; keep the branch
-# alive — this Cargo pin is its only anchor, same pattern as the lwip
-# fork pin). Adds the global `tcp-connect-timeout:` (seconds) config
-# field wired into DirectAdapter::with_connect_timeout so a hung direct
-# dial errors instead of hanging; `prepare_ios_config` injects 10 s.
+# HEAD: ac3fcd8d — meow-rs v0.21.0. This retires the
+# `ios/connect-timeout-0.20.1` side branch: its one commit (the global
+# `tcp-connect-timeout:` field wired into DirectAdapter::with_connect_timeout,
+# which `prepare_ios_config` injects at 10 s) merged to main before 0.21.0,
+# so the release is a superset and the branch no longer needs to be kept
+# alive as a Cargo anchor.
+#
+# What the 0.20.1 → 0.21.0 range adds that this crate actually runs:
+# - sing-mux multiplexing (#412 series, #414–#418) plus Xray Mux.Cool,
+#   yamux, and h2mux. NOTE: `mux` is now in meow-proxy's *default*
+#   feature list, so it ships in the NE whether or not a profile uses it
+#   (h2 + yamux + tokio-util). Watch the 50 MB NE budget.
+# - Correctness fixes on paths this crate leans on: fake-IP lookup
+#   serialisation against a check-then-act double-allocate (#434/#436),
+#   fake-ip store compare-and-delete symmetry (#454), atomic UDP NAT-key
+#   claim with eviction gated on session identity (#432/#438 — same family
+#   as the project_udp_nat_dashmap_deadlock freeze), and h2 write-path
+#   partial-write / cancelled-datagram recovery (#423, #428, #441, #452).
+# - Hardening: REALITY pre-auth transcript cap + ordering (#430/#439),
+#   rule / proxy-provider path containment inside the cache dir
+#   (#429/#444, polish #458), direct HTTP fetch body caps for
+#   rule-provider and geodata (#431/#437), h2 bump to 0.4.16
+#   (RUSTSEC-2026-0258).
+#
+# BREAKING, and handled on our side: #429/#444/#458 turn an absolute or
+# `..`-escaping `rule-providers[*].path` / `proxy-providers[*].path` into a
+# hard `load_config` error — i.e. the tunnel would refuse to start on any
+# profile exported from a desktop client. `prepare_ios_config`
+# (engine.rs::contain_provider_paths) now rewrites those to `./<basename>`
+# inside the App Group container before the engine ever sees them; see
+# `escaping_provider_paths_are_contained` and
+# `prepared_escaping_provider_config_actually_loads`. We do not set
+# `SKIP_SAFE_PATH_CHECK` (the #458 mihomo-compat hatch) — rewriting keeps
+# the containment guarantee.
+# - DNS: proxy server hostnames now resolve through the configured DNS
+#   (#420). `engine::start` hands `dns.proxy_resolver` to
+#   `ResolverHostHook::new_with_proxy_resolver` so a
+#   `dns.proxy-server-nameserver` block is honoured instead of always
+#   going through the main resolver. Hosts-file domain aliases (#410).
+# - Interop: unquoted numeric `reality-opts.short-id` (#408/#446), XTLS
+#   Vision + mux gate narrowed to sing-mux so Mux.Cool is allowed
+#   (#424/#445).
+# - meow-rs vendored the madeye/lwip fork in-tree as `meow-lwip` (#409,
+#   #411), but only behind `listener-tun`, which this crate does not
+#   enable — so it does not collide with our own `lwip` patch below.
 #
 # Base 0.20.1 (c5557577) picked up the AnyTLS outbound + REALITY
 # rework (#377: REALITY moved in-tree onto rustls primitives so it no longer
@@ -91,7 +130,7 @@ lwip = "0.3"
 # VMess AEAD interop fix. meow-dns runs in fake-ip mode: the FFI config
 # parser pins `enhanced-mode: fake-ip` with `fake-ip-range: 28.0.0.0/8`
 # (the 2026-07-17 redir-host/DoT switch was reverted in PR #321).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -108,12 +147,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d283
 # the lwip tun2socks path; would drag netstack-smoltcp/tun-rs dead weight
 # into the NE binary) and `external-ui-download` (force-disabled at compile
 # time on iOS; would only add the zip crate).
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc", features = ["boring-tls", "anytls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "041c986a24d28316498de6ad01a4460ae62b42cc" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e", features = ["boring-tls", "anytls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
 
 [build-dependencies]
 cbindgen = "0.28"

--- a/core/rust/meow-ios-ffi/src/engine.rs
+++ b/core/rust/meow-ios-ffi/src/engine.rs
@@ -101,8 +101,89 @@ fn prepare_ios_config(yaml: &str) -> Result<String> {
         if !m.contains_key(&key) {
             m.insert(key, serde_yaml::Value::Number(10.into()));
         }
+        contain_provider_paths(m);
     }
     serde_yaml::to_string(&doc).context("serializing stripped config YAML")
+}
+
+/// Rewrite `rule-providers[*].path` / `proxy-providers[*].path` values that
+/// would escape the provider cache directory into a contained
+/// `./<basename>`.
+///
+/// meow-rs gained a `safe_path` containment guard (upstream #429): a provider
+/// `path:` that is absolute, or that lexically escapes the cache dir via
+/// `..`, is now a hard error out of `load_config` — which on iOS means
+/// `meow_engine_start` fails and the tunnel never comes up. That guard is
+/// correct (it closed an arbitrary-file-write), but it is a breaking change
+/// for a very common real-world config: a subscription or profile exported
+/// from a desktop client carries paths like
+/// `/Users/me/.config/meow/ruleset/cn.yaml`.
+///
+/// Rejecting those on iOS buys nothing. The App Group container is the only
+/// writable location in the sandbox, so a desktop absolute path could never
+/// have resolved here regardless — it is dead information, not user intent.
+/// Normalizing it to the basename inside the cache dir preserves the
+/// provider's function and keeps upstream's containment guarantee intact
+/// (we only ever write a contained relative path back).
+///
+/// Contained relative paths are left untouched, so configs authored for iOS
+/// keep their exact on-disk layout, subdirectories included.
+fn contain_provider_paths(root: &mut serde_yaml::Mapping) {
+    for section in ["rule-providers", "proxy-providers"] {
+        let Some(serde_yaml::Value::Mapping(providers)) =
+            root.get_mut(serde_yaml::Value::String(section.to_string()))
+        else {
+            continue;
+        };
+        for (name, entry) in providers.iter_mut() {
+            let Some(entry) = entry.as_mapping_mut() else {
+                continue;
+            };
+            let path_key = serde_yaml::Value::String("path".to_string());
+            let Some(current) = entry.get(&path_key).and_then(serde_yaml::Value::as_str) else {
+                continue;
+            };
+            let Some(safe) = contained_provider_path(current, name.as_str()) else {
+                continue;
+            };
+            tracing::warn!(
+                "prepare_ios_config: {section} '{}' path '{current}' escapes the provider \
+                 directory; rewriting to '{safe}' inside the App Group container",
+                name.as_str().unwrap_or("?"),
+            );
+            entry.insert(path_key, serde_yaml::Value::String(safe));
+        }
+    }
+}
+
+/// Return `Some(replacement)` when `path` would escape the provider cache
+/// directory, or `None` when it is already contained and must be left alone.
+///
+/// Lexical, not filesystem-based: the cache dir is the App Group container at
+/// runtime and does not exist during unit tests, so `canonicalize` is not
+/// available here. meow-rs re-checks the result against the real directory
+/// anyway — this pass only has to stop handing it a path it will reject.
+fn contained_provider_path(path: &str, name: Option<&str>) -> Option<String> {
+    use std::path::{Component, Path};
+
+    let p = Path::new(path);
+    let escapes = p.is_absolute()
+        || p.components()
+            .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)));
+    if !escapes {
+        return None;
+    }
+
+    // Prefer the original file name so a rewritten provider keeps a
+    // recognizable on-disk identity; fall back to the provider's key when the
+    // path has no usable final component (`/`, `..`, …).
+    let basename = p
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty() && *s != ".." && *s != ".")
+        .or(name)
+        .unwrap_or("provider");
+    Some(format!("./{basename}"))
 }
 
 /// RAII handle that removes a file on drop. Used so the sibling
@@ -258,7 +339,20 @@ pub fn start(config_path: &str) -> Result<()> {
     // the upstream never resolves to a 28.x fake IP. Android installs the same
     // hook plus a `SocketProtector` via its JNI bridge; iOS needs only the hook
     // (the NE process's own sockets already bypass its tunnel).
-    meow_common::set_host_resolver(Arc::new(meow_dns::ResolverHostHook::new(resolver.clone())));
+    //
+    // `new_with_proxy_resolver` (meow-rs #420) honours
+    // `dns.proxy-server-nameserver` when set: proxy-server hostnames then
+    // resolve only through that dedicated resolver, matching mihomo. When
+    // unset, `proxy_resolver` is `None` and the hook uses the main resolver.
+    // Always install: iOS is a VPN platform and `meow_patch_config` pins
+    // `dns.enable: true`, so the stub-resolver-when-DNS-off desktop path
+    // does not apply.
+    meow_common::set_host_resolver(Arc::new(
+        meow_dns::ResolverHostHook::new_with_proxy_resolver(
+            resolver.clone(),
+            cfg.dns.proxy_resolver.clone(),
+        ),
+    ));
 
     let tunnel = Tunnel::new(resolver.clone());
     tunnel.set_mode(cfg.general.mode);
@@ -583,6 +677,199 @@ log-level: info
                 .and_then(|v| v.as_i64()),
             Some(42),
             "a user/subscription-set value must win over the injected default"
+        );
+    }
+
+    /// Helper: run `prepare_ios_config` over a one-provider config and return
+    /// the `path:` it emitted.
+    fn prepared_provider_path(section: &str, path: &str) -> String {
+        let yaml = format!(
+            "mode: rule\n{section}:\n  cn:\n    type: http\n    behavior: domain\n    \
+             url: https://example.test/cn.txt\n    path: {path}\n"
+        );
+        let out = prepare_ios_config(&yaml).expect("strip ok");
+        let doc: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        doc.as_mapping()
+            .unwrap()
+            .get(serde_yaml::Value::String(section.into()))
+            .and_then(serde_yaml::Value::as_mapping)
+            .and_then(|m| m.get(serde_yaml::Value::String("cn".into())))
+            .and_then(serde_yaml::Value::as_mapping)
+            .and_then(|m| m.get(serde_yaml::Value::String("path".into())))
+            .and_then(serde_yaml::Value::as_str)
+            .expect("path key survives")
+            .to_string()
+    }
+
+    #[test]
+    fn contained_provider_paths_are_left_untouched() {
+        // Configs authored for iOS must keep their exact on-disk layout,
+        // subdirectories included — rewriting these would move the cache file
+        // out from under an already-populated container.
+        for path in ["./cn.txt", "cn.txt", "./ruleset/cn.txt", "ruleset/cn.txt"] {
+            assert_eq!(
+                prepared_provider_path("rule-providers", path),
+                path,
+                "contained path {path} must not be rewritten"
+            );
+        }
+    }
+
+    #[test]
+    fn escaping_provider_paths_are_contained() {
+        // Regression guard for the meow-rs #429 `safe_path` containment: these
+        // shapes hard-fail `load_config` (verified against the pinned engine),
+        // so `prepare_ios_config` has to normalize them or the tunnel never
+        // starts. A desktop-exported profile is the common source.
+        for section in ["rule-providers", "proxy-providers"] {
+            assert_eq!(
+                prepared_provider_path(section, "/Users/me/.config/meow/ruleset/cn.yaml"),
+                "./cn.yaml",
+                "{section}: an absolute desktop path must be contained by basename"
+            );
+            assert_eq!(
+                prepared_provider_path(section, "../../etc/cn.txt"),
+                "./cn.txt",
+                "{section}: a `..` escape must be contained by basename"
+            );
+        }
+    }
+
+    #[test]
+    fn escaping_provider_path_without_basename_falls_back_to_provider_name() {
+        assert_eq!(
+            prepared_provider_path("rule-providers", "/"),
+            "./cn",
+            "a path with no usable final component falls back to the provider key"
+        );
+    }
+
+    fn load_yaml_in_tempdir(yaml: &str) -> anyhow::Result<meow_config::Config> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let f = dir.path().join("effective-config.yaml");
+        std::fs::write(&f, yaml).unwrap();
+        crate::get_engine_runtime().block_on(meow_config::load_config(f.to_str().unwrap()))
+    }
+
+    fn assert_prepared_escaping_provider_loads(section: &str, yaml: &str) {
+        // End-to-end: the whole point of the rewrite is that the engine's own
+        // loader accepts the result. Runs the prepared YAML through
+        // `load_config` with a real cache dir, which is where meow-rs applies
+        // the containment check. #458 made proxy-provider escapes a hard
+        // rebuild failure (rule-provider parity), so both sections must pass.
+        let prepared = prepare_ios_config(yaml).expect("strip ok");
+        let res = load_yaml_in_tempdir(&prepared);
+        assert!(
+            res.is_ok(),
+            "prepared {section} config must clear the engine's provider-path containment, got: {:?}",
+            res.err()
+        );
+    }
+
+    #[test]
+    fn unprepared_escaping_rule_provider_path_is_rejected_by_engine() {
+        // Pins that 0.21.0 still hard-fails #429 containment — the rewrite
+        // in `prepare_ios_config` is load-bearing, not defensive.
+        let yaml = "mixed-port: 7890\nproxies:\n  - name: p1\n    type: direct\nrules:\n  \
+                    - MATCH,p1\nrule-providers:\n  cn:\n    type: http\n    behavior: domain\n    \
+                    url: https://example.test/cn.txt\n    path: /var/mobile/ruleset/cn.txt\n    \
+                    interval: 86400\n";
+        let Err(err) = load_yaml_in_tempdir(yaml) else {
+            panic!("escaping rule-provider path must fail load_config");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("escapes"),
+            "engine must reject the unprepared path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn unprepared_escaping_proxy_provider_path_is_rejected_by_engine() {
+        // #458: proxy-provider escapes fail the whole rebuild, not warn-skip.
+        let yaml = "mixed-port: 7890\nproxies:\n  - name: p1\n    type: direct\nrules:\n  \
+                    - MATCH,p1\nproxy-providers:\n  nodes:\n    type: http\n    \
+                    url: https://example.test/proxies.yaml\n    path: /Users/me/.config/meow/nodes.yaml\n    \
+                    interval: 86400\n";
+        let Err(err) = load_yaml_in_tempdir(yaml) else {
+            panic!("escaping proxy-provider path must fail load_config");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("escapes"),
+            "engine must reject the unprepared path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn prepared_escaping_provider_config_actually_loads() {
+        assert_prepared_escaping_provider_loads(
+            "rule-providers",
+            "mixed-port: 7890\nproxies:\n  - name: p1\n    type: direct\nrules:\n  \
+             - MATCH,p1\nrule-providers:\n  cn:\n    type: http\n    behavior: domain\n    \
+             url: https://example.test/cn.txt\n    path: /var/mobile/ruleset/cn.txt\n    \
+             interval: 86400\n",
+        );
+    }
+
+    #[test]
+    fn prepared_escaping_proxy_provider_config_actually_loads() {
+        // #458: proxy-provider containment violations now fail the whole
+        // rebuild, not warn-skip. A desktop-exported `path:` would take the
+        // tunnel down unless `prepare_ios_config` rewrites it first.
+        assert_prepared_escaping_provider_loads(
+            "proxy-providers",
+            "mixed-port: 7890\nproxies:\n  - name: p1\n    type: direct\nrules:\n  \
+             - MATCH,p1\nproxy-providers:\n  nodes:\n    type: http\n    \
+             url: https://example.test/proxies.yaml\n    path: /Users/me/.config/meow/nodes.yaml\n    \
+             interval: 86400\n",
+        );
+    }
+
+    #[test]
+    fn proxy_server_nameserver_builds_dedicated_resolver() {
+        // meow-rs #420: `dns.proxy-server-nameserver` produces a dedicated
+        // `proxy_resolver` that `start()` must hand to
+        // `ResolverHostHook::new_with_proxy_resolver`. If this goes `None`
+        // the hook silently falls back to the main resolver and the user's
+        // proxy-server nameservers are ignored.
+        let yaml = r#"
+mixed-port: 7890
+dns:
+  enable: true
+  nameserver: [8.8.8.8]
+  proxy-server-nameserver: [1.1.1.1]
+proxies:
+  - name: p1
+    type: direct
+rules:
+  - MATCH,p1
+"#;
+        let cfg = load_stripped_config_from_str(yaml).expect("config loads");
+        assert!(cfg.dns.enabled, "dns.enable: true must survive prepare");
+        assert!(
+            cfg.dns.proxy_resolver.is_some(),
+            "proxy-server-nameserver must produce a dedicated resolver"
+        );
+    }
+
+    #[test]
+    fn no_proxy_server_nameserver_leaves_proxy_resolver_none() {
+        let yaml = r#"
+mixed-port: 7890
+dns:
+  enable: true
+  nameserver: [8.8.8.8]
+proxies:
+  - name: p1
+    type: direct
+rules:
+  - MATCH,p1
+"#;
+        let cfg = load_stripped_config_from_str(yaml).expect("config loads");
+        assert!(
+            cfg.dns.proxy_resolver.is_none(),
+            "without proxy-server-nameserver the hook must use the main resolver"
         );
     }
 

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,10 +1,8 @@
-• Reliability: the tunnel's TCP/IP engine was reworked from the ground up, fixing rare "connected but no traffic" freezes — especially after the phone sleeps overnight
-• Smarter wake handling: after waking, the tunnel checks its actual data path and only restarts when truly needed
-• DNS: the dns: section of your config (nameserver, fallback, fake-ip-filter, nameserver-policy) is now respected
-• Config changes apply instantly with hot reload, without dropping the connection where possible
-• New App Icon picker in Settings, with two additional icons
-• "Subscriptions" are now called "Configs" throughout the app
-• Global mode now routes through your config's primary outbound
-• Clearer error when a config URL uses plain http:// instead of https://
+• Proxy engine updated to meow-rs 0.21.0, adding multiplexing (sing-mux, yamux, h2mux, Mux.Cool) plus fake-IP, UDP NAT, and REALITY/h2 reliability fixes
+• Desktop-exported configs with absolute rule- or proxy-provider paths now start on iOS
+• dns.proxy-server-nameserver is honoured when set
+• Hung DIRECT connections time out in 10 seconds instead of hanging
+• The tunnel waits for the app's first TCP payload before opening a proxy connection, so port probes no longer create phantom sessions
+• One UDP ASSOCIATE per app source port, so P2P/BitTorrent swarms no longer starve HTTPS
 
 Issues and feedback: https://github.com/madeye/meow-ios/issues

--- a/fastlane/metadata/zh-Hans/release_notes.txt
+++ b/fastlane/metadata/zh-Hans/release_notes.txt
@@ -1,10 +1,8 @@
-• 稳定性：隧道的 TCP/IP 引擎彻底重构，修复了偶发的"显示已连接但没有流量"卡死问题——尤其是手机过夜休眠后
-• 更智能的唤醒处理：唤醒后先检查数据通路的真实状态，只在确有必要时才重启
-• DNS：配置文件的 dns: 段（nameserver、fallback、fake-ip-filter、nameserver-policy）现在会被尊重
-• 配置变更即时热加载，尽可能不中断连接
-• 设置中新增应用图标选择页，附两款新图标
-• "订阅"统一更名为"配置"
-• 全局模式现在走配置的主出站节点
-• 配置链接使用纯 http:// 时会给出明确错误提示
+• 代理引擎升级到 meow-rs 0.21.0，新增多路复用（sing-mux、yamux、h2mux、Mux.Cool），并修复 fake-IP、UDP NAT 与 REALITY/h2 稳定性问题
+• 从桌面端导出、带绝对路径规则/代理提供者的配置现在可以在 iOS 上启动
+• 配置了 dns.proxy-server-nameserver 时会生效
+• 卡住的 DIRECT 连接会在 10 秒超时，而不再一直挂起
+• 隧道会等应用发出第一个 TCP 数据包再建立代理连接，端口探测不再产生幽灵会话
+• 每个应用源端口共用一条 UDP ASSOCIATE，P2P/BitTorrent 集群不会再挤占 HTTPS
 
 问题与反馈：https://github.com/madeye/meow-ios/issues

--- a/metadata/testflight/whats_new/2026082201.txt
+++ b/metadata/testflight/whats_new/2026082201.txt
@@ -1,0 +1,9 @@
+Build 2026082201 (1.6.0)
+
+• Proxy engine updated to meow-rs 0.21.0: multiplexing (sing-mux, yamux, h2mux, Mux.Cool), fake-IP race fixes, safer UDP NAT, and REALITY/h2 hardening.
+• Desktop-exported configs with absolute rule-/proxy-provider paths now start on iOS instead of failing to load.
+• dns.proxy-server-nameserver is honoured when set.
+• Hung DIRECT connections time out in 10s instead of hanging until the idle sweeper.
+• TCP: the tunnel waits for the app's first payload before opening a proxy connection, so port probes and cancelled preconnects no longer create phantom sessions.
+• UDP: one SOCKS5 ASSOCIATE per app source port (not per peer), so P2P/BitTorrent swarms no longer starve HTTPS.
+• Please test: import a desktop Clash/meow config that uses rule-providers; browse normally; try a mux-enabled node if your subscription has one; leave the VPN connected overnight.

--- a/metadata/testflight/zh-Hans/whats_new/2026082201.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026082201.txt
@@ -1,0 +1,9 @@
+构建 2026082201 (1.6.0)
+
+• 代理引擎升级到 meow-rs 0.21.0：支持多路复用（sing-mux、yamux、h2mux、Mux.Cool），修复 fake-IP 竞态，UDP NAT 更安全，并加固 REALITY/h2。
+• 从桌面端导出、带绝对路径 rule-providers / proxy-providers 的配置现在可以在 iOS 上启动，不再加载失败。
+• 配置了 dns.proxy-server-nameserver 时会生效。
+• 卡住的 DIRECT 连接会在 10 秒超时，而不再等到空闲清理。
+• TCP：隧道会等应用发出第一个数据包再建立代理连接，端口探测和被取消的预连接不再产生幽灵会话。
+• UDP：每个应用源端口共用一条 SOCKS5 ASSOCIATE（不再按对端拆），P2P/BitTorrent 集群不会再挤占 HTTPS。
+• 请测试：导入带 rule-providers 的桌面 Clash/meow 配置；正常浏览；如果订阅里有 mux 节点请试连；让 VPN 保持连接过夜。

--- a/project.yml
+++ b/project.yml
@@ -42,8 +42,8 @@ targets:
       path: App/Info.plist
       properties:
         CFBundleDisplayName: meow
-        CFBundleShortVersionString: "1.5.0"
-        CFBundleVersion: "2026080601"
+        CFBundleShortVersionString: "1.6.0"
+        CFBundleVersion: "2026082201"
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen:
@@ -192,8 +192,8 @@ targets:
       path: PacketTunnel/Info.plist
       properties:
         CFBundleDisplayName: meow Tunnel
-        CFBundleShortVersionString: "1.5.0"
-        CFBundleVersion: "2026080601"
+        CFBundleShortVersionString: "1.6.0"
+        CFBundleVersion: "2026082201"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.networkextension.packet-tunnel
           NSExtensionPrincipalClass: PacketTunnelProvider


### PR DESCRIPTION
## Summary

Bump the embedded meow-rs engine from the `ios/connect-timeout-0.20.1` side branch to **v0.21.0** (`ac3fcd8d`) and cut **1.6.0** (build `2026082201`).

- `tcp-connect-timeout` is on main, so the side-branch pin is retired.
- `prepare_ios_config` rewrites absolute/`..` rule- and proxy-provider paths so desktop-exported profiles survive the #429/#444/#458 `load_config` containment check.
- `engine::start` uses `ResolverHostHook::new_with_proxy_resolver` so `dns.proxy-server-nameserver` is honoured (#420).
- TestFlight What-to-Test + App Store release notes for 1.6.0.

Also includes the tun2socks fixes already on main since 1.5.0 (first-payload TCP dial, per-source UDP ASSOCIATE, 10s DIRECT connect bound).

## Path B — local-CI-green attestation

- [x] `swiftformat --lint .` at repo root → 0 files require formatting.
- [x] `swiftlint --strict` at repo root → 0 violations in 113 files.
- [x] Matching test suites locally:
  - `cd core/rust/meow-ios-ffi && cargo test --lib` → **79 passed**
  - `cd core/rust/meow-ios-ffi && cargo clippy --all-targets -- -D warnings` → clean
  - `scripts/build-rust.sh` → xcframework written
  - `cargo build --release --target aarch64-apple-ios` → success
  - No Swift source changes (plist/version/notes only on the app side), so MeowTests/UITests not re-run.
- [x] `git diff origin/main...HEAD --stat` verified — 13 files, all intended (rust pin + engine.rs + version plists + notes). No accidental additions.

## Test plan

- [x] Provider-path containment: unprepared escaping paths fail `load_config`; prepared YAML loads (rule- and proxy-providers).
- [x] `dns.proxy-server-nameserver` produces a dedicated resolver; absence leaves it `None`.
- [x] Device Release install of the 0.21.0 engine on Max Lv's iPhone (1.5.0 build was still on-device; this PR is the 1.6.0 cut).