### PR TITLE
docs: point repo and site URLs at the meow-rs org

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -59,4 +59,4 @@ If this policy changes, the updated text will be committed to this repository. T
 
 ## Contact
 
-Questions about this policy: open an issue at <https://github.com/madeye/meow-ios/issues> or email <max.c.lv@gmail.com>.
+Questions about this policy: open an issue at <https://github.com/meow-rs/meow-ios/issues> or email <max.c.lv@gmail.com>.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ branding. Since then, `main` also picked up a wake-from-idle reliability
 fix — after sleep/wake the tunnel probes its data path and only restarts
 when the probe fails — plus a meow-rs engine bump to 0.18.0 and a leading
 swipe menu for refreshing individual subscriptions. See the
-[release notes](https://github.com/madeye/meow-ios/releases) for earlier
+[release notes](https://github.com/meow-rs/meow-ios/releases) for earlier
 per-version changelogs.
 
 ## Status

--- a/docs/INVESTIGATION-2026-05-19-geoip-download-tls-failure.md
+++ b/docs/INVESTIGATION-2026-05-19-geoip-download-tls-failure.md
@@ -350,6 +350,6 @@ e442d7b  feat(geo): lazy-download GeoIP/ASN databases on connect
 ```
 
 No GitHub issue currently filed for this specific banner. `gh search`
-across `madeye/meow-ios` for `geoip OR jsdelivr OR "无法启动隧道" OR
+across `meow-rs/meow-ios` for `geoip OR jsdelivr OR "无法启动隧道" OR
 "Failed to download" OR TLS` returned only #112 (YAML import format,
 unrelated).

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,14 +18,14 @@
       property="og:description"
       content="Native iOS proxy client (meow-rs) for iOS 17+. Clash-style YAML subscriptions, rule-based routing, DNS over HTTPS, QR-code profile sharing, and a SwiftUI material design in light and dark. Available on the App Store, with a public beta on TestFlight."
     />
-    <meta property="og:url" content="https://madeye.github.io/meow-ios/" />
+    <meta property="og:url" content="https://meow-rs.github.io/meow-ios/" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://madeye.github.io/meow-ios/appicon.png" />
+    <meta property="og:image" content="https://meow-rs.github.io/meow-ios/appicon.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1024" />
     <meta property="og:image:height" content="1024" />
     <meta property="og:image:alt" content="meow app icon — an orange tabby cat peeking over a white ledge with its paws draped over the edge, on a blue background" />
-    <meta property="og:video" content="https://media.githubusercontent.com/media/madeye/meow-ios/main/docs/meow-intro.mp4" />
+    <meta property="og:video" content="https://media.githubusercontent.com/media/meow-rs/meow-ios/main/docs/meow-intro.mp4" />
     <meta property="og:video:type" content="video/mp4" />
     <meta property="og:video:width" content="1920" />
     <meta property="og:video:height" content="1080" />
@@ -37,7 +37,7 @@
       name="twitter:description"
       content="Native iOS proxy client (meow-rs) for iOS 17+. Clash-style YAML subscriptions, rule-based routing, DoH, QR-code profile sharing, and a SwiftUI material design in light and dark. Available on the App Store, with a public beta on TestFlight."
     />
-    <meta name="twitter:image" content="https://madeye.github.io/meow-ios/appicon.png" />
+    <meta name="twitter:image" content="https://meow-rs.github.io/meow-ios/appicon.png" />
     <meta name="twitter:image:alt" content="meow app icon — an orange tabby cat peeking over a white ledge with its paws draped over the edge, on a blue background" />
 
     <link rel="icon" type="image/png" href="appicon.png" />
@@ -477,11 +477,11 @@
             height="1080"
           >
             <source
-              src="https://media.githubusercontent.com/media/madeye/meow-ios/main/docs/meow-intro.mp4"
+              src="https://media.githubusercontent.com/media/meow-rs/meow-ios/main/docs/meow-intro.mp4"
               type="video/mp4"
             />
             Your browser does not support embedded video. Watch on
-            <a href="https://media.githubusercontent.com/media/madeye/meow-ios/main/docs/meow-intro.mp4">meow-intro.mp4</a>.
+            <a href="https://media.githubusercontent.com/media/meow-rs/meow-ios/main/docs/meow-intro.mp4">meow-intro.mp4</a>.
           </video>
         </div>
 
@@ -498,7 +498,7 @@
             </svg>
             Join the beta
           </a>
-          <a class="cta-secondary" href="https://github.com/madeye/meow-ios">
+          <a class="cta-secondary" href="https://github.com/meow-rs/meow-ios">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.69-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17.91-.26 1.89-.39 2.86-.39.97 0 1.95.13 2.86.39 2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56C20.21 21.39 23.5 17.07 23.5 12 23.5 5.65 18.35.5 12 .5Z"/>
             </svg>
@@ -605,7 +605,7 @@
             tunnel runs locally inside the Network Extension sandbox; the only
             network traffic is the proxy traffic you configure yourself. See
             the
-            <a href="https://github.com/madeye/meow-ios/blob/main/PRIVACY.md"
+            <a href="https://github.com/meow-rs/meow-ios/blob/main/PRIVACY.md"
               >privacy policy</a
             >.
           </p>
@@ -622,16 +622,16 @@
           </p>
           <p>
             Please report issues via
-            <a href="https://github.com/madeye/meow-ios/issues">GitHub Issues</a>.
+            <a href="https://github.com/meow-rs/meow-ios/issues">GitHub Issues</a>.
           </p>
         </div>
 
         <h2>Open source</h2>
         <p class="section-sub" style="margin-bottom: 0;">
           meow-ios is open source under the
-          <a href="https://github.com/madeye/meow-ios/blob/main/LICENSE">MIT license</a>.
+          <a href="https://github.com/meow-rs/meow-ios/blob/main/LICENSE">MIT license</a>.
           Source, issue tracker, and release notes live at
-          <a href="https://github.com/madeye/meow-ios">github.com/madeye/meow-ios</a>.
+          <a href="https://github.com/meow-rs/meow-ios">github.com/meow-rs/meow-ios</a>.
         </p>
 
         <footer>

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -25,4 +25,4 @@ meow is a one-time purchase, with no in-app purchases and no subscription fees. 
 
 OPEN SOURCE
 meow-ios is open source. Source, issue tracker, and release notes:
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/fastlane/metadata/en-US/marketing_url.txt
+++ b/fastlane/metadata/en-US/marketing_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/fastlane/metadata/en-US/privacy_url.txt
+++ b/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios/blob/main/PRIVACY.md
+https://github.com/meow-rs/meow-ios/blob/main/PRIVACY.md

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -5,4 +5,4 @@
 • The tunnel waits for the app's first TCP payload before opening a proxy connection, so port probes no longer create phantom sessions
 • One UDP ASSOCIATE per app source port, so P2P/BitTorrent swarms no longer starve HTTPS
 
-Issues and feedback: https://github.com/madeye/meow-ios/issues
+Issues and feedback: https://github.com/meow-rs/meow-ios/issues

--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/fastlane/metadata/review_information/notes.txt
+++ b/fastlane/metadata/review_information/notes.txt
@@ -6,9 +6,9 @@ HOW TO TEST THE SUBSCRIPTION FEATURE
 1. Launch meow. The first tab is "Subscriptions".
 2. Tap the "+" button in the top-right toolbar and choose "Add from URL".
 3. Enter any name and this demo configuration URL:
-   https://raw.githubusercontent.com/madeye/meow-ios/main/docs/review-demo-config.yaml
+   https://raw.githubusercontent.com/meow-rs/meow-ios/main/docs/review-demo-config.yaml
 4. Tap Add. The YAML configuration is downloaded and listed. The pencil icon opens the built-in YAML editor; the refresh icon re-fetches the subscription.
 5. With the demo subscription selected, turn on the switch in the bar at the top of the screen and approve the iOS VPN permission prompt. The packet tunnel starts; the "Proxy Groups" tab shows the "Demo" group from the configuration.
 6. Browse in Safari — traffic flows through the on-device tunnel (the demo configuration routes it DIRECT, since meow does not operate any proxy servers).
 
-PRIVACY: the app collects no user data of any kind (no analytics/tracking SDKs, no developer servers). Traffic is processed entirely on-device by the Network Extension and forwarded only to servers from the user's own configuration. Privacy policy: https://github.com/madeye/meow-ios/blob/main/PRIVACY.md
+PRIVACY: the app collects no user data of any kind (no analytics/tracking SDKs, no developer servers). Traffic is processed entirely on-device by the Network Extension and forwarded only to servers from the user's own configuration. Privacy policy: https://github.com/meow-rs/meow-ios/blob/main/PRIVACY.md

--- a/fastlane/metadata/zh-Hans/description.txt
+++ b/fastlane/metadata/zh-Hans/description.txt
@@ -25,4 +25,4 @@ meow 为一次性买断的付费应用，不含任何内购或订阅收费。本
 
 开源
 meow-ios 是开源软件。源代码、问题追踪与发布说明：
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/fastlane/metadata/zh-Hans/marketing_url.txt
+++ b/fastlane/metadata/zh-Hans/marketing_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/fastlane/metadata/zh-Hans/privacy_url.txt
+++ b/fastlane/metadata/zh-Hans/privacy_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios/blob/main/PRIVACY.md
+https://github.com/meow-rs/meow-ios/blob/main/PRIVACY.md

--- a/fastlane/metadata/zh-Hans/release_notes.txt
+++ b/fastlane/metadata/zh-Hans/release_notes.txt
@@ -5,4 +5,4 @@
 • 隧道会等应用发出第一个 TCP 数据包再建立代理连接，端口探测不再产生幽灵会话
 • 每个应用源端口共用一条 UDP ASSOCIATE，P2P/BitTorrent 集群不会再挤占 HTTPS
 
-问题与反馈：https://github.com/madeye/meow-ios/issues
+问题与反馈：https://github.com/meow-rs/meow-ios/issues

--- a/fastlane/metadata/zh-Hans/support_url.txt
+++ b/fastlane/metadata/zh-Hans/support_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/en-US/description.txt
+++ b/metadata/en-US/description.txt
@@ -25,4 +25,4 @@ meow is a one-time purchase, with no in-app purchases and no subscription fees. 
 
 OPEN SOURCE
 meow-ios is open source. Source, issue tracker, and release notes:
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/metadata/en-US/marketing_url.txt
+++ b/metadata/en-US/marketing_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/metadata/en-US/privacy_url.txt
+++ b/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios/blob/main/PRIVACY.md
+https://github.com/meow-rs/meow-ios/blob/main/PRIVACY.md

--- a/metadata/en-US/release_notes.txt
+++ b/metadata/en-US/release_notes.txt
@@ -8,4 +8,4 @@
 
 Known limitation: non-DNS UDP traffic is not yet forwarded by the tunnel — QUIC/HTTP3 falls back to TCP HTTP/2 (usually transparent to the user). Fix is in progress.
 
-Issues and feedback: https://github.com/madeye/meow-ios/issues
+Issues and feedback: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/en-US/support_url.txt
+++ b/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/beta_app_description.txt
+++ b/metadata/testflight/beta_app_description.txt
@@ -6,4 +6,4 @@ Known limitation: non-DNS UDP traffic is not yet forwarded — QUIC/HTTP3 falls 
 
 The app does not collect analytics, subscription URLs, proxy credentials, configuration contents, DNS queries, or tunneled traffic.
 
-GitHub: https://github.com/madeye/meow-ios
+GitHub: https://github.com/meow-rs/meow-ios

--- a/metadata/testflight/beta_app_marketing_url.txt
+++ b/metadata/testflight/beta_app_marketing_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/metadata/testflight/whats_new/2026042501.txt
+++ b/metadata/testflight/whats_new/2026042501.txt
@@ -17,4 +17,4 @@ KNOWN LIMITATIONS
 • Non-DNS UDP traffic is not forwarded yet. WireGuard outbounds will not pass traffic. QUIC / HTTP3 falls back to TCP HTTP/2 (usually transparent).
 
 Please send TestFlight feedback or open an issue at:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026042502.txt
+++ b/metadata/testflight/whats_new/2026042502.txt
@@ -29,4 +29,4 @@ KNOWN LIMITATIONS
   HTTP/2 (usually transparent).
 
 Please send TestFlight feedback or open an issue at:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026042906.txt
+++ b/metadata/testflight/whats_new/2026042906.txt
@@ -44,4 +44,4 @@ KNOWN LIMITATIONS
   by design — matches trust-china-dns upstream).
 
 Please send TestFlight feedback or open an issue at:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026043001.txt
+++ b/metadata/testflight/whats_new/2026043001.txt
@@ -27,4 +27,4 @@ KNOWN LIMITATIONS
   upstreams by design — matches trust-china-dns upstream).
 
 Please send TestFlight feedback or open an issue at:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026051201.txt
+++ b/metadata/testflight/whats_new/2026051201.txt
@@ -58,4 +58,4 @@ KNOWN LIMITATIONS
   subscription / config YAML instead.
 
 Please send TestFlight feedback or open an issue at:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026051301.txt
+++ b/metadata/testflight/whats_new/2026051301.txt
@@ -59,4 +59,4 @@ WHAT TO TEST
    editor — no new crashes or UI hangs vs 2026051201.
 
 Please send TestFlight feedback or open an issue at:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026052004.txt
+++ b/metadata/testflight/whats_new/2026052004.txt
@@ -69,4 +69,4 @@ FOR TESTERS
   with the device model and iOS version. Include the timing:
   "instant on launch" vs "after first connect attempt" — they
   point at different code paths.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026052102.txt
+++ b/metadata/testflight/whats_new/2026052102.txt
@@ -69,4 +69,4 @@ FOR TESTERS
   with the device model and iOS version. Include the timing:
   "instant on launch" vs "after first connect attempt" — they
   point at different code paths.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026052103.txt
+++ b/metadata/testflight/whats_new/2026052103.txt
@@ -69,4 +69,4 @@ FOR TESTERS
   with the device model and iOS version. Include the timing:
   "instant on launch" vs "after first connect attempt" — they
   point at different code paths.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026052301.txt
+++ b/metadata/testflight/whats_new/2026052301.txt
@@ -47,4 +47,4 @@ FOR TESTERS
   GEOSITE,youtube,YouTube) and confirm the matching node is hit
   from the moment you tap Connect — previously the rule silently
   no-op'd until the geosite DB landed.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026052401.txt
+++ b/metadata/testflight/whats_new/2026052401.txt
@@ -24,4 +24,4 @@ FOR TESTERS
   this could trigger a silent disconnect under burst load.
 • Verify GEOIP rules still fire correctly (the MMDB is now mmap'd
   instead of heap-loaded; functional behavior should be identical).
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026052503.txt
+++ b/metadata/testflight/whats_new/2026052503.txt
@@ -23,4 +23,4 @@ FOR TESTERS
 • Heavy-browsing memory test: open 10+ tabs simultaneously and
   confirm the VPN stays connected (no jetsam kill).
 • Verify geosite rules with keyword/regex patterns fire correctly.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026052901.txt
+++ b/metadata/testflight/whats_new/2026052901.txt
@@ -34,4 +34,4 @@ FOR TESTERS
   routes (no stale state).
 • Heavy browsing: open 10+ tabs simultaneously; confirm VPN stays
   connected (no jetsam kill).
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026060701.txt
+++ b/metadata/testflight/whats_new/2026060701.txt
@@ -26,4 +26,4 @@ FOR TESTERS
   hop to a v4-only AP); browsing should recover within seconds.
 • QUIC check: with the VPN up on an IPv4-only network, YouTube /
   Instagram video should stream without long stalls.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026060702.txt
+++ b/metadata/testflight/whats_new/2026060702.txt
@@ -21,4 +21,4 @@ FOR TESTERS
   flow immediately in the morning.
 • IPv6 flip: on dual-stack Wi-Fi, disable IPv6 on the router; browsing
   should recover within seconds.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026060703.txt
+++ b/metadata/testflight/whats_new/2026060703.txt
@@ -21,4 +21,4 @@ FOR TESTERS
   flow immediately in the morning.
 • IPv6 flip: on dual-stack Wi-Fi, disable IPv6 on the router; browsing
   should recover within seconds.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026061402.txt
+++ b/metadata/testflight/whats_new/2026061402.txt
@@ -15,4 +15,4 @@ FOR TESTERS
   videos — content should load normally over the proxy.
 • General browsing and streaming should be unaffected; please report any
   site or app that worked before but now stalls or fails to load.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026061501.txt
+++ b/metadata/testflight/whats_new/2026061501.txt
@@ -16,4 +16,4 @@ FOR TESTERS
   especially QUIC-heavy apps (Xiaohongshu / RedNote). Traffic should
   never silently stall. If you ever have to toggle the VPN to restore
   traffic, please report it with roughly when it happened.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/whats_new/2026061502.txt
+++ b/metadata/testflight/whats_new/2026061502.txt
@@ -15,4 +15,4 @@ FOR TESTERS
   YouTube, Instagram). Pages and media should load normally and stay
   routed through the proxy. If anything fails to resolve or appears to
   bypass the tunnel, please report it with the app and rough time.
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/beta_app_description.txt
+++ b/metadata/testflight/zh-Hans/beta_app_description.txt
@@ -6,4 +6,4 @@ meow 是基于 meow-rs 的原生 iOS 代理客户端——支持 Clash 风格的
 
 应用不收集分析数据、订阅地址、代理凭证、配置内容、DNS 查询或隧道转发流量。
 
-GitHub：https://github.com/madeye/meow-ios
+GitHub：https://github.com/meow-rs/meow-ios

--- a/metadata/testflight/zh-Hans/whats_new/2026042501.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026042501.txt
@@ -17,4 +17,4 @@
 • 尚未转发非 DNS 的 UDP 流量。WireGuard 出站无法通过，QUIC / HTTP3 会回退到 TCP HTTP/2（通常对用户透明）。
 
 请通过 TestFlight 反馈，或在此处提交 Issue：
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026042502.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026042502.txt
@@ -24,4 +24,4 @@
   会回退到 TCP HTTP/2（通常对用户透明）。
 
 请通过 TestFlight 反馈，或在此处提交 Issue：
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026042906.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026042906.txt
@@ -38,4 +38,4 @@ Build 2026042906 (1.1.5)
   DoH)。
 
 请通过 TestFlight 反馈或在以下地址提 issue:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026043001.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026043001.txt
@@ -22,4 +22,4 @@ GeoIP 提取的 CN 段、以及 1.1.5 的所有行为均保持不变。
   DoT / DoH)。
 
 请通过 TestFlight 反馈或在以下地址提 issue:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026051201.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026051201.txt
@@ -47,4 +47,4 @@ Build 2026051201 (1.2.0)
   YAML 的 dns: 段里指定 DNS。
 
 请通过 TestFlight 反馈或在以下地址提 issue:
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026051301.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026051301.txt
@@ -47,4 +47,4 @@ Build 2026051301 (1.2.1)
    应无新的崩溃或 UI 卡顿。
 
 如有反馈请通过 TestFlight 或前往
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026052004.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026052004.txt
@@ -59,4 +59,4 @@ Build 2026052004 (1.1.4)
   请通过 TestFlight 反馈提交,附设备型号和 iOS 版本。
   请说明时序:"启动瞬间崩" vs "首次连接尝试后崩" —— 它们
   指向不同的代码路径。
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026052102.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026052102.txt
@@ -59,4 +59,4 @@ Build 2026052102 (1.3.1)
   请通过 TestFlight 反馈提交,附设备型号和 iOS 版本。
   请说明时序:"启动瞬间崩" vs "首次连接尝试后崩" —— 它们
   指向不同的代码路径。
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026052103.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026052103.txt
@@ -59,4 +59,4 @@ Build 2026052103 (1.3.1)
   请通过 TestFlight 反馈提交,附设备型号和 iOS 版本。
   请说明时序:"启动瞬间崩" vs "首次连接尝试后崩" —— 它们
   指向不同的代码路径。
-• Issues: https://github.com/madeye/meow-ios/issues
+• Issues: https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026052301.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026052301.txt
@@ -40,4 +40,4 @@
 • GEOSITE 规则路由：从配置里挑一条（例如 GEOSITE,youtube,YouTube），
   确认点 Connect 之后立刻命中对应节点——此前该规则要等 geosite DB
   下载到位才生效。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026052401.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026052401.txt
@@ -21,4 +21,4 @@ Build 2026052401 (1.3.1)
   连接（无 jetsam 杀进程）。此前突发负载可能导致静默断连。
 • 验证 GEOIP 规则仍正常工作（MMDB 改为 mmap 加载，功能
   行为应完全一致）。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026052503.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026052503.txt
@@ -20,4 +20,4 @@ Build 2026052503 (1.3.1)
 • 重度浏览内存测试：同时打开 10+ 个标签页，确认 VPN 保持
   连接（无 jetsam 杀进程）。
 • 验证使用关键字/正则模式的 geosite 规则正常工作。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026052901.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026052901.txt
@@ -30,4 +30,4 @@ Build 2026052901 (1.3.1)
   状态）。
 • 重度浏览：同时打开 10+ 个标签页；确认 VPN 保持连接（无 jetsam
   杀进程）。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026060701.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026060701.txt
@@ -24,4 +24,4 @@ Build 2026060701 (1.3.1)
   纯 IPv4 热点），浏览应在几秒内恢复。
 • QUIC 检查：纯 IPv4 网络开启 VPN 后，YouTube / Instagram
   视频应能流畅播放，无长时间卡顿。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026060702.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026060702.txt
@@ -16,4 +16,4 @@ Build 2026060702 (1.3.1)
   问题）。
 • 整夜空闲：保持 VPN 连接过夜，早晨流量应立即恢复。
 • IPv6 切换：在双栈 Wi-Fi 上关闭路由器的 IPv6，浏览应在几秒内恢复。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026060703.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026060703.txt
@@ -16,4 +16,4 @@ Build 2026060702 (1.3.1)
   问题）。
 • 整夜空闲：保持 VPN 连接过夜，早晨流量应立即恢复。
 • IPv6 切换：在双栈 Wi-Fi 上关闭路由器的 IPv6，浏览应在几秒内恢复。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026061402.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026061402.txt
@@ -13,4 +13,4 @@ Build 2026061402 (1.3.2)
   代理加载。
 • 常规浏览与视频流应不受影响；如遇此前正常、现在却卡住或无法加载的
   网站或应用，请反馈。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026061501.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026061501.txt
@@ -12,4 +12,4 @@ Build 2026061501 (1.3.2)
 • 在网络切换和空闲时段正常使用，尤其是 QUIC 较多的应用（小红书）。
   流量不应再静默卡死。如果仍需手动开关 VPN 才能恢复，请反馈并附上
   大致发生时间。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/testflight/zh-Hans/whats_new/2026061502.txt
+++ b/metadata/testflight/zh-Hans/whats_new/2026061502.txt
@@ -12,4 +12,4 @@ Build 2026061502 (1.3.2)
 • 重点测试 HTTP/3 较多的应用和 Safari（小红书、YouTube、Instagram）。
   页面和媒体应正常加载并保持经代理路由。如果出现无法解析或疑似绕过
   隧道的情况，请反馈并附上应用名称和大致时间。
-• 问题反馈：https://github.com/madeye/meow-ios/issues
+• 问题反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/zh-Hans/description.txt
+++ b/metadata/zh-Hans/description.txt
@@ -25,4 +25,4 @@ meow 为一次性买断的付费应用，不含任何内购或订阅收费。本
 
 开源
 meow-ios 是开源软件。源代码、问题追踪与发布说明：
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/metadata/zh-Hans/marketing_url.txt
+++ b/metadata/zh-Hans/marketing_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios
+https://github.com/meow-rs/meow-ios

--- a/metadata/zh-Hans/privacy_url.txt
+++ b/metadata/zh-Hans/privacy_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios/blob/main/PRIVACY.md
+https://github.com/meow-rs/meow-ios/blob/main/PRIVACY.md

--- a/metadata/zh-Hans/release_notes.txt
+++ b/metadata/zh-Hans/release_notes.txt
@@ -8,4 +8,4 @@
 
 已知限制：隧道尚未转发非 DNS 的 UDP 流量，QUIC/HTTP3 会回退到 TCP HTTP/2（对用户通常是透明的）。正在修复。
 
-问题与反馈：https://github.com/madeye/meow-ios/issues
+问题与反馈：https://github.com/meow-rs/meow-ios/issues

--- a/metadata/zh-Hans/support_url.txt
+++ b/metadata/zh-Hans/support_url.txt
@@ -1,1 +1,1 @@
-https://github.com/madeye/meow-ios/issues
+https://github.com/meow-rs/meow-ios/issues


### PR DESCRIPTION
## Summary

The GitHub repo moved from `madeye/meow-ios` to [`meow-rs/meow-ios`](https://github.com/meow-rs/meow-ios). Pages now live at https://meow-rs.github.io/meow-ios/.

Rewrites live README, PRIVACY, landing page, App Store / TestFlight metadata, and archived What-to-Test notes. `madeye/meow-rs` (engine) and `madeye/meow` (Android) are unchanged.

Old `github.com/madeye/meow-ios` already 301s; `madeye.github.io/meow-ios` is 404.

Path A — docs/metadata only, no App/MeowCore/Swift/Rust/workflow changes.