### PR TITLE
chore(deps): bump meow-rs pin to v0.21.1

### DIFF
--- a/core/rust/geosite-mrs-builder/Cargo.lock
+++ b/core/rust/geosite-mrs-builder/Cargo.lock
@@ -454,8 +454,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "bytes",
@@ -478,8 +478,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "ipnet",
  "iprange",
@@ -495,8 +495,8 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 
 [[package]]
 name = "minimal-lexical"

--- a/core/rust/geosite-mrs-builder/Cargo.toml
+++ b/core/rust/geosite-mrs-builder/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 ureq = { version = "2", default-features = false, features = ["tls", "native-certs"] }
-meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
+meow-rules = { git = "https://github.com/madeye/meow-rs", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
 
 # `.mrs` writing pulls zstd via meow-rules; no extra dep needed here.

--- a/core/rust/macos-utun-harness/Cargo.lock
+++ b/core/rust/macos-utun-harness/Cargo.lock
@@ -2080,8 +2080,8 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2110,8 +2110,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "axum",
  "base64",
@@ -2143,8 +2143,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2167,8 +2167,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2201,8 +2201,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2263,8 +2263,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "base64",
  "libc",
@@ -2278,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2328,8 +2328,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2345,8 +2345,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2375,13 +2375,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",

--- a/core/rust/meow-ios-ffi/Cargo.lock
+++ b/core/rust/meow-ios-ffi/Cargo.lock
@@ -2018,8 +2018,8 @@ dependencies = [
 
 [[package]]
 name = "meow-anytls"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2048,8 +2048,8 @@ dependencies = [
 
 [[package]]
 name = "meow-api"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "axum",
  "base64",
@@ -2081,8 +2081,8 @@ dependencies = [
 
 [[package]]
 name = "meow-common"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2105,8 +2105,8 @@ dependencies = [
 
 [[package]]
 name = "meow-config"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2139,8 +2139,8 @@ dependencies = [
 
 [[package]]
 name = "meow-dns"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",
@@ -2203,8 +2203,8 @@ dependencies = [
 
 [[package]]
 name = "meow-listener"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "base64",
  "libc",
@@ -2218,8 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "meow-proxy"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2268,8 +2268,8 @@ dependencies = [
 
 [[package]]
 name = "meow-rules"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2285,8 +2285,8 @@ dependencies = [
 
 [[package]]
 name = "meow-transport"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2315,13 +2315,13 @@ dependencies = [
 
 [[package]]
 name = "meow-trie"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 
 [[package]]
 name = "meow-tunnel"
-version = "0.21.0"
-source = "git+https://github.com/madeye/meow-rs?rev=ac3fcd8d77ce437749b5f5e504dee020e0d99e0e#ac3fcd8d77ce437749b5f5e504dee020e0d99e0e"
+version = "0.21.1"
+source = "git+https://github.com/madeye/meow-rs?rev=bc38424bcea5efad18b4dbb2ebd679f54fc68531#bc38424bcea5efad18b4dbb2ebd679f54fc68531"
 dependencies = [
  "async-trait",
  "dashmap 6.2.1",

--- a/core/rust/meow-ios-ffi/Cargo.toml
+++ b/core/rust/meow-ios-ffi/Cargo.toml
@@ -68,12 +68,17 @@ lwip = "0.3"
 # to a release tag normally; bump deliberately rather than tracking main.
 # Each crate is a workspace member of madeye/meow-rs.
 #
-# HEAD: ac3fcd8d — meow-rs v0.21.0. This retires the
-# `ios/connect-timeout-0.20.1` side branch: its one commit (the global
-# `tcp-connect-timeout:` field wired into DirectAdapter::with_connect_timeout,
-# which `prepare_ios_config` injects at 10 s) merged to main before 0.21.0,
-# so the release is a superset and the branch no longer needs to be kept
-# alive as a Cargo anchor.
+# HEAD: bc38424b — meow-rs v0.21.1. Adds the AnyTLS handshake fix
+# (#469): auth used to go out as three TLS records; anytls-go / sing-box
+# / sing-anytls read it in one shot, saw only the 32-byte password hash,
+# and EOF'd on padding length — every AnyTLS node failed handshake
+# against those servers. 0.21.1 coalesces the record. Also a Windows-only
+# meow-lwip bindgen bump, behind `listener-tun` which we do not enable.
+#
+# v0.21.0 retired the `ios/connect-timeout-0.20.1` side branch: its one
+# commit (the global `tcp-connect-timeout:` field wired into
+# DirectAdapter::with_connect_timeout, which `prepare_ios_config` injects
+# at 10 s) merged to main before 0.21.0.
 #
 # What the 0.20.1 → 0.21.0 range adds that this crate actually runs:
 # - sing-mux multiplexing (#412 series, #414–#418) plus Xray Mux.Cool,
@@ -130,7 +135,7 @@ lwip = "0.3"
 # VMess AEAD interop fix. meow-dns runs in fake-ip mode: the FFI config
 # parser pins `enhanced-mode: fake-ip` with `fake-ip-range: 28.0.0.0/8`
 # (the 2026-07-17 redir-host/DoT switch was reverted in PR #321).
-meow-common = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
+meow-common = { git = "https://github.com/madeye/meow-rs", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
 # `boring-tls` activates BoringSSL-backed TLS in meow-transport so ECH
 # (RFC 9460 SVCB / HTTPS ECHConfigList) and uTLS fingerprinting work for
 # proxy outbound. Without it, any proxy entry with `ech-opts:` set is
@@ -147,12 +152,12 @@ meow-common = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce43
 # the lwip tun2socks path; would drag netstack-smoltcp/tun-rs dead weight
 # into the NE binary) and `external-ui-download` (force-disabled at compile
 # time on iOS; would only add the zip crate).
-meow-config = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e", features = ["boring-tls", "anytls"] }
-meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
-meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
-meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e", default-features = false, features = ["listener-mixed"] }
-meow-api = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
-meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "ac3fcd8d77ce437749b5f5e504dee020e0d99e0e" }
+meow-config = { git = "https://github.com/madeye/meow-rs", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", features = ["boring-tls", "anytls"] }
+meow-dns = { git = "https://github.com/madeye/meow-rs", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-tunnel = { git = "https://github.com/madeye/meow-rs", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-listener = { git = "https://github.com/madeye/meow-rs", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531", default-features = false, features = ["listener-mixed"] }
+meow-api = { git = "https://github.com/madeye/meow-rs", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
+meow-proxy = { git = "https://github.com/madeye/meow-rs", rev = "bc38424bcea5efad18b4dbb2ebd679f54fc68531" }
 
 [build-dependencies]
 cbindgen = "0.28"


### PR DESCRIPTION
## Summary

Pin meow-rs `ac3fcd8d` (v0.21.0) → `bc38424b` (v0.21.1).

Picks up **AnyTLS #469**: auth is one TLS record instead of three, so anytls-go / sing-box / sing-anytls servers no longer EOF on padding length. No FFI API change. Windows-only meow-lwip bindgen bump is behind `listener-tun`, which this crate does not enable.

## Path B — local-CI-green attestation

- [x] `swiftformat --lint .` → 0/127 files require formatting
- [x] `swiftlint --strict` → 0 violations in 113 files
- [x] Matching suites:
  - `cd core/rust/meow-ios-ffi && cargo test --lib` → **79 passed**
  - `cargo clippy --all-targets -- -D warnings` → clean
  - `scripts/build-rust.sh` → xcframework written (device + sim)
- [x] `git diff origin/main...HEAD --stat` — 5 files, all intended (Cargo.toml/lock for ffi, harness, geosite-mrs-builder). No accidental additions.

No Swift source changes.